### PR TITLE
allow diagram load without gui

### DIFF
--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -120,7 +120,11 @@ int CurveDiagram::calcDiagram()
   Arcs.clear();
 
   double GridStep, corr, zD, zDstep, GridNum;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   y1 = QucsSettings.font.pointSize() + 6;
 
   x1 = 10;      // position of label text

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -163,7 +163,11 @@ void Diagram::createAxisLabels()
   Graph *pg;
   int   x, y, w, wmax = 0;
   QString Str;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   int LineSpacing = metrics.lineSpacing();
 
 
@@ -1655,7 +1659,11 @@ void Diagram::createPolarDiagram(Axis *Axis, int Mode)
   else  tmp = 0;
   Arcs.append(new struct Arc(0, y2, x2, y2, tmp, 16*360-phi, QPen(Qt::black,0)));
 
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   /// \fixme
   QSize r = metrics.size(0, Texts.last()->s);  // width of text
   len = x2+r.width()-4;   // more space at the right
@@ -1892,7 +1900,11 @@ bool Diagram::calcYAxis(Axis *Axis, int x0)
   double GridStep, corr, zD, zDstep, GridNum;
 
   QString tmp;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   int maxWidth = 0;
 
   bool back = false;

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -292,7 +292,11 @@ void Marker::makeInvalid()
 // ---------------------------------------------------------------------
 void Marker::getTextSize(const QFont& Font)
 {
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   QSize r = metrics.size(0, Text);
   x2 = r.width()+5;
   y2 = r.height()+5;

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -635,7 +635,11 @@ int Rect3DDiagram::calcAxis(Axis *Axis, int x, int y,
   double xstepD, ystepD;
 
   QString tmp;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   int maxWidth = 0;
   int count, gx, gy, w;
 
@@ -728,7 +732,11 @@ void Rect3DDiagram::createAxis(Axis *Axis, bool Right,
   if(Axis == &yAxis)  Index = 1;
 
   QString s;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
 
   x = x2_ - x1_;
   y = y2_ - y1_;
@@ -790,7 +798,11 @@ int Rect3DDiagram::calcDiagram()
   Arcs.clear();
 
   double GridStep, corr, zD, zDstep, GridNum;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
 
   x3 = x2 + 7;
   int z, z2, o, w;

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -129,7 +129,11 @@ int RectDiagram::calcDiagram()
   Arcs.clear();
 
   double GridStep, corr, zD, zDstep, GridNum;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   y1 = QucsSettings.font.pointSize() + 6;
 
   x1 = 10;      // position of label text

--- a/qucs/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/qucs/diagrams/tabdiagram.cpp
@@ -131,7 +131,11 @@ int TabDiagram::calcDiagram()
 
   x1 = 0;  // no scroll bar
   x3 = x2;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   //qDebug("QucsSettings.font %i", QucsSettings.font.pointSize());
   int tHeight = metrics.lineSpacing();
   QString Str;

--- a/qucs/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/qucs/diagrams/timingdiagram.cpp
@@ -125,7 +125,11 @@ int TimingDiagram::calcDiagram()
 
   y1 = 0;  // no scroll bar
   x3 = x2;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   int tHeight = metrics.lineSpacing();
   QString Str;
   int colWidth=0, x=4, y, xStart = 0, z;

--- a/qucs/qucs/diagrams/truthdiagram.cpp
+++ b/qucs/qucs/diagrams/truthdiagram.cpp
@@ -55,7 +55,11 @@ int TruthDiagram::calcDiagram()
 
   x1 = 0;  // no scroll bar
   x3 = x2;
-  QFontMetrics  metrics(((Schematic*)QucsMain->DocumentTab->currentPage())->font());   // get size of text
+  QFont font = QFont("Helvetica", 12);
+  if (QucsMain) {
+    font = ((Schematic*)QucsMain->DocumentTab->currentPage())->font();
+  }
+  QFontMetrics  metrics(font);   // get size of text
   int tHeight = metrics.lineSpacing();
   QString Str;
   int colWidth=0, x=6, y;

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -711,6 +711,7 @@ int doPrint(QString schematic, QString printFile)
   sch->Diagrams = &(sch->DocDiags);
   sch->Paintings = &(sch->DocPaints);
   sch->Components = &(sch->DocComps);
+  sch->reloadGraphs();
 
   qDebug() << "*** try to print file  :" << printFile;
 

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -895,10 +895,10 @@ bool Schematic::loadDocument()
     if(Line == "<Wires>") {
       if(!loadWires(&stream)) { file.close(); return false; } }
     else
-    if ((Schematic*)QucsMain != 0) { // GUI running, load Diagrams, Paintings
     if(Line == "<Diagrams>") {
       if(!loadDiagrams(&stream, &DocDiags)) { file.close(); return false; } }
     else
+    if ((Schematic*)QucsMain != 0) { // GUI running, load Diagrams, Paintings
     if(Line == "<Paintings>") {
       if(!loadPaintings(&stream, &DocPaints)) { file.close(); return false; } }
     else {


### PR DESCRIPTION
In gui mode, diagram will use font setting in gui main
In non-gui mode, it use default font QFont("Helvetica", 12)
