### PR TITLE
Fixed duplicate shortcuts for tools

### DIFF
--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -562,7 +562,7 @@ void QucsApp::initActions()
   connect(callAtt, SIGNAL(activated()), SLOT(slotCallAtt()));
 
   callRes = new QAction(tr("Resistor color codes"), this);
-  callRes->setShortcut(Qt::CTRL+Qt::Key_7);
+  callRes->setShortcut(Qt::CTRL+Qt::Key_8);
   callRes->setStatusTip(tr("Starts Qucs resistor color codes"));
   callRes->setWhatsThis(
   tr("Resistor color codes\n\nStarts standard resistor color code computation program"));


### PR DESCRIPTION
Fixed duplicate shortcuts `Ctrl+7` for different qucs-tools after `qucsactivefilter` addition in `Tools` menu
