### PR TITLE
fixed issue #18

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1395,7 +1395,6 @@ bool QucsApp::deleteDirectoryContent(QDir& Dir)
 {
   // removes every file, remove("*") does not work
   QStringList Files = Dir.entryList("*", QDir::Files|QDir::Hidden);  // all files
-  qDebug()<<Files;
   QStringList::iterator it;
   for(it = Files.begin(); it != Files.end(); it++) {
      if(!Dir.remove(*it)) {


### PR DESCRIPTION
Fixed bug #18. This bug was located inside `QucsApp::slotMenuDelProject`. This method gets project directory name from the `QFileDialog`. It assumed that this directory name was ended with `QDir::separator()` symbol. Then this symbol was removed from the of the string. In fact, `QFileDialog` returns directory name without trailing `QDir::separator()`. This fact leads to that bug that project name is determined wrong, when last 4 symbols (`_prj`) are truncated. Now checking of trailing `QDir::separator` is added. Now Qucs removes the last symbol of project directory path only if `QDir::separartor()` is present. And project always is removes correctly now. Also slash (`/`) symbol is replaced by platform independent  `QDir::separartor()`.
