### PR TITLE
Fixed issue #20 --- syntax hilighting at text files saving

### DIFF
--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -334,6 +334,7 @@ bool TextDoc::load ()
   lastSaved = QDateTime::currentDateTime ();
   loadSettings ();
   SimOpenDpl = simulation ? true : false;
+  refreshLanguage();
   return true;
 }
 
@@ -363,6 +364,7 @@ int TextDoc::save ()
   /// clear highlighted lines on save \see MessageDock::slotCursor()
   QList<QTextEdit::ExtraSelection> extraSelections;
   this->setExtraSelections(extraSelections);
+  refreshLanguage();
 
   return 0;
 }
@@ -539,4 +541,11 @@ void TextDoc::highlightCurrentLine()
     }
 
     setExtraSelections(extraSelections);
+}
+
+void TextDoc::refreshLanguage()
+{
+    this->setLanguage(DocName);
+    syntaxHighlight->setLanguage(language);
+    syntaxHighlight->setDocument(document());
 }

--- a/qucs/qucs/textdoc.h
+++ b/qucs/qucs/textdoc.h
@@ -82,6 +82,7 @@ public:
 
   bool loadSettings (void);
   bool saveSettings (void);
+  void refreshLanguage(void);
 
   QMenu* createStandardContextMenu(const QPoint&);
 


### PR DESCRIPTION
Correct syntax highlighting was not correctly determined for all types of text files. Now it sets always correctly. Fixed issue https://github.com/Qucs/qucs/issues/20 --- syntax highlighting at text files saving. Changed textdoc.cpp and textdoc.h. Added new method refreshLanguage().
