### PR TITLE
Corrected qucsrescodes command name for Linux

### DIFF
--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -841,7 +841,7 @@ void QucsApp::slotCallRes()
 #elif __APPLE__
   prog = "qucsrescodes.app/Contents/MacOS/qucsrescodes";
 #else
-  prog = "qucrescodes";
+  prog = "qucsrescodes";
 #endif
 
   QProcess *QucsRes = new QProcess();


### PR DESCRIPTION
The `qucsrescodes` tool doest not start when `Tools` menu item is clicked. This bug takes place for Linux. It was caused by error in `qucsrescodes` command name. This commit contains correction for it.
