### PR TITLE
use hyperref package in all situation

### DIFF
--- a/qucs-doc/technical/technical.tex
+++ b/qucs-doc/technical/technical.tex
@@ -23,6 +23,20 @@
 \usepackage[section]{placeins}
 \usepackage{listings}
 \usepackage{longtable}
+\usepackage[a4paper,
+	bookmarks,
+	bookmarksopen=true,
+	bookmarksnumbered=true,
+	pdfpagemode=UseOutlines,
+	baseurl=(http://qucs.sourceforge.net),
+	pdfstartview=FitH,
+	colorlinks,
+	linkcolor=black,
+	urlcolor=black,
+	citecolor=black,
+	backref=false,
+	plainpages=false,
+	pagebackref=false]{hyperref}
 
 % Compatibility code for LaTeX and pdfTeX.
 \newif\ifpdf
@@ -42,21 +56,6 @@
 
 % Only evaluated if run using pdfTeX.
 \ifpdf
-\usepackage[pdftex,
-	a4paper,
-	bookmarks,
-	bookmarksopen=true,
-	bookmarksnumbered=true,
-	pdfpagemode=UseOutlines,
-	baseurl=(http://qucs.sourceforge.net),
-	pdfstartview=FitH,
-	colorlinks,
-	linkcolor=black,
-	urlcolor=black,
-	citecolor=black,
-	backref=false,
-	plainpages=false,
-	pagebackref=false]{hyperref}
 \pdfcompresslevel 9
 \pdfinfo {
   /Title   (Qucs)


### PR DESCRIPTION
This is a fix try of issue #55 
Origin technical.pdf only use package hyperref when compile with pdfTex.
The package is responsible for generating hyperlink to chapter and section. Use this package in all situation restore the hyperlink in table of contents.
