### PR TITLE
Fixed issue #24

### DIFF
--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -790,16 +790,16 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem* Item)
   if(toTake) GraphInput->setText("");
 
   int     i  = GraphInput->cursorPosition();
-  QString s  = GraphInput->text();
+  //QString s="";
   //QString s1 = Item->text();
   int row = Item->row();
   QString s1 = ChooseVars->item(row, 0)->text();
   QFileInfo Info(defaultDataSet);
   if(ChooseData->currentText() != Info.baseName(true))
     s1 = ChooseData->currentText() + ":" + s1;
-  GraphInput->setText(s.left(i) + s1 + s.right(s.length()-i));
+  GraphInput->setText(s1);
 
-  if(s.isEmpty()) {
+  //if(s.isEmpty()) {
     GraphList->addItem(GraphInput->text());////insertItem(i, GraphInput->text());
     GraphList->setCurrentRow(GraphList->count()-1);
 
@@ -834,7 +834,7 @@ void DiagramDialog::slotTakeVar(QTableWidgetItem* Item)
     Graphs.append(g);
     changed = true;
     toTake  = true;
-  }
+  //}
 
   GraphInput->blockSignals(false);
 


### PR DESCRIPTION
I think this bug is caused by following fact. If `DiagramDialog::slotDeleteGraph()` is called when `Delete` button is pressed, it always clears `GraphInput` line edit contents. Then it emits signal `textChanged` and initiates `slotRestToTake`. This slot clears graph variable, because input field is cleared. But selected item remains in `GraphList`. And it seems that variable is not cleared. 

I propose the next solution. Now `DiagramDialog::slotDeleteGraph()` sets in `GraphInput` the last remaining variable from the `GraphList`. If there is no remaining items, it sets empty string. This way works for me. There is no invalid curves now.
