### PR TITLE
fix bug147, font deform after print

### DIFF
--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -653,7 +653,7 @@ void Schematic::paintSchToViewpainter(ViewPainter *p, bool printAll, bool toImag
         if (toImage) {
             pc->paint(p);
         } else {
-            pc->print(p, screenDpiX / printerDpiX);
+            pc->print(p, (float)screenDpiX / printerDpiX);
         }
         pc->isSelected = selected;
       }


### PR DESCRIPTION
In schematic.cpp, it pass resize ratio (a float) with division of two integer with out type casting
add (float) solve this problem.
