### PR TITLE
add double quote to prevent simulation fail by space in filename

### DIFF
--- a/qucs/qucs/qucsdigi
+++ b/qucs/qucs/qucsdigi
@@ -95,6 +95,6 @@ echo "simulating..."
 wait $!
 
 echo -n "running VCD conversion..."
-$BINDIR/qucsconv $OPTION -if vcd -of qucsdata -i $NAME.vcd -o $NAMEOUT
+$BINDIR/qucsconv $OPTION -if vcd -of qucsdata -i $NAME.vcd -o "$NAMEOUT"
 echo " done."
 

--- a/qucs/qucs/qucsveri
+++ b/qucs/qucs/qucsveri
@@ -65,5 +65,5 @@ vvp $NAME -vcd
 wait $!
 
 echo -n "running VCD conversion..."
-$BINDIR/qucsconv $OPTION -if vcd -of qucsdata -i $NAME.vcd -o $NAMEOUT
+$BINDIR/qucsconv $OPTION -if vcd -of qucsdata -i $NAME.vcd -o "$NAMEOUT"
 echo " done."


### PR DESCRIPTION
Fix issue #28 
The problem is that space in project name will cause qucsconv think the string before space as the output file name. Add a double quote on output file name solve this issue.
I didn't fix the qucsdigi.dat and qucsveri.dat since I'm not sure will windows handle string variable like shell script. Also, there may have other problem in qucsdigilib which I'm not sure.
