### PR TITLE
cmake README and ignore cmake recommend directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ tokens_vcd.h
 # Temp Files #
 ##############
 *~
+.*.swp
 
 # Autotools Generated #
 #######################
@@ -128,6 +129,11 @@ ltmain.sh
 *.pyc
 moc_*.cpp
 .libs
+
+# Cmake recommended generated #
+###############################
+qucs/bin
+qucs-core/bin
 
 # Packages #
 ############

--- a/README.md
+++ b/README.md
@@ -42,4 +42,23 @@ Compile qucs-core:
 
 Note, Qucs it will be installed by default to `/usr/local/`. This can be modified by passing `--prefix=[some location]` to the `./configure` script.
 
+###Compile with CMake (recommended on Archlinux)
+
+Compile qucs:
+
+    cd qucs
+    mkdir bin && cd bin
+    cmake ../
+    make
+    sudo make install
+
+Compile qucs-core:
+
+    cd qucs-lib
+    mkdir bin && cd bin
+    cmake ../
+    make
+    sudo make install
+
+Note, to change cmake default install path, passing `-DCMAKE_INSTALL_PREFIX:PATH=[some location]` to the `cmake` script.
 


### PR DESCRIPTION
Since the automake cannot compile on my laptop, I switch to use cmake to build qucs.
I add some introduction on how to use cmake in README.md

---

My default setting is build cmake in qucs/bin and qucs-core/bin
so I add directory ignore in .gitignore
