### PR TITLE
Feature54 shortcut newversion

### DIFF
--- a/qucs/qucs/dialogs/CMakeLists.txt
+++ b/qucs/qucs/dialogs/CMakeLists.txt
@@ -13,7 +13,7 @@ labeldialog.cpp			searchdialog.cpp vtabbutton.cpp
 librarydialog.cpp		settingsdialog.cpp vtabwidget.cpp
 matchdialog.cpp			simmessage.cpp newprojdialog.cpp
 sweepdialog.cpp			exportdialog.cpp loaddialog.cpp
-keysequenceedit.cpp
+qucsshortcutdialog.cpp keysequenceedit.cpp
 )
 
 SET(DIALOGS_MOC_HDRS
@@ -39,6 +39,7 @@ vtabbar.h
 vtabbeddockwidget.h
 vtabbutton.h
 vtabwidget.h
+qucsshortcutdialog.h
 keysequenceedit.h
 )
 

--- a/qucs/qucs/dialogs/CMakeLists.txt
+++ b/qucs/qucs/dialogs/CMakeLists.txt
@@ -13,6 +13,7 @@ labeldialog.cpp			searchdialog.cpp vtabbutton.cpp
 librarydialog.cpp		settingsdialog.cpp vtabwidget.cpp
 matchdialog.cpp			simmessage.cpp newprojdialog.cpp
 sweepdialog.cpp			exportdialog.cpp loaddialog.cpp
+keysequenceedit.cpp
 )
 
 SET(DIALOGS_MOC_HDRS
@@ -38,6 +39,7 @@ vtabbar.h
 vtabbeddockwidget.h
 vtabbutton.h
 vtabwidget.h
+keysequenceedit.h
 )
 
 QT4_WRAP_CPP( DIALOGS_MOC_SRCS ${DIALOGS_MOC_HDRS} )

--- a/qucs/qucs/dialogs/Makefile.am
+++ b/qucs/qucs/dialogs/Makefile.am
@@ -29,7 +29,7 @@ MOCHEADERS = settingsdialog.h simmessage.h qucssettingsdialog.h      \
      sweepdialog.h searchdialog.h librarydialog.h importdialog.h     \
      packagedialog.h savedialog.h vasettingsdialog.h                 \
      vtabbutton.h vtabbar.h vtabwidget.h vtabbeddockwidget.h        \
-     exportdialog.h loaddialog.h newprojdialog.h
+     exportdialog.h loaddialog.h newprojdialog.h keysequenceedit.h
 
 MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 
@@ -39,7 +39,7 @@ libdialogs_a_SOURCES = settingsdialog.cpp newprojdialog.cpp \
      librarydialog.cpp importdialog.cpp packagedialog.cpp \
      savedialog.cpp vasettingsdialog.cpp \
      vtabbutton.cpp vtabbar.cpp vtabwidget.cpp vtabbeddockwidget.cpp \
-     exportdialog.cpp loaddialog.cpp
+     exportdialog.cpp loaddialog.cpp keysequenceedit.cpp
 
 nodist_libdialogs_a_SOURCES = $(MOCFILES)
 

--- a/qucs/qucs/dialogs/Makefile.am
+++ b/qucs/qucs/dialogs/Makefile.am
@@ -29,7 +29,8 @@ MOCHEADERS = settingsdialog.h simmessage.h qucssettingsdialog.h      \
      sweepdialog.h searchdialog.h librarydialog.h importdialog.h     \
      packagedialog.h savedialog.h vasettingsdialog.h                 \
      vtabbutton.h vtabbar.h vtabwidget.h vtabbeddockwidget.h        \
-     exportdialog.h loaddialog.h newprojdialog.h keysequenceedit.h
+     exportdialog.h loaddialog.h newprojdialog.h keysequenceedit.h \
+		 qucsshortcutdialog.h
 
 MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 
@@ -39,7 +40,8 @@ libdialogs_a_SOURCES = settingsdialog.cpp newprojdialog.cpp \
      librarydialog.cpp importdialog.cpp packagedialog.cpp \
      savedialog.cpp vasettingsdialog.cpp \
      vtabbutton.cpp vtabbar.cpp vtabwidget.cpp vtabbeddockwidget.cpp \
-     exportdialog.cpp loaddialog.cpp keysequenceedit.cpp
+     exportdialog.cpp loaddialog.cpp keysequenceedit.cpp \
+		 qucsshortcutdialog.cpp
 
 nodist_libdialogs_a_SOURCES = $(MOCFILES)
 

--- a/qucs/qucs/dialogs/keysequenceedit.cpp
+++ b/qucs/qucs/dialogs/keysequenceedit.cpp
@@ -39,6 +39,7 @@ KeySequenceEdit::KeySequenceEdit(QWidget *parent)
 KeySequenceEdit::KeySequenceEdit(const QKeySequence &keySequence, QWidget *parent)
   : QLineEdit(parent)
 {
+  validKey = false;
   setKeySequence(keySequence);
 }
 
@@ -69,6 +70,7 @@ KeySequenceEdit::keyPressEvent(QKeyEvent *event)
     return; 
   } 
 
+  validKey = true;
   // check for a combination of user clicks 
   // if the keyText is empty than it's a special key like F1, F5, ... 
   Qt::KeyboardModifiers modifiers = event->modifiers(); 
@@ -85,7 +87,10 @@ KeySequenceEdit::keyPressEvent(QKeyEvent *event)
 void
 KeySequenceEdit::keyReleaseEvent(QKeyEvent *event)
 {
-  qDebug() << "Key Release: " << QKeySequence(keyInt).toString(QKeySequence::NativeText);
-  setText(QKeySequence(keyInt).toString(QKeySequence::NativeText));
-  clearFocus();
+  if (validKey) {
+    qDebug() << "Key Release: " << QKeySequence(keyInt).toString(QKeySequence::NativeText);
+    setText(QKeySequence(keyInt).toString(QKeySequence::NativeText));
+    clearFocus();
+    validKey = false;
+  }
 }

--- a/qucs/qucs/dialogs/keysequenceedit.cpp
+++ b/qucs/qucs/dialogs/keysequenceedit.cpp
@@ -1,0 +1,91 @@
+/*--------------------------------------------------------------------------------
+-*- coding: utf-8 -*-
+
+Filename: keysequenceedit.cpp
+This file is part of project: qucs.
+Description: A inheritance to QLineEdit that detect user input hotkey
+
+Copyright (C) 2014 -  You-Tang Lee (YodaLee) <lc85301@gmail.com>
+All Rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--------------------------------------------------------------------------------*/
+
+#include <QLineEdit>
+#include <QDebug>
+#include <QKeyEvent>
+
+#include "keysequenceedit.h"
+
+using namespace std;
+
+KeySequenceEdit::KeySequenceEdit(QWidget *parent)
+  : QLineEdit(parent)
+{
+}
+
+KeySequenceEdit::KeySequenceEdit(const QKeySequence &keySequence, QWidget *parent)
+  : QLineEdit(parent)
+{
+  setKeySequence(keySequence);
+}
+
+KeySequenceEdit::~KeySequenceEdit()
+{
+}
+
+void
+KeySequenceEdit::setKeySequence(const QKeySequence &keySequence)
+{
+  setText(QString(keySequence));
+}
+
+void 
+KeySequenceEdit::keyPressEvent(QKeyEvent *event) 
+{
+  keyInt = event->key(); 
+  Qt::Key key = static_cast<Qt::Key>(keyInt); 
+  if(key == Qt::Key_unknown){ 
+    qDebug() << "Unknown key from a macro probably"; 
+    return; 
+  } 
+  // the user have clicked just and only the special keys Ctrl, Shift, Alt, Meta. 
+  if(key == Qt::Key_Control || 
+      key == Qt::Key_Shift || 
+      key == Qt::Key_Alt || 
+      key == Qt::Key_Meta) { 
+    return; 
+  } 
+
+  // check for a combination of user clicks 
+  // if the keyText is empty than it's a special key like F1, F5, ... 
+  Qt::KeyboardModifiers modifiers = event->modifiers(); 
+  if(modifiers & Qt::ShiftModifier) 
+    keyInt += Qt::SHIFT; 
+  if(modifiers & Qt::ControlModifier) 
+    keyInt += Qt::CTRL; 
+  if(modifiers & Qt::AltModifier) 
+    keyInt += Qt::ALT; 
+  if(modifiers & Qt::MetaModifier) 
+    keyInt += Qt::META; 
+} 
+
+void
+KeySequenceEdit::keyReleaseEvent(QKeyEvent *event)
+{
+  qDebug() << "Key Release: " << QKeySequence(keyInt).toString(QKeySequence::NativeText);
+  setText(QKeySequence(keyInt).toString(QKeySequence::NativeText));
+  clearFocus();
+}

--- a/qucs/qucs/dialogs/keysequenceedit.h
+++ b/qucs/qucs/dialogs/keysequenceedit.h
@@ -1,0 +1,49 @@
+/*--------------------------------------------------------------------------------
+-*- coding: utf-8 -*-
+
+Filename: keysequenceedit.h
+This file is part of project: qucs.
+Description: A inheritance to QLineEdit that detect user input hotkey
+
+Copyright (C) 2014 -  You-Tang Lee (YodaLee) <lc85301@gmail.com>
+All Rights reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--------------------------------------------------------------------------------*/
+
+#ifndef KEYSEQUENCEEDIT_H_
+#define KEYSEQUENCEEDIT_H_ value
+
+#include <QLineEdit>
+
+class KeySequenceEdit : public QLineEdit
+{
+  Q_OBJECT
+public:
+  KeySequenceEdit (QWidget *parent = 0);
+  KeySequenceEdit (const QKeySequence &keySequence, QWidget *parent = 0);
+  virtual ~KeySequenceEdit ();
+protected:
+  void keyPressEvent(QKeyEvent *event);
+  void keyReleaseEvent(QKeyEvent *event);
+private slots:
+  void setKeySequence(const QKeySequence &);
+private:
+  int keyInt;
+  
+};
+
+
+#endif /* end of include guard: KEYSEQUENCEEDIT_H_ */

--- a/qucs/qucs/dialogs/keysequenceedit.h
+++ b/qucs/qucs/dialogs/keysequenceedit.h
@@ -42,7 +42,7 @@ private slots:
   void setKeySequence(const QKeySequence &);
 private:
   int keyInt;
-  
+  bool validKey;
 };
 
 

--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -106,15 +106,20 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent, const char *name)
     editorEdit->setToolTip(tr("Set to qucs, qucsedit or the path to your favorite text editor."));
     appSettingsGrid->addWidget(editorEdit,4,1);
 
-    appSettingsGrid->addWidget(new QLabel(tr("start wiring when clicking open node:"), appSettingsTab) ,5,0);
+    appSettingsGrid->addWidget(new QLabel(tr("start wiring when clicking open node:"), appSettingsTab), 5, 0);
     checkWiring = new QCheckBox(appSettingsTab);
     appSettingsGrid->addWidget(checkWiring,5,1);
 
 
-    appSettingsGrid->addWidget(new QLabel(tr("Load documents from future versions ")));
+    appSettingsGrid->addWidget(new QLabel(tr("Load documents from future versions "), appSettingsTab), 6, 0);
     checkLoadFromFutureVersions = new QCheckBox(appSettingsTab);
     appSettingsGrid->addWidget(checkLoadFromFutureVersions,6,1);
     checkLoadFromFutureVersions->setChecked(QucsSettings.IgnoreFutureVersion);
+
+    appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 7, 0);
+    ShortcutButton = new QPushButton(appSettingsTab);
+    //connect(ShortcutButton, SIGNAL(clicked()), SLOT());
+    appSettingsGrid->addWidget(ShortcutButton,7,1);
 
     t->addTab(appSettingsTab, tr("Settings"));
 
@@ -349,6 +354,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent, const char *name)
     Font  = QucsSettings.font;
     FontButton->setText(Font.toString());
     BGColorButton->setPaletteBackgroundColor(QucsSettings.BGColor);
+    ShortcutButton->setText("Custom Shortcut");
     undoNumEdit->setText(QString::number(QucsSettings.maxUndo));
     editorEdit->setText(QucsSettings.Editor);
     checkWiring->setChecked(QucsSettings.NodeWiring);

--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -118,7 +118,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent, const char *name)
 
     appSettingsGrid->addWidget(new QLabel(tr("Set custom shortcut:"), appSettingsTab), 7, 0);
     ShortcutButton = new QPushButton(appSettingsTab);
-    //connect(ShortcutButton, SIGNAL(clicked()), SLOT());
+    connect(ShortcutButton, SIGNAL(clicked()), SLOT(slotShortcutDialog()));
     appSettingsGrid->addWidget(ShortcutButton,7,1);
 
     t->addTab(appSettingsTab, tr("Settings"));
@@ -581,6 +581,13 @@ void QucsSettingsDialog::slotBGColorDialog()
                    BGColorButton->paletteBackgroundColor(), this);
     if(c.isValid())
         BGColorButton->setPaletteBackgroundColor(c);
+}
+
+// -----------------------------------------------------------
+void QucsSettingsDialog::slotShortcutDialog()
+{
+  QucsShortcutDialog *d = new QucsShortcutDialog(App);
+  d->exec();
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/qucs/dialogs/qucssettingsdialog.h
@@ -19,6 +19,7 @@
 #define QUCSSETTINGSDIALOG_H
 
 #include "qucs.h"
+#include "qucsshortcutdialog.h"
 
 #include <QDialog>
 #include <QFont>
@@ -49,6 +50,7 @@ private slots:
     void slotApply();
     void slotFontDialog();
     void slotBGColorDialog();
+    void slotShortcutDialog();
     void slotDefaultValues();
     void slotAddFileType();
     void slotRemoveFileType();

--- a/qucs/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/qucs/dialogs/qucssettingsdialog.h
@@ -80,7 +80,7 @@ public:
     QFont Font;
     QCheckBox *checkWiring, *checkLoadFromFutureVersions;
     QComboBox *LanguageCombo;
-    QPushButton *FontButton, *BGColorButton;
+    QPushButton *FontButton, *BGColorButton, *ShortcutButton;
     QLineEdit *undoNumEdit, *editorEdit, *Input_Suffix, *Input_Program,
               *homeEdit, *admsXmlEdit, *ascoEdit, *octaveEdit;
     QTableWidget *fileTypesTableWidget, *pathsTableWidget;

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -200,6 +200,87 @@ QucsShortcutDialog::slotOK()
 void
 QucsShortcutDialog::slotImport()
 {
+  QString filename;
+
+  filename = QFileDialog::getOpenFileName(this, tr("Import Shortcut Map"),
+      ".", "Mapfiles (*.shortcutmap)");
+  if (!filename.isEmpty()) {
+
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly)) {
+      QMessageBox::critical(this, tr("Unable to open file"),
+          file.errorString());
+      return;
+    }
+    QTextStream stream(&file);
+    QString line, action, keySequence;
+
+    do {
+      if (stream.atEnd()) {
+        file.close();
+        return;
+      }
+
+      line = stream.readLine();
+    } while(line.isEmpty());
+
+    //check header
+    if (line != "<Qucs Shortcut>") {
+      file.close();
+      QMessageBox::critical(0, tr("Error"),
+        tr("Wrong document type: "+filename));
+      return;
+    }
+
+    QVector<QPair<QString, QMap<QString, QString>* > >::iterator menu_it = QucsSettings.Shortcut.begin();
+    QVector<QPair<QString, QMap<QString, QString>* > >::iterator end = QucsSettings.Shortcut.end();
+    //we assume shortcut map file save all shortcut
+    //clean all pre-exist map
+    while (menu_it != end) {
+      menu_it->second->clear();
+      menu_it++;
+    }
+
+    int i, j;
+    menu_it = QucsSettings.Shortcut.begin();
+    while (!stream.atEnd()) {
+      line = stream.readLine();
+      line = line.stripWhiteSpace();
+      if (line.isEmpty()) { continue; }
+
+      if (line.startsWith("Menu")) {
+        //get iterator
+        i = line.indexOf("<", 5);
+        j = line.indexOf(">", 5);
+        line = line.mid(i+1, j-i-1);
+        //find the related map
+        qDebug() << line;
+        menu_it = QucsSettings.Shortcut.begin();
+        while(menu_it != end) {
+          if (menu_it->first == line) {
+            qDebug() << "Menu: " << line;
+            break;
+          }
+          menu_it++;
+        }
+      } else if (line.startsWith("Action")) {
+        //read action
+        i = line.indexOf("<", 7);
+        j = line.indexOf(">", 7);
+        action = line.mid(i+1, j-i-1);
+        i = line.indexOf("<", j);
+        j = line.lastIndexOf(">");
+        keySequence = line.mid(i+1, j-i-1);
+        if (menu_it != end) {
+          qDebug() << "Action: " << action << " : " << keySequence;
+          menu_it->second->insert(action, keySequence);
+        }
+      }
+    }
+
+    file.close();
+  }
+  slotChooseMenu();
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -36,6 +36,7 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   qDebug() << "open shortcut dialog";
   App = parent;
   setWindowTitle(tr("Edit Qucs Shortcuts"));
+  invalidKeys << "Esc";
 
   conflictAt = -1;
   conflictKey = QString();
@@ -56,7 +57,8 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   defaultButton = new QPushButton(tr("default"));
   okButton = new QPushButton(tr("OK"));
 
-  connect(sequenceInput, SIGNAL(textChanged(QString)), SLOT(slotCheckUnique()));
+  connect(sequenceInput, SIGNAL(textChanged(QString)), SLOT(slotCheckKey()));
+  connect(this, SIGNAL(signalValidKey()), SLOT(slotCheckUnique()));
   connect(setButton, SIGNAL(clicked()), SLOT(slotSetShortcut()));
   connect(removeButton, SIGNAL(clicked()), SLOT(slotRemoveShortcut()));
   connect(defaultButton, SIGNAL(clicked()), SLOT(slotDefaultShortcut()));
@@ -185,6 +187,22 @@ QucsShortcutDialog::slotOK()
 {
   App->setAllShortcut();
   accept();
+}
+
+void
+QucsShortcutDialog::slotCheckKey()
+{
+  QString keysequence = sequenceInput->text();
+  foreach(QString invalidKey, invalidKeys) {
+    if (keysequence == invalidKey) {
+      sequenceInput->clear();
+      QString msg = QString("Unable to set shortcut of: ") + invalidKey;
+      messageLabel->setText(msg);
+      return;
+    }
+  }
+
+  emit signalValidKey();
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -37,6 +37,9 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   App = parent;
   setWindowTitle(tr("Edit Qucs Shortcuts"));
 
+  conflictAt = -1;
+  conflictKey = QString();
+
   menuList = new QListWidget();
   actionList = new QTableWidget();
   actionList->horizontalHeader()->setStretchLastSection(true);
@@ -47,12 +50,13 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   actionList->setSelectionBehavior(QAbstractItemView::SelectRows);
 
   sequenceInput = new KeySequenceEdit;
-  messageLabel = new QLabel("test message");
+  messageLabel = new QLabel();
   setButton = new QPushButton(tr("set shortcut"));
   removeButton = new QPushButton(tr("remove shortcut"));
   defaultButton = new QPushButton(tr("default"));
   okButton = new QPushButton(tr("OK"));
 
+  connect(sequenceInput, SIGNAL(textChanged(QString)), SLOT(slotCheckUnique()));
   connect(setButton, SIGNAL(clicked()), SLOT(slotSetShortcut()));
   connect(removeButton, SIGNAL(clicked()), SLOT(slotRemoveShortcut()));
   connect(defaultButton, SIGNAL(clicked()), SLOT(slotDefaultShortcut()));
@@ -146,10 +150,26 @@ QucsShortcutDialog::setShortcut(QString keySequence)
 {
   int menurow = menuList->currentRow();
   int row = actionList->currentRow();
-  QString key = actionList->item(row, 0)->text();
 
+  //solve conflict
+  if (conflictAt != -1) {
+    if (menurow == conflictAt) {
+      QList<QTableWidgetItem *> conflictItems = actionList->findItems(conflictKey, Qt::MatchExactly);
+      if (conflictItems.size() != 0) {
+        int idx = actionList->row(conflictItems.at(0));
+        actionList->item(idx, 1)->setText(QString());
+      }
+    }
+    QucsSettings.Shortcut.at(conflictAt).second->insert(conflictKey, QString());
+    conflictAt = -1;
+    conflictKey.clear();
+    messageLabel->clear();
+  }
+
+  QString key = actionList->item(row, 0)->text();
   QucsSettings.Shortcut.at(menurow).second->insert(key, keySequence);
   actionList->item(row, 1)->setText(keySequence);
+  sequenceInput->clear();
 }
 
 void 
@@ -164,6 +184,37 @@ void
 QucsShortcutDialog::slotOK() 
 {
   accept();
+}
+
+void
+QucsShortcutDialog::slotCheckUnique()
+{
+  QString keysequence = sequenceInput->text();
+  if (keysequence == QString()) {
+    return;
+  }
+
+  conflictAt = -1;
+  conflictKey = "";
+  messageLabel->clear();
+
+  QVector<QPair<QString, QMap<QString, QString>* > >::const_iterator menu_it = QucsSettings.Shortcut.constBegin();
+
+  while(menu_it != QucsSettings.Shortcut.constEnd()) {
+    QMap<QString, QString>::const_iterator action_it = menu_it->second->constBegin();
+    while(action_it != menu_it->second->constEnd()) {
+      if (keysequence == action_it.value()) {
+        conflictAt = menu_it - QucsSettings.Shortcut.constBegin();
+        conflictKey = action_it.key();
+        QString msg = QString("Conflict With: ") + menu_it->first 
+            + "->" + conflictKey;
+        messageLabel->setText(msg);
+        return;
+      }
+      action_it++;
+    }
+    menu_it++;
+  }
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -183,6 +183,7 @@ QucsShortcutDialog::slotDefaultShortcut()
 void 
 QucsShortcutDialog::slotOK() 
 {
+  App->setAllShortcut();
   accept();
 }
 

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -39,6 +39,12 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
 
   menuList = new QListWidget();
   actionList = new QTableWidget();
+  actionList->horizontalHeader()->setStretchLastSection(true);
+  actionList->verticalHeader()->hide();
+  actionList->setColumnCount(2);
+  actionList->setHorizontalHeaderLabels(
+      QStringList() << tr("Action") << tr("Shortcut Key"));
+  actionList->setSelectionBehavior(QAbstractItemView::SelectRows);
 
   sequenceInput = new KeySequenceEdit;
   messageLabel = new QLabel("test message");
@@ -77,6 +83,13 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   all->addLayout(bottomLayout);
 
   this->setLayout(all);
+
+  connect(menuList, SIGNAL(itemClicked(QListWidgetItem*))
+      , this, SLOT(slotChooseMenu()));
+  
+  //fill initial value
+  fillMenu();
+  slotChooseMenu();
 }
 
 QucsShortcutDialog::~QucsShortcutDialog()
@@ -86,6 +99,28 @@ QucsShortcutDialog::~QucsShortcutDialog()
 void
 QucsShortcutDialog::slotChooseMenu()
 {
+  int menurow = menuList->currentRow();
+  actionList->clearContents();
+
+  QMap<QString, QString> *map = QucsSettings.Shortcut.at(menurow).second;
+  QMap<QString, QString>::const_iterator action_it = map->constBegin();
+
+  int row = 0;
+  while(action_it != map->constEnd()) {
+    actionList->setRowCount(map->size());
+
+    QTableWidgetItem *item_0 = new QTableWidgetItem(action_it.key());
+    QTableWidgetItem *item_1 = new QTableWidgetItem(action_it.value());
+
+    item_0->setFlags(item_0->flags() & ~Qt::ItemIsEditable);
+    item_1->setFlags(item_1->flags() & ~Qt::ItemIsEditable);
+    actionList->setItem(row, 0, item_0);
+    actionList->setItem(row, 1, item_1);
+
+    row++;
+    action_it++;
+  }
+  actionList->setCurrentCell(0, 0);
 }
 
 void 
@@ -112,4 +147,14 @@ QucsShortcutDialog::slotOK()
 void
 QucsShortcutDialog::fillMenu()
 {
+  QVector<QPair<QString, QMap<QString, QString>* > >::const_iterator menu_it = QucsSettings.Shortcut.constBegin();
+
+  while(menu_it != QucsSettings.Shortcut.constEnd()) {
+    QListWidgetItem *item = new QListWidgetItem(menu_it->first);
+    menuList->addItem(item);
+
+    menu_it++;
+  }
+
+  menuList->setCurrentRow(0);
 }

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -53,6 +53,9 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   defaultButton = new QPushButton(tr("default"));
   okButton = new QPushButton(tr("OK"));
 
+  connect(setButton, SIGNAL(clicked()), SLOT(slotSetShortcut()));
+  connect(removeButton, SIGNAL(clicked()), SLOT(slotRemoveShortcut()));
+  connect(defaultButton, SIGNAL(clicked()), SLOT(slotDefaultShortcut()));
   connect(okButton, SIGNAL(clicked()), SLOT(slotOK()));
 
   QHBoxLayout *topLayout = new QHBoxLayout;
@@ -126,16 +129,35 @@ QucsShortcutDialog::slotChooseMenu()
 void 
 QucsShortcutDialog::slotSetShortcut() 
 {
+  if (sequenceInput->text() != QString())
+  {
+    setShortcut(sequenceInput->text());
+  }
 }
 
 void 
 QucsShortcutDialog::slotRemoveShortcut() 
 {
+  setShortcut("");
+}
+
+void
+QucsShortcutDialog::setShortcut(QString keySequence)
+{
+  int menurow = menuList->currentRow();
+  int row = actionList->currentRow();
+  QString key = actionList->item(row, 0)->text();
+
+  QucsSettings.Shortcut.at(menurow).second->insert(key, keySequence);
+  actionList->item(row, 1)->setText(keySequence);
 }
 
 void 
 QucsShortcutDialog::slotDefaultShortcut() 
 {
+  clearShortcutMap();
+  setDefaultShortcut();
+  slotChooseMenu();
 }
 
 void 

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -56,6 +56,8 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   removeButton = new QPushButton(tr("remove shortcut"));
   defaultButton = new QPushButton(tr("default"));
   okButton = new QPushButton(tr("OK"));
+  importButton = new QPushButton(tr("Import"));
+  exportButton = new QPushButton(tr("Export"));
 
   connect(sequenceInput, SIGNAL(textChanged(QString)), SLOT(slotCheckKey()));
   connect(this, SIGNAL(signalValidKey()), SLOT(slotCheckUnique()));
@@ -65,6 +67,8 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   connect(removeButton, SIGNAL(clicked()), SLOT(slotRemoveShortcut()));
   connect(defaultButton, SIGNAL(clicked()), SLOT(slotDefaultShortcut()));
   connect(okButton, SIGNAL(clicked()), SLOT(slotOK()));
+  connect(importButton, SIGNAL(clicked()), SLOT(slotImport()));
+  connect(exportButton, SIGNAL(clicked()), SLOT(slotExport()));
 
   QHBoxLayout *topLayout = new QHBoxLayout;
   topLayout->addWidget(menuList);
@@ -85,6 +89,8 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
   midLayout->addLayout(btnLayout);
 
   QHBoxLayout *bottomLayout = new QHBoxLayout;
+  bottomLayout->addWidget(importButton);
+  bottomLayout->addWidget(exportButton);
   bottomLayout->addStretch();
   bottomLayout->addWidget(okButton);
 
@@ -189,6 +195,16 @@ QucsShortcutDialog::slotOK()
 {
   App->setAllShortcut();
   accept();
+}
+
+void
+QucsShortcutDialog::slotImport()
+{
+}
+
+void
+QucsShortcutDialog::slotExport()
+{
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -205,6 +205,45 @@ QucsShortcutDialog::slotImport()
 void
 QucsShortcutDialog::slotExport()
 {
+  QString filename;
+
+  QFileDialog *sd = new QFileDialog;
+  sd->setDefaultSuffix("shortcutmap");
+  sd->setDirectory(".");
+  sd->setFilter("Mapfiles (*.shortcutmap)");
+  sd->setAcceptMode(QFileDialog::AcceptSave);
+  int result = sd->exec();
+  if (result == QDialog::Accepted) {
+    QString filename = sd->selectedFiles()[0];
+    qDebug() << filename;
+
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly)) {
+      QMessageBox::critical(this, tr("Unable to open file"),
+          file.errorString());
+      return;
+    }
+    QTextStream stream(&file);
+    stream << "<Qucs Shortcut>\n";
+
+    QVector<QPair<QString, QMap<QString, QString>* > >::const_iterator menu_it = QucsSettings.Shortcut.constBegin();
+    while (menu_it != QucsSettings.Shortcut.constEnd()) {
+      stream << "Menu <" << menu_it->first << ">\n";
+
+      QMap<QString, QString>::const_iterator action_it = menu_it->second->constBegin();
+      while (action_it != menu_it->second->constEnd()) {
+        stream << "Action <" << action_it.key() << "> <" << action_it.value() << ">\n"; 
+        ++action_it;
+      }
+
+      ++menu_it;
+    }
+
+    file.close();
+  } else {
+    qDebug("Cannot get file");
+  }
+  delete sd;
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -59,6 +59,8 @@ QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
 
   connect(sequenceInput, SIGNAL(textChanged(QString)), SLOT(slotCheckKey()));
   connect(this, SIGNAL(signalValidKey()), SLOT(slotCheckUnique()));
+  connect(actionList, SIGNAL(itemSelectionChanged()), SLOT(slotSetFocus()));
+
   connect(setButton, SIGNAL(clicked()), SLOT(slotSetShortcut()));
   connect(removeButton, SIGNAL(clicked()), SLOT(slotRemoveShortcut()));
   connect(defaultButton, SIGNAL(clicked()), SLOT(slotDefaultShortcut()));
@@ -234,6 +236,12 @@ QucsShortcutDialog::slotCheckUnique()
     }
     menu_it++;
   }
+}
+
+void
+QucsShortcutDialog::slotSetFocus()
+{
+  sequenceInput->setFocus();
 }
 
 void

--- a/qucs/qucs/dialogs/qucsshortcutdialog.cpp
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+                           qucssettingsdialog.h
+                          ----------------------
+    begin                : Fri Oct 3 2014
+    copyright            : (C) 2014 by Yodalee
+    email                : lc85301@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtGui>
+
+#include "qucsshortcutdialog.h"
+#include "main.h"
+
+#include <iostream>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QWidget>
+#include <QLabel>
+
+#include <QDebug>
+
+using namespace std;
+
+QucsShortcutDialog::QucsShortcutDialog(QucsApp *parent, const char *name)
+  : QDialog(parent, name)
+{
+  qDebug() << "open shortcut dialog";
+  App = parent;
+  setWindowTitle(tr("Edit Qucs Shortcuts"));
+
+  menuList = new QListWidget();
+  actionList = new QTableWidget();
+
+  sequenceInput = new KeySequenceEdit;
+  messageLabel = new QLabel("test message");
+  setButton = new QPushButton(tr("set shortcut"));
+  removeButton = new QPushButton(tr("remove shortcut"));
+  defaultButton = new QPushButton(tr("default"));
+  okButton = new QPushButton(tr("OK"));
+
+  connect(okButton, SIGNAL(clicked()), SLOT(slotOK()));
+
+  QHBoxLayout *topLayout = new QHBoxLayout;
+  topLayout->addWidget(menuList);
+  topLayout->addWidget(actionList);
+
+  QVBoxLayout *btnLayout = new QVBoxLayout;
+  btnLayout->addWidget(setButton);
+  btnLayout->addWidget(removeButton);
+  btnLayout->addWidget(defaultButton);
+
+  QVBoxLayout *textLayout = new QVBoxLayout;
+  textLayout->addWidget(sequenceInput);
+  textLayout->addWidget(messageLabel);
+  textLayout->setAlignment(Qt::AlignVCenter);
+
+  QHBoxLayout *midLayout = new QHBoxLayout;
+  midLayout->addLayout(textLayout);
+  midLayout->addLayout(btnLayout);
+
+  QHBoxLayout *bottomLayout = new QHBoxLayout;
+  bottomLayout->addStretch();
+  bottomLayout->addWidget(okButton);
+
+  QVBoxLayout *all = new QVBoxLayout;
+  all->addLayout(topLayout);
+  all->addLayout(midLayout);
+  all->addLayout(bottomLayout);
+
+  this->setLayout(all);
+}
+
+QucsShortcutDialog::~QucsShortcutDialog()
+{
+}
+
+void
+QucsShortcutDialog::slotChooseMenu()
+{
+}
+
+void 
+QucsShortcutDialog::slotSetShortcut() 
+{
+}
+
+void 
+QucsShortcutDialog::slotRemoveShortcut() 
+{
+}
+
+void 
+QucsShortcutDialog::slotDefaultShortcut() 
+{
+}
+
+void 
+QucsShortcutDialog::slotOK() 
+{
+  accept();
+}
+
+void
+QucsShortcutDialog::fillMenu()
+{
+}

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -41,7 +41,6 @@ private slots:
 private: 
   void fillMenu();
 private: 
-  int current;
   QucsApp *App;
 
   QListWidget *menuList;

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+                           qucssettingsdialog.h
+                          ----------------------
+    begin                : Fri Oct 3 2014
+    copyright            : (C) 2014 by Yodalee
+    email                : lc85301@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QUCSSHORTCUTDIALOG_H_
+#define QUCSSHORTCUTDIALOG_H_ value
+
+#include "qucs.h"
+#include "keysequenceedit.h"
+
+class QPushButton;
+class QLabel;
+class QStandardItemModel;
+
+class QucsShortcutDialog : public QDialog 
+{
+  Q_OBJECT
+public:
+  QucsShortcutDialog(QucsApp *parent = 0, const char *name = 0);
+  virtual ~QucsShortcutDialog ();
+private slots:
+  void slotChooseMenu();
+  void slotSetShortcut();
+  void slotRemoveShortcut();
+  void slotDefaultShortcut();
+  void slotOK();
+
+private: 
+  void fillMenu();
+private: 
+  int current;
+  QucsApp *App;
+
+  QListWidget *menuList;
+  QTableWidget *actionList;
+  QLabel *messageLabel;
+  KeySequenceEdit *sequenceInput;
+  QPushButton *setButton, *removeButton, *defaultButton, *okButton;
+};
+
+#endif /* end of include guard: QUCSSHORTCUTDIALOG_H_ */

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -37,6 +37,8 @@ private slots:
   void slotRemoveShortcut();
   void slotDefaultShortcut();
   void slotOK();
+  void slotImport();
+  void slotExport();
 
   void slotCheckKey();
   void slotCheckUnique();
@@ -60,7 +62,8 @@ private:
   QTableWidget *actionList;
   QLabel *messageLabel;
   KeySequenceEdit *sequenceInput;
-  QPushButton *setButton, *removeButton, *defaultButton, *okButton;
+  QPushButton *setButton, *removeButton, *defaultButton, *okButton,
+    *importButton, *exportButton;
 };
 
 #endif /* end of include guard: QUCSSHORTCUTDIALOG_H_ */

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -38,10 +38,16 @@ private slots:
   void slotDefaultShortcut();
   void slotOK();
 
+  void slotCheckUnique();
+
 private: 
   void fillMenu();
   void setShortcut(QString);
 private: 
+  //conflict record
+  int conflictAt;
+  QString conflictKey;
+
   QucsApp *App;
 
   QListWidget *menuList;

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -40,6 +40,7 @@ private slots:
 
   void slotCheckKey();
   void slotCheckUnique();
+  void slotSetFocus();
 
 signals:
   void signalValidKey();

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -40,6 +40,7 @@ private slots:
 
 private: 
   void fillMenu();
+  void setShortcut(QString);
 private: 
   QucsApp *App;
 

--- a/qucs/qucs/dialogs/qucsshortcutdialog.h
+++ b/qucs/qucs/dialogs/qucsshortcutdialog.h
@@ -38,7 +38,11 @@ private slots:
   void slotDefaultShortcut();
   void slotOK();
 
+  void slotCheckKey();
   void slotCheckUnique();
+
+signals:
+  void signalValidKey();
 
 private: 
   void fillMenu();
@@ -47,6 +51,7 @@ private:
   //conflict record
   int conflictAt;
   QString conflictKey;
+  QStringList invalidKeys;
 
   QucsApp *App;
 

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -60,142 +60,142 @@ QStringList qucsPathList;
 // Loads the settings file and stores the settings.
 bool loadSettings()
 {
-    QSettings settings("qucs","qucs");
+  QSettings settings("qucs","qucs");
 
-    if(settings.contains("x"))QucsSettings.x=settings.value("x").toInt();
-    if(settings.contains("y"))QucsSettings.y=settings.value("y").toInt();
-    if(settings.contains("dx"))QucsSettings.dx=settings.value("dx").toInt();
-    if(settings.contains("dy"))QucsSettings.dy=settings.value("dy").toInt();
-    if(settings.contains("font"))QucsSettings.font.fromString(settings.value("font").toString());
-    if(settings.contains("largeFontSize"))QucsSettings.largeFontSize=settings.value("largeFontSize").toDouble();
-    if(settings.contains("maxUndo"))QucsSettings.maxUndo=settings.value("maxUndo").toInt();
-    if(settings.contains("NodeWiring"))QucsSettings.NodeWiring=settings.value("NodeWiring").toInt();
-    if(settings.contains("BGColor"))QucsSettings.BGColor.setNamedColor(settings.value("BGColor").toString());
-    if(settings.contains("Editor"))QucsSettings.Editor=settings.value("Editor").toString();
-    if(settings.contains("FileTypes"))QucsSettings.FileTypes=settings.value("FileTypes").toStringList();
-    if(settings.contains("Language"))QucsSettings.Language=settings.value("Language").toString();
-    if(settings.contains("Comment"))QucsSettings.Comment.setNamedColor(settings.value("Comment").toString());
-    if(settings.contains("String"))QucsSettings.String.setNamedColor(settings.value("String").toString());
-    if(settings.contains("Integer"))QucsSettings.Integer.setNamedColor(settings.value("Integer").toString());
-    if(settings.contains("Real"))QucsSettings.Real.setNamedColor(settings.value("Real").toString());
-    if(settings.contains("Character"))QucsSettings.Character.setNamedColor(settings.value("Character").toString());
-    if(settings.contains("Type"))QucsSettings.Type.setNamedColor(settings.value("Type").toString());
-    if(settings.contains("Attribute"))QucsSettings.Attribute.setNamedColor(settings.value("Attribute").toString());
-    if(settings.contains("Directive"))QucsSettings.Directive.setNamedColor(settings.value("Directive").toString());
-    if(settings.contains("Task"))QucsSettings.Comment.setNamedColor(settings.value("Task").toString());
+  if(settings.contains("x"))QucsSettings.x=settings.value("x").toInt();
+  if(settings.contains("y"))QucsSettings.y=settings.value("y").toInt();
+  if(settings.contains("dx"))QucsSettings.dx=settings.value("dx").toInt();
+  if(settings.contains("dy"))QucsSettings.dy=settings.value("dy").toInt();
+  if(settings.contains("font"))QucsSettings.font.fromString(settings.value("font").toString());
+  if(settings.contains("largeFontSize"))QucsSettings.largeFontSize=settings.value("largeFontSize").toDouble();
+  if(settings.contains("maxUndo"))QucsSettings.maxUndo=settings.value("maxUndo").toInt();
+  if(settings.contains("NodeWiring"))QucsSettings.NodeWiring=settings.value("NodeWiring").toInt();
+  if(settings.contains("BGColor"))QucsSettings.BGColor.setNamedColor(settings.value("BGColor").toString());
+  if(settings.contains("Editor"))QucsSettings.Editor=settings.value("Editor").toString();
+  if(settings.contains("FileTypes"))QucsSettings.FileTypes=settings.value("FileTypes").toStringList();
+  if(settings.contains("Language"))QucsSettings.Language=settings.value("Language").toString();
+  if(settings.contains("Comment"))QucsSettings.Comment.setNamedColor(settings.value("Comment").toString());
+  if(settings.contains("String"))QucsSettings.String.setNamedColor(settings.value("String").toString());
+  if(settings.contains("Integer"))QucsSettings.Integer.setNamedColor(settings.value("Integer").toString());
+  if(settings.contains("Real"))QucsSettings.Real.setNamedColor(settings.value("Real").toString());
+  if(settings.contains("Character"))QucsSettings.Character.setNamedColor(settings.value("Character").toString());
+  if(settings.contains("Type"))QucsSettings.Type.setNamedColor(settings.value("Type").toString());
+  if(settings.contains("Attribute"))QucsSettings.Attribute.setNamedColor(settings.value("Attribute").toString());
+  if(settings.contains("Directive"))QucsSettings.Directive.setNamedColor(settings.value("Directive").toString());
+  if(settings.contains("Task"))QucsSettings.Comment.setNamedColor(settings.value("Task").toString());
 
-    if(settings.contains("Editor"))QucsSettings.Editor = settings.value("Editor").toString();
-    //if(settings.contains("BinDir"))QucsSettings.BinDir = settings.value("BinDir").toString();
-    //if(settings.contains("LangDir"))QucsSettings.LangDir = settings.value("LangDir").toString();
-    //if(settings.contains("LibDir"))QucsSettings.LibDir = settings.value("LibDir").toString();
-    if(settings.contains("AdmsXmlBinDir"))QucsSettings.AdmsXmlBinDir = settings.value("AdmsXmlBinDir").toString();
-    if(settings.contains("AscoBinDir"))QucsSettings.AscoBinDir = settings.value("AscoBinDir").toString();
-    //if(settings.contains("OctaveDir"))QucsSettings.OctaveDir = settings.value("OctaveDir").toString();
-    //if(settings.contains("ExamplesDir"))QucsSettings.ExamplesDir = settings.value("ExamplesDir").toString();
-    //if(settings.contains("DocDir"))QucsSettings.DocDir = settings.value("DocDir").toString();
-    if(settings.contains("OctaveBinDir"))QucsSettings.OctaveBinDir.setPath(settings.value("OctaveBinDir").toString());
-    if(settings.contains("QucsHomeDir"))
-      if(settings.value("QucsHomeDir").toString() != "")
-         QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
-    QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
+  if(settings.contains("Editor"))QucsSettings.Editor = settings.value("Editor").toString();
+  //if(settings.contains("BinDir"))QucsSettings.BinDir = settings.value("BinDir").toString();
+  //if(settings.contains("LangDir"))QucsSettings.LangDir = settings.value("LangDir").toString();
+  //if(settings.contains("LibDir"))QucsSettings.LibDir = settings.value("LibDir").toString();
+  if(settings.contains("AdmsXmlBinDir"))QucsSettings.AdmsXmlBinDir = settings.value("AdmsXmlBinDir").toString();
+  if(settings.contains("AscoBinDir"))QucsSettings.AscoBinDir = settings.value("AscoBinDir").toString();
+  //if(settings.contains("OctaveDir"))QucsSettings.OctaveDir = settings.value("OctaveDir").toString();
+  //if(settings.contains("ExamplesDir"))QucsSettings.ExamplesDir = settings.value("ExamplesDir").toString();
+  //if(settings.contains("DocDir"))QucsSettings.DocDir = settings.value("DocDir").toString();
+  if(settings.contains("OctaveBinDir"))QucsSettings.OctaveBinDir.setPath(settings.value("OctaveBinDir").toString());
+  if(settings.contains("QucsHomeDir"))
+    if(settings.value("QucsHomeDir").toString() != "")
+       QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
+  QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
 
-    if (settings.contains("IngnoreVersion")) QucsSettings.IgnoreFutureVersion = settings.value("IngnoreVersion").toBool();
-    else QucsSettings.IgnoreFutureVersion = false;
-
-
-    QucsSettings.RecentDocs = settings.value("RecentDocs").toString().split("*",QString::SkipEmptyParts);
-    QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
+  if (settings.contains("IngnoreVersion")) QucsSettings.IgnoreFutureVersion = settings.value("IngnoreVersion").toBool();
+  else QucsSettings.IgnoreFutureVersion = false;
 
 
-    // If present read in the list of directory paths in which Qucs should
-    // search for subcircuit schematics
-    int npaths = settings.beginReadArray("Paths");
-    for (int i = 0; i < npaths; ++i)
-    {
-        settings.setArrayIndex(i);
-        QString apath = settings.value("path").toString();
-        qucsPathList.append(apath);
-    }
-    settings.endArray();
+  QucsSettings.RecentDocs = settings.value("RecentDocs").toString().split("*",QString::SkipEmptyParts);
+  QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
 
-    //load shortcut setting
-    QVector<QPair<QString, QMap<QString, QString>* > > *vec = &QucsSettings.Shortcut;
-    QVector<QPair<QString, QMap<QString, QString>* > >::iterator menu_it = vec->begin();
 
-    settings.beginGroup("Shortcut");
+  // If present read in the list of directory paths in which Qucs should
+  // search for subcircuit schematics
+  int npaths = settings.beginReadArray("Paths");
+  for (int i = 0; i < npaths; ++i)
+  {
+      settings.setArrayIndex(i);
+      QString apath = settings.value("path").toString();
+      qucsPathList.append(apath);
+  }
+  settings.endArray();
 
-    while(menu_it != vec->end()) {
-      settings.beginGroup(menu_it->first);
+  //load shortcut setting
+  QVector<QPair<QString, QMap<QString, QString>* > > *vec = &QucsSettings.Shortcut;
+  QVector<QPair<QString, QMap<QString, QString>* > >::iterator menu_it = vec->begin();
 
-      QMap<QString, QString> *submap = menu_it->second;
-      QStringList actionlist = settings.childKeys();
-      foreach(QString actionkey, actionlist) {
-        submap->insert(actionkey, settings.value(actionkey).toString());
-      }
+  settings.beginGroup("Shortcut");
 
-      settings.endGroup();
+  while(menu_it != vec->end()) {
+    settings.beginGroup(menu_it->first);
 
-      menu_it++;
+    QMap<QString, QString> *submap = menu_it->second;
+    QStringList actionlist = settings.childKeys();
+    foreach(QString actionkey, actionlist) {
+      submap->insert(actionkey, settings.value(actionkey).toString());
     }
 
     settings.endGroup();
 
-    QucsSettings.numRecentDocs = 0;
+    menu_it++;
+  }
 
-    return true;
+  settings.endGroup();
+
+  QucsSettings.numRecentDocs = 0;
+
+  return true;
 }
 
 // #########################################################################
 // Saves the settings in the settings file.
 bool saveApplSettings(QucsApp *qucs)
 {
-    QSettings settings ("qucs","qucs");
+  QSettings settings ("qucs","qucs");
 
-    settings.setValue("x", QucsSettings.x);
-    settings.setValue("y", QucsSettings.y);
-    settings.setValue("dx", QucsSettings.dx);
-    settings.setValue("dy", QucsSettings.dy);
-    settings.setValue("font", QucsSettings.font.toString());
-    settings.setValue("largeFontSize", QucsSettings.largeFontSize);
-    settings.setValue("maxUndo", QucsSettings.maxUndo);
-    settings.setValue("NodeWiring", QucsSettings.NodeWiring);
-    settings.setValue("BGColor", QucsSettings.BGColor.name());
-    settings.setValue("Editor", QucsSettings.Editor);
-    settings.setValue("FileTypes", QucsSettings.FileTypes);
-    settings.setValue("Language", QucsSettings.Language);
-    settings.setValue("Comment", QucsSettings.Comment.name());
-    settings.setValue("String", QucsSettings.String.name());
-    settings.setValue("Integer", QucsSettings.Integer.name());
-    settings.setValue("Real", QucsSettings.Real.name());
-    settings.setValue("Character", QucsSettings.Character.name());
-    settings.setValue("Type", QucsSettings.Type.name());
-    settings.setValue("Attribute", QucsSettings.Attribute.name());
-    settings.setValue("Directive", QucsSettings.Directive.name());
-    settings.setValue("Task", QucsSettings.Comment.name());
-    settings.setValue("Editor", QucsSettings.Editor);
-    //settings.setValue("BinDir", QucsSettings.BinDir);
-    //settings.setValue("LangDir", QucsSettings.LangDir);
-    //settings.setValue("LibDir", QucsSettings.LibDir);
-    settings.setValue("AdmsXmlBinDir", QucsSettings.AdmsXmlBinDir.canonicalPath());
-    settings.setValue("AscoBinDir", QucsSettings.AscoBinDir.canonicalPath());
-    //settings.setValue("OctaveDir", QucsSettings.OctaveDir);
-    //settings.setValue("ExamplesDir", QucsSettings.ExamplesDir);
-    //settings.setValue("DocDir", QucsSettings.DocDir);
-    settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
-    settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());
-    settings.setValue("IngnoreVersion",QucsSettings.IgnoreFutureVersion);
+  settings.setValue("x", QucsSettings.x);
+  settings.setValue("y", QucsSettings.y);
+  settings.setValue("dx", QucsSettings.dx);
+  settings.setValue("dy", QucsSettings.dy);
+  settings.setValue("font", QucsSettings.font.toString());
+  settings.setValue("largeFontSize", QucsSettings.largeFontSize);
+  settings.setValue("maxUndo", QucsSettings.maxUndo);
+  settings.setValue("NodeWiring", QucsSettings.NodeWiring);
+  settings.setValue("BGColor", QucsSettings.BGColor.name());
+  settings.setValue("Editor", QucsSettings.Editor);
+  settings.setValue("FileTypes", QucsSettings.FileTypes);
+  settings.setValue("Language", QucsSettings.Language);
+  settings.setValue("Comment", QucsSettings.Comment.name());
+  settings.setValue("String", QucsSettings.String.name());
+  settings.setValue("Integer", QucsSettings.Integer.name());
+  settings.setValue("Real", QucsSettings.Real.name());
+  settings.setValue("Character", QucsSettings.Character.name());
+  settings.setValue("Type", QucsSettings.Type.name());
+  settings.setValue("Attribute", QucsSettings.Attribute.name());
+  settings.setValue("Directive", QucsSettings.Directive.name());
+  settings.setValue("Task", QucsSettings.Comment.name());
+  settings.setValue("Editor", QucsSettings.Editor);
+  //settings.setValue("BinDir", QucsSettings.BinDir);
+  //settings.setValue("LangDir", QucsSettings.LangDir);
+  //settings.setValue("LibDir", QucsSettings.LibDir);
+  settings.setValue("AdmsXmlBinDir", QucsSettings.AdmsXmlBinDir.canonicalPath());
+  settings.setValue("AscoBinDir", QucsSettings.AscoBinDir.canonicalPath());
+  //settings.setValue("OctaveDir", QucsSettings.OctaveDir);
+  //settings.setValue("ExamplesDir", QucsSettings.ExamplesDir);
+  //settings.setValue("DocDir", QucsSettings.DocDir);
+  settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
+  settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());
+  settings.setValue("IngnoreVersion",QucsSettings.IgnoreFutureVersion);
 
-    // Copy the list of directory paths in which Qucs should
-    // search for subcircuit schematics from qucsPathList
-    settings.remove("Paths");
-    settings.beginWriteArray("Paths");
-    int i = 0;
-    foreach(QString path, qucsPathList) {
-         settings.setArrayIndex(i);
-         settings.setValue("path", path);
-         i++;
-     }
-     settings.endArray();
+  // Copy the list of directory paths in which Qucs should
+  // search for subcircuit schematics from qucsPathList
+  settings.remove("Paths");
+  settings.beginWriteArray("Paths");
+  int i = 0;
+  foreach(QString path, qucsPathList) {
+    settings.setArrayIndex(i);
+    settings.setValue("path", path);
+    i++;
+  }
+  settings.endArray();
 
   //save shortcut settings, also delete all pointer of shortcut map
   settings.beginGroup("Shortcut");

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -118,6 +118,28 @@ bool loadSettings()
     }
     settings.endArray();
 
+    //load shortcut setting
+    QVector<QPair<QString, QMap<QString, QString>* > > *vec = &QucsSettings.Shortcut;
+    QVector<QPair<QString, QMap<QString, QString>* > >::iterator menu_it = vec->begin();
+
+    settings.beginGroup("Shortcut");
+
+    while(menu_it != vec->end()) {
+      settings.beginGroup(menu_it->first);
+
+      QMap<QString, QString> *submap = menu_it->second;
+      QStringList actionlist = settings.childKeys();
+      foreach(QString actionkey, actionlist) {
+        submap->insert(actionkey, settings.value(actionkey).toString());
+      }
+
+      settings.endGroup();
+
+      menu_it++;
+    }
+
+    settings.endGroup();
+
     QucsSettings.numRecentDocs = 0;
 
     return true;
@@ -174,6 +196,24 @@ bool saveApplSettings(QucsApp *qucs)
          i++;
      }
      settings.endArray();
+
+  //save shortcut settings, also delete all pointer of shortcut map
+  settings.beginGroup("Shortcut");
+  QVector<QPair<QString, QMap<QString, QString>* > >::const_iterator menu_it = QucsSettings.Shortcut.constBegin();
+  while (menu_it != QucsSettings.Shortcut.constEnd()) {
+
+    QMap<QString, QString>::const_iterator action_it = menu_it->second->constBegin();
+
+    settings.beginGroup(menu_it->first);
+    while (action_it != menu_it->second->constEnd()) {
+      settings.setValue(action_it.key(), action_it.value());
+      ++action_it;
+    }
+    settings.endGroup();
+
+    ++menu_it;
+  }
+  settings.endGroup();
 
   return true;
 
@@ -951,6 +991,7 @@ int main(int argc, char *argv[])
       if(octaveExec1.exists()) QucsSettings.OctaveBinDir.setPath(QString("/usr/local/bin/"));
 #endif
   }
+  setDefaultShortcut();
   loadSettings();
 
   if(!QucsSettings.BGColor.isValid())

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -26,6 +26,8 @@
 #include <QColor>
 #include <Q3PtrList>
 #include <QStringList>
+#include <QVector>
+#include <QPair>
 
 #include "wire.h"
 #include "node.h"
@@ -74,8 +76,10 @@ struct tQucsSettings {
   unsigned int numRecentDocs;
   QStringList RecentDocs;
 
-  bool IgnoreFutureVersion;
+  //shortcut
+  QVector<QPair<QString, QMap<QString, QString>* > > Shortcut;
 
+  bool IgnoreFutureVersion;
 };
 
 extern tQucsSettings QucsSettings;  // extern because nearly everywhere used
@@ -83,6 +87,8 @@ extern QucsApp *QucsMain;  // the Qucs application itself
 extern QString lastDir;    // to remember last directory for several dialogs
 extern QStringList qucsPathList;
 
+void setDefaultShortcut();
+void clearShortcutMap();
 bool loadSettings();
 bool saveApplSettings(QucsApp*);
 void qucsMessageOutput(QtMsgType type, const char *msg);

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -124,6 +124,7 @@ QucsApp::QucsApp()
 
   initView();
   initActions();
+  setAllShortcut();
   initMenuBar();
   initToolBar();
   initStatusBar();

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2161,6 +2161,7 @@ void QucsApp::closeEvent(QCloseEvent* Event)
     QucsSettings.dx=size().width();
     QucsSettings.dy=size().height();
     saveApplSettings(this);
+    clearShortcutMap();
 
    if(closeAllFiles()) {
       emit signalKillEmAll();   // kill all subprocesses

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -234,6 +234,7 @@ public:
   void updatePathList(QStringList);
   void updateSchNameHash(void); // maps all schematic files in the path list
   void updateSpiceNameHash(void); // maps all spice files in the path list
+  void setAllShortcut();
 
 /* **************************************************
    *****  The following methods are located in  *****

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -25,6 +25,7 @@
 #include "dialogs/vtabbeddockwidget.h"
 #include "octave_window.h"
 
+// initial default value into Shortcut object
 void 
 setDefaultShortcut() 
 {
@@ -158,6 +159,123 @@ clearShortcutMap()
   QucsSettings.Shortcut.clear();
 }
 
+
+// set Shortcut value to each action
+void
+QucsApp::setAllShortcut()
+{
+  QVector<QPair<QString, QMap<QString, QString>* > >* vec = &QucsSettings.Shortcut;
+  QMap<QString, QString> *map = NULL;
+
+  map = vec->at(0).second; //File
+
+  fileNew        ->setShortcut(QKeySequence(map->value("New")));
+  textNew        ->setShortcut(QKeySequence(map->value("New Text")));
+  fileOpen      ->setShortcut(QKeySequence(map->value("Open")));
+  fileClose      ->setShortcut(QKeySequence(map->value("Close")));
+  fileSave      ->setShortcut(QKeySequence(map->value("Save")));
+  fileSaveAs    ->setShortcut(QKeySequence(map->value("Save as")));
+  fileSaveAs    ->setShortcut(QKeySequence(map->value("Save All")));
+  fileExamples  ->setShortcut(QKeySequence(map->value("Examples")));
+  symEdit        ->setShortcut(QKeySequence(map->value("Edit Circuit Symbol")));
+  fileSettings  ->setShortcut(QKeySequence(map->value("Document Settings")));
+  filePrint      ->setShortcut(QKeySequence(map->value("Print")));
+  filePrintFit  ->setShortcut(QKeySequence(map->value("Print Fit to Page")));
+  fileQuit      ->setShortcut(QKeySequence(map->value("Exit")));
+  applSettings  ->setShortcut(QKeySequence(map->value("Application Settings")));
+  refreshSchPath->setShortcut(QKeySequence(map->value("Refresh Search Path")));
+  exportAsImage  ->setShortcut(QKeySequence(map->value("Export as image")));
+
+  map = vec->at(1).second; //Edit
+  undo          ->setShortcut(QKeySequence(map->value("Undo")));
+  redo          ->setShortcut(QKeySequence(map->value("Redo")));
+  editCut        ->setShortcut(QKeySequence(map->value("Cut")));
+  editCopy      ->setShortcut(QKeySequence(map->value("Copy")));
+  editPaste      ->setShortcut(QKeySequence(map->value("Paste")));
+  editDelete    ->setShortcut(QKeySequence(map->value("Delete")));
+  select        ->setShortcut(QKeySequence(map->value("Select")));
+  selectAll      ->setShortcut(QKeySequence(map->value("Select All")));
+  selectMarker  ->setShortcut(QKeySequence(map->value("Select Markers")));
+  editFind      ->setShortcut(QKeySequence(map->value("Find")));
+  editFindAgain ->setShortcut(QKeySequence(map->value("Find Again")));
+  changeProps    ->setShortcut(QKeySequence(map->value("Replace")));
+  editRotate    ->setShortcut(QKeySequence(map->value("Rotate")));
+  editMirror    ->setShortcut(QKeySequence(map->value("Mirror about X Axis")));
+  editMirrorY    ->setShortcut(QKeySequence(map->value("Mirror about Y Axis")));
+  editActivate  ->setShortcut(QKeySequence(map->value("Deactivate Activate")));
+  intoH          ->setShortcut(QKeySequence(map->value("Go into Subcircuit")));
+  popH          ->setShortcut(QKeySequence(map->value("Pop out")));
+
+  map = vec->at(2).second; //positioning
+  moveText    ->setShortcut(QKeySequence(map->value("Move Component Text")));
+  onGrid      ->setShortcut(QKeySequence(map->value("Set on Grid")));
+  centerHor    ->setShortcut(QKeySequence(map->value("Center horizontally")));
+  centerVert  ->setShortcut(QKeySequence(map->value("Center vertically")));
+  alignTop    ->setShortcut(QKeySequence(map->value("Align top")));
+  alignBottom  ->setShortcut(QKeySequence(map->value("Align bottom")));
+  alignLeft    ->setShortcut(QKeySequence(map->value("Align left")));
+  alignRight  ->setShortcut(QKeySequence(map->value("Align right")));
+  distrHor    ->setShortcut(QKeySequence(map->value("Distribute horizontally")));
+  distrVert    ->setShortcut(QKeySequence(map->value("Distribute vertically")));
+
+  map = vec->at(3).second; //Insert
+  insWire      ->setShortcut(QKeySequence(map->value("Wire")));
+  insLabel    ->setShortcut(QKeySequence(map->value("Wire Label")));
+  insEquation  ->setShortcut(QKeySequence(map->value("Insert Equation")));
+  insGround    ->setShortcut(QKeySequence(map->value("Insert Ground")));
+  insPort      ->setShortcut(QKeySequence(map->value("Insert Port")));
+  setMarker    ->setShortcut(QKeySequence(map->value("Set Marker on Graph")));
+  insEntity    ->setShortcut(QKeySequence(map->value("VHDL entity")));
+
+  map = vec->at(4).second; //Project
+  projNew      ->setShortcut(QKeySequence(map->value("New Project")));
+  projOpen    ->setShortcut(QKeySequence(map->value("Open Project")));
+  addToProj    ->setShortcut(QKeySequence(map->value("Add Files to Project")));
+  projClose    ->setShortcut(QKeySequence(map->value("Close Project")));
+  projDel      ->setShortcut(QKeySequence(map->value("Delete Project")));
+  createLib    ->setShortcut(QKeySequence(map->value("Create Library")));
+  createPkg    ->setShortcut(QKeySequence(map->value("Create Package")));
+  extractPkg  ->setShortcut(QKeySequence(map->value("Extract Package")));
+  importData  ->setShortcut(QKeySequence(map->value("Import Export Data")));
+  graph2csv    ->setShortcut(QKeySequence(map->value("Export to CSV")));
+  buildModule  ->setShortcut(QKeySequence(map->value("Build Verilog-A module")));
+  loadModule  ->setShortcut(QKeySequence(map->value("Load Verilog-A module")));
+
+  map = vec->at(5).second; //Tool
+  callEditor      ->setShortcut(QKeySequence(map->value("Text Editor")));
+  callFilter      ->setShortcut(QKeySequence(map->value("Filter synthesis")));
+  callActiveFilter->setShortcut(QKeySequence(map->value("Active filter synthesis")));
+  callLine        ->setShortcut(QKeySequence(map->value("Line calculation")));
+  callLib          ->setShortcut(QKeySequence(map->value("Component Library")));
+  callMatch        ->setShortcut(QKeySequence(map->value("Matching Circuit")));
+  callAtt          ->setShortcut(QKeySequence(map->value("Attenuator synthesis")));
+  callRes          ->setShortcut(QKeySequence(map->value("Resistor color codes")));
+
+  map = vec->at(6).second; //Simulation
+  simulate->setShortcut(QKeySequence(map->value("Simulate")));
+  dpl_sch  ->setShortcut(QKeySequence(map->value("View Data Display Schematic")));
+  dcbias  ->setShortcut(QKeySequence(map->value("Calculate DC bias")));
+  showMsg  ->setShortcut(QKeySequence(map->value("Show Last Messages")));
+  showNet  ->setShortcut(QKeySequence(map->value("Show Last Netlist")));
+
+  map = vec->at(7).second; //View
+  magAll        ->setShortcut(QKeySequence(map->value("View All")));
+  magOne        ->setShortcut(QKeySequence(map->value("View 1:1")));
+  magPlus        ->setShortcut(QKeySequence(map->value("Zoom in")));
+  magMinus      ->setShortcut(QKeySequence(map->value("Zoom out")));
+  viewToolBar    ->setShortcut(QKeySequence(map->value("Toolbar")));
+  viewStatusBar  ->setShortcut(QKeySequence(map->value("Statusbar")));
+  viewBrowseDock->setShortcut(QKeySequence(map->value("Dock Window")));
+  viewOctaveDock->setShortcut(QKeySequence(map->value("Octave Window")));
+
+  map = vec->at(8).second; //Help
+  helpIndex    ->setShortcut(QKeySequence(map->value("Help Index")));
+  helpGetStart->setShortcut(QKeySequence(map->value("Getting Started")));
+  helpAboutApp->setShortcut(QKeySequence(map->value("About Qucs")));
+  helpAboutQt  ->setShortcut(QKeySequence(map->value("About Qt")));
+}
+
+
 /**
  * @brief QucsApp::initActions Initializes all QActions of the application
  */
@@ -168,32 +286,27 @@ void QucsApp::initActions()
   // note: first argument of QAction() for backward compatibility Qt < 3.2
 
   fileNew = new QAction(QIcon((":/bitmaps/filenew.png")), tr("&New"), this);
-  fileNew->setShortcut(Qt::CTRL+Qt::Key_N);
   fileNew->setStatusTip(tr("Creates a new document"));
   fileNew->setWhatsThis(
 	        tr("New\n\nCreates a new schematic or data display document"));
   connect(fileNew, SIGNAL(activated()), SLOT(slotFileNew()));
 
   textNew = new QAction(QIcon((":/bitmaps/textnew.png")), tr("New &Text"), this);
-  textNew->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_V);
   textNew->setStatusTip(tr("Creates a new text document"));
   textNew->setWhatsThis(tr("New Text\n\nCreates a new text document"));
   connect(textNew, SIGNAL(activated()), SLOT(slotTextNew()));
 
   fileOpen = new QAction(QIcon((":/bitmaps/fileopen.png")),	tr("&Open..."), this);
-  fileOpen->setShortcut(Qt::CTRL+Qt::Key_O);
   fileOpen->setStatusTip(tr("Opens an existing document"));
   fileOpen->setWhatsThis(tr("Open File\n\nOpens an existing document"));
   connect(fileOpen, SIGNAL(activated()), SLOT(slotFileOpen()));
 
   fileSave = new QAction(QIcon((":/bitmaps/filesave.png")),	tr("&Save"), this);
-  fileSave->setShortcut(Qt::CTRL+Qt::Key_S);
   fileSave->setStatusTip(tr("Saves the current document"));
   fileSave->setWhatsThis(tr("Save File\n\nSaves the current document"));
   connect(fileSave, SIGNAL(activated()), SLOT(slotFileSave()));
 
   fileSaveAs = new QAction(tr("Save as..."), this);
-  fileSaveAs->setShortcut(Qt::CTRL+Qt::Key_Minus);
   fileSaveAs->setStatusTip(
 	tr("Saves the current document under a new filename"));
   fileSaveAs->setWhatsThis(
@@ -201,13 +314,11 @@ void QucsApp::initActions()
   connect(fileSaveAs, SIGNAL(activated()), SLOT(slotFileSaveAs()));
 
   fileSaveAll = new QAction(QIcon((":/bitmaps/filesaveall.png")),	tr("Save &All"), this);
-  fileSaveAll->setShortcut(Qt::CTRL+Qt::Key_Plus);
   fileSaveAll->setStatusTip(tr("Saves all open documents"));
   fileSaveAll->setWhatsThis(tr("Save All Files\n\nSaves all open documents"));
   connect(fileSaveAll, SIGNAL(activated()), SLOT(slotFileSaveAll()));
 
   fileClose = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("&Close"), this);
-  fileClose->setShortcut(Qt::CTRL+Qt::Key_W);
   fileClose->setStatusTip(tr("Closes the current document"));
   fileClose->setWhatsThis(tr("Close File\n\nCloses the current document"));
   connect(fileClose, SIGNAL(activated()), SLOT(slotFileClose()));
@@ -220,26 +331,22 @@ void QucsApp::initActions()
 
 
   symEdit = new QAction(tr("&Edit Circuit Symbol"), this);
-  symEdit->setShortcut(Qt::Key_F9);
   symEdit->setStatusTip(tr("Edits the symbol for this schematic"));
   symEdit->setWhatsThis(
 	tr("Edit Circuit Symbol\n\nEdits the symbol for this schematic"));
   connect(symEdit, SIGNAL(activated()), SLOT(slotSymbolEdit()));
 
   fileSettings = new QAction(tr("&Document Settings..."), this);
-  fileSettings->setShortcut(Qt::CTRL+Qt::Key_Period);
   fileSettings->setStatusTip(tr("Document Settings"));
   fileSettings->setWhatsThis(tr("Settings\n\nSets properties of the file"));
   connect(fileSettings, SIGNAL(activated()), SLOT(slotFileSettings()));
 
   filePrint = new QAction(QIcon((":/bitmaps/fileprint.png")), tr("&Print..."), this);
-  filePrint->setShortcut(Qt::CTRL+Qt::Key_P);
   filePrint->setStatusTip(tr("Prints the current document"));
   filePrint->setWhatsThis(tr("Print File\n\nPrints the current document"));
   connect(filePrint, SIGNAL(activated()), SLOT(slotFilePrint()));
 
   filePrintFit = new QAction(tr("Print Fit to Page..."), this);
-  filePrintFit->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_P);
   filePrintFit->setStatusTip(tr("Print Fit to Page"));
   filePrintFit->setWhatsThis(
 	tr("Print Fit to Page\n\n"
@@ -247,27 +354,23 @@ void QucsApp::initActions()
   connect(filePrintFit, SIGNAL(activated()), SLOT(slotFilePrintFit()));
 
   fileQuit = new QAction(tr("E&xit"), this);
-  fileQuit->setShortcut(Qt::CTRL+Qt::Key_Q);
   fileQuit->setStatusTip(tr("Quits the application"));
   fileQuit->setWhatsThis(tr("Exit\n\nQuits the application"));
   connect(fileQuit, SIGNAL(activated()), SLOT(slotFileQuit()));
 
   applSettings = new QAction(tr("Application Settings..."), this);
-  applSettings->setShortcut(Qt::CTRL+Qt::Key_Comma);
   applSettings->setStatusTip(tr("Application Settings"));
   applSettings->setWhatsThis(
 	tr("Qucs Settings\n\nSets properties of the application"));
   connect(applSettings, SIGNAL(activated()), SLOT(slotApplSettings()));
 
   refreshSchPath = new QAction(tr("Refresh Search Path..."), this);
-  //refreshSchPath->setShortcut(Qt::CTRL+Qt::Key_Comma);
   refreshSchPath->setStatusTip(tr("Refresh Search Path"));
   refreshSchPath->setWhatsThis(
     tr("Refresh Path\n\nRechecks the list of paths for subcircuit files."));
   connect(refreshSchPath, SIGNAL(activated()), SLOT(slotRefreshSchPath()));
 
   alignTop = new QAction(tr("Align top"), this);
-  alignTop->setShortcut(Qt::CTRL+Qt::Key_T);
   alignTop->setStatusTip(tr("Align top selected elements"));
   alignTop->setWhatsThis(
 	tr("Align top\n\nAlign selected elements to their upper edge"));
@@ -318,7 +421,6 @@ void QucsApp::initActions()
   connect(centerVert, SIGNAL(activated()), SLOT(slotCenterVertical()));
 
   onGrid = new QAction(tr("Set on Grid"), this);
-  onGrid->setShortcut(Qt::CTRL+Qt::Key_U);
   onGrid->setStatusTip(tr("Sets selected elements on grid"));
   onGrid->setWhatsThis(
 	tr("Set on Grid\n\nSets selected elements on grid"));
@@ -326,7 +428,6 @@ void QucsApp::initActions()
   connect(onGrid, SIGNAL(toggled(bool)), SLOT(slotOnGrid(bool)));
 
   moveText = new QAction(tr("Move Component Text"), this);
-  moveText->setShortcut(Qt::CTRL+Qt::Key_K);
   moveText->setStatusTip(tr("Moves the property text of components"));
   moveText->setWhatsThis(
 	tr("Move Component Text\n\nMoves the property text of components"));
@@ -334,14 +435,12 @@ void QucsApp::initActions()
   connect(moveText, SIGNAL(toggled(bool)), SLOT(slotMoveText(bool)));
 
   changeProps = new QAction(tr("Replace..."), this);
-  changeProps->setShortcut(Qt::Key_F7);
   changeProps->setStatusTip(tr("Replace component properties or VHDL code"));
   changeProps->setWhatsThis(
 	tr("Replace\n\nChange component properties\nor\ntext in VHDL code"));
   connect(changeProps, SIGNAL(activated()), SLOT(slotChangeProps()));
 
   editCut = new QAction(QIcon((":/bitmaps/editcut.png")),	tr("Cu&t"), this);
-  editCut->setShortcut(Qt::CTRL+Qt::Key_X);
   editCut->setStatusTip(
 	tr("Cuts out the selection and puts it into the clipboard"));
   editCut->setWhatsThis(
@@ -349,7 +448,6 @@ void QucsApp::initActions()
   connect(editCut, SIGNAL(activated()), SLOT(slotEditCut()));
 
   editCopy = new QAction(QIcon((":/bitmaps/editcopy.png")), tr("&Copy"), this);
-  editCopy->setShortcut(Qt::CTRL+Qt::Key_C);
   editCopy->setStatusTip(
 	tr("Copies the selection into the clipboard"));
   editCopy->setWhatsThis(
@@ -357,7 +455,6 @@ void QucsApp::initActions()
   connect(editCopy, SIGNAL(activated()), SLOT(slotEditCopy()));
 
   editPaste = new QAction(QIcon((":/bitmaps/editpaste.png")), tr("&Paste"), this);
-  editPaste->setShortcut(Qt::CTRL+Qt::Key_V);
   editPaste->setStatusTip(
 	tr("Pastes the clipboard contents to the cursor position"));
   editPaste->setWhatsThis(
@@ -366,20 +463,17 @@ void QucsApp::initActions()
   connect(editPaste, SIGNAL(toggled(bool)), SLOT(slotEditPaste(bool)));
 
   editDelete = new QAction(QIcon((":/bitmaps/editdelete.png")), tr("&Delete"), this);
-  editDelete->setShortcut(Qt::Key_Delete);
   editDelete->setStatusTip(tr("Deletes the selected components"));
   editDelete->setWhatsThis(tr("Delete\n\nDeletes the selected components"));
   editDelete->setToggleAction(true);
   connect(editDelete, SIGNAL(toggled(bool)), SLOT(slotEditDelete(bool)));
 
   editFind = new QAction(tr("Find..."), this);
-  editFind->setShortcut(Qt::CTRL+Qt::Key_F);
   editFind->setStatusTip(tr("Find a piece of text"));
   editFind->setWhatsThis(tr("Find\n\nSearches for a piece of text"));
   connect(editFind, SIGNAL(activated()), SLOT(slotEditFind()));
 
   editFindAgain = new QAction(tr("Find Again"), this);
-  editFindAgain->setShortcut(Qt::Key_F3);
   editFindAgain->setStatusTip(tr("Find same text again"));
   editFindAgain->setWhatsThis(
                  tr("Find\n\nSearches for the same piece of text again"));
@@ -421,78 +515,66 @@ void QucsApp::initActions()
 */
 
   undo = new QAction(QIcon((":/bitmaps/undo.png")), tr("&Undo"), this);
-  undo->setShortcut(Qt::CTRL+Qt::Key_Z);
   undo->setStatusTip(tr("Undoes the last command"));
   undo->setWhatsThis(tr("Undo\n\nMakes the last action undone"));
   connect(undo, SIGNAL(activated()), SLOT(slotEditUndo()));
 
   redo = new QAction(QIcon((":/bitmaps/redo.png")), tr("&Redo"), this);
-  redo->setShortcut(Qt::CTRL+Qt::Key_Y);
   redo->setStatusTip(tr("Redoes the last command"));
   redo->setWhatsThis(tr("Redo\n\nRepeats the last action once more"));
   connect(redo, SIGNAL(activated()), SLOT(slotEditRedo()));
 
   projNew = new QAction(tr("&New Project..."), this);
-  projNew->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_N);
   projNew->setStatusTip(tr("Creates a new project"));
   projNew->setWhatsThis(tr("New Project\n\nCreates a new project"));
   connect(projNew, SIGNAL(activated()), SLOT(slotProjNewButt()));
 
   projOpen = new QAction(tr("&Open Project..."), this);
-	projOpen->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_O);
   projOpen->setStatusTip(tr("Opens an existing project"));
   projOpen->setWhatsThis(tr("Open Project\n\nOpens an existing project"));
   connect(projOpen, SIGNAL(activated()), SLOT(slotMenuOpenProject()));
 
   projDel = new QAction(tr("&Delete Project..."), this);
-  projDel->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_D);
   projDel->setStatusTip(tr("Deletes an existing project"));
   projDel->setWhatsThis(tr("Delete Project\n\nDeletes an existing project"));
   connect(projDel, SIGNAL(activated()), SLOT(slotMenuDelProject()));
 
   projClose = new QAction(tr("&Close Project"), this);
-  projClose->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_W);
   projClose->setStatusTip(tr("Closes the current project"));
   projClose->setWhatsThis(tr("Close Project\n\nCloses the current project"));
   connect(projClose, SIGNAL(activated()), SLOT(slotMenuCloseProject()));
 
   addToProj = new QAction(tr("&Add Files to Project..."), this);
-  addToProj->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_A);
   addToProj->setStatusTip(tr("Copies files to project directory"));
   addToProj->setWhatsThis(
 	tr("Add Files to Project\n\nCopies files to project directory"));
   connect(addToProj, SIGNAL(activated()), SLOT(slotAddToProject()));
 
   createLib = new QAction(tr("Create &Library..."), this);
-  createLib->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_L);
   createLib->setStatusTip(tr("Create Library from Subcircuits"));
   createLib->setWhatsThis(
 	tr("Create Library\n\nCreate Library from Subcircuits"));
   connect(createLib, SIGNAL(activated()), SLOT(slotCreateLib()));
 
   createPkg = new QAction(tr("Create &Package..."), this);
-  createPkg->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_Z);
   createPkg->setStatusTip(tr("Create compressed Package from Projects"));
   createPkg->setWhatsThis(
     tr("Create Package\n\nCreate compressed Package from complete Projects"));
   connect(createPkg, SIGNAL(activated()), SLOT(slotCreatePackage()));
 
   extractPkg = new QAction(tr("E&xtract Package..."),  this);
-  extractPkg->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_X);
   extractPkg->setStatusTip(tr("Install Content of a Package"));
   extractPkg->setWhatsThis(
 	tr("Extract Package\n\nInstall Content of a Package"));
   connect(extractPkg, SIGNAL(activated()), SLOT(slotExtractPackage()));
 
   importData = new QAction(tr("&Import/Export Data..."), this);
-  importData->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_I);
   importData->setStatusTip(tr("Convert data file"));
   importData->setWhatsThis(
 	tr("Import/Export Data\n\nConvert data file to various file formats"));
   connect(importData, SIGNAL(activated()), SLOT(slotImportData()));
 
   graph2csv = new QAction(tr("Export to &CSV..."), this);
-  graph2csv->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_C);
   graph2csv->setStatusTip(tr("Convert graph data to CSV file"));
   graph2csv->setWhatsThis(
 	tr("Export to CSV\n\nConvert graph data to CSV file"));
@@ -509,26 +591,22 @@ void QucsApp::initActions()
   connect(loadModule, SIGNAL(activated()), SLOT(slotLoadModule()));
 
   magAll = new QAction(QIcon((":/bitmaps/viewmagfit.png")), tr("View All"), this);
-  magAll->setShortcut(Qt::Key_0);
   magAll->setStatusTip(tr("Show the whole page"));
   magAll->setWhatsThis(tr("View All\n\nShows the whole page content"));
   connect(magAll, SIGNAL(activated()), SLOT(slotShowAll()));
 
   magOne = new QAction(QIcon((":/bitmaps/viewmag1.png")), tr("View 1:1"), this);
-  magOne->setShortcut(Qt::Key_1);
   magOne->setStatusTip(tr("Views without magnification"));
   magOne->setWhatsThis(tr("View 1:1\n\nShows the page content without magnification"));
   connect(magOne, SIGNAL(activated()), SLOT(slotShowOne()));
 
   magPlus = new QAction(QIcon((":/bitmaps/viewmag+.png")),	tr("Zoom in"), this);
-  magPlus->setShortcut(Qt::Key_Plus);
   magPlus->setStatusTip(tr("Zooms into the current view"));
   magPlus->setWhatsThis(tr("Zoom in\n\nZooms the current view"));
   magPlus->setToggleAction(true);
   connect(magPlus, SIGNAL(toggled(bool)), SLOT(slotZoomIn(bool)));
 
   magMinus = new QAction(QIcon((":/bitmaps/viewmag-.png")), tr("Zoom out"), this);
-  magMinus->setShortcut(Qt::Key_Minus);
   magMinus->setStatusTip(tr("Zooms out the current view"));
   magMinus->setWhatsThis(tr("Zoom out\n\nZooms out the current view"));
   connect(magMinus, SIGNAL(activated()), SLOT(slotZoomOut()));
@@ -545,21 +623,18 @@ void QucsApp::initActions()
   connect(select, SIGNAL(toggled(bool)), SLOT(slotSelect(bool)));
 
   selectAll = new QAction(tr("Select All"), this);
-  selectAll->setShortcut(Qt::CTRL+Qt::Key_A);
   selectAll->setStatusTip(tr("Selects all elements"));
   selectAll->setWhatsThis(
 	tr("Select All\n\nSelects all elements of the document"));
   connect(selectAll, SIGNAL(activated()), SLOT(slotSelectAll()));
 
   selectMarker = new QAction(tr("Select Markers"), this);
-  selectMarker->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_M);
   selectMarker->setStatusTip(tr("Selects all markers"));
   selectMarker->setWhatsThis(
 	tr("Select Markers\n\nSelects all diagram markers of the document"));
   connect(selectMarker, SIGNAL(activated()), SLOT(slotSelectMarker()));
 
   editRotate = new QAction(QIcon((":/bitmaps/rotate_ccw.png")), tr("Rotate"), this);
-  editRotate->setShortcut(Qt::CTRL+Qt::Key_R);
   editRotate->setStatusTip(tr("Rotates the selected component by 90\x00B0"));
   editRotate->setWhatsThis(
     tr("Rotate\n\nRotates the selected component by 90\x00B0 counter-clockwise"));
@@ -567,7 +642,6 @@ void QucsApp::initActions()
   connect(editRotate, SIGNAL(toggled(bool)), SLOT(slotEditRotate(bool)));
 
   editMirror = new QAction(QIcon((":/bitmaps/mirror.png")), tr("Mirror about X Axis"), this);
-  editMirror->setShortcut(Qt::CTRL+Qt::Key_J);
   editMirror->setStatusTip(tr("Mirrors the selected item about X Axis"));
   editMirror->setWhatsThis(
 	tr("Mirror about X Axis\n\nMirrors the selected item about X Axis"));
@@ -575,7 +649,6 @@ void QucsApp::initActions()
   connect(editMirror, SIGNAL(toggled(bool)), SLOT(slotEditMirrorX(bool)));
 
   editMirrorY = new QAction(QIcon((":/bitmaps/mirrory.png")), tr("Mirror about Y Axis"), this);
-  editMirrorY->setShortcut(Qt::CTRL+Qt::Key_M);
   editMirrorY->setStatusTip(tr("Mirrors the selected item about Y Axis"));
   editMirrorY->setWhatsThis(
 	tr("Mirror about Y Axis\n\nMirrors the selected item about Y Axis"));
@@ -583,14 +656,12 @@ void QucsApp::initActions()
   connect(editMirrorY, SIGNAL(toggled(bool)), SLOT(slotEditMirrorY(bool)));
 
   intoH = new QAction(QIcon((":/bitmaps/bottom.png")), tr("Go into Subcircuit"), this);
-  intoH->setShortcut(Qt::CTRL+Qt::Key_I);
   intoH->setStatusTip(tr("Goes inside the selected subcircuit"));
   intoH->setWhatsThis(
 	tr("Go into Subcircuit\n\nGoes inside the selected subcircuit"));
   connect(intoH, SIGNAL(activated()), SLOT(slotIntoHierarchy()));
 
   popH = new QAction(QIcon((":/bitmaps/top.png")), tr("Pop out"), this);
-  popH->setShortcut(Qt::CTRL+Qt::Key_H);
   popH->setStatusTip(tr("Pop outside subcircuit"));
   popH->setWhatsThis(
 	tr("Pop out\n\nGoes up one hierarchy level, i.e. leaves subcircuit"));
@@ -598,7 +669,6 @@ void QucsApp::initActions()
   popH->setEnabled(false);  // only enabled if useful !!!!
 
   editActivate = new QAction(QIcon((":/bitmaps/deactiv.png")),	tr("Deactivate/Activate"), this);
-  editActivate->setShortcut(Qt::CTRL+Qt::Key_D);
   editActivate->setStatusTip(tr("Deactivate/Activate selected components"));
   editActivate->setWhatsThis(
 	tr("Deactivate/Activate\n\nDeactivate/Activate the selected components"));
@@ -606,7 +676,6 @@ void QucsApp::initActions()
   connect(editActivate, SIGNAL(toggled(bool)), SLOT(slotEditActivate(bool)));
 
   insEquation = new QAction(QIcon((":/bitmaps/equation.png")),	tr("Insert Equation"), this);
-  insEquation->setShortcut(Qt::CTRL+Qt::Key_Less);
   insEquation->setStatusTip(tr("Inserts an equation"));
   insEquation->setWhatsThis(
 	tr("Insert Equation\n\nInserts a user defined equation"));
@@ -614,7 +683,6 @@ void QucsApp::initActions()
   connect(insEquation, SIGNAL(toggled(bool)), SLOT(slotInsertEquation(bool)));
 
   insGround = new QAction(QIcon((":/bitmaps/ground.png")), tr("Insert Ground"), this);
-  insGround->setShortcut(Qt::CTRL+Qt::Key_G);
   insGround->setStatusTip(tr("Inserts a ground symbol"));
   insGround->setWhatsThis(tr("Insert Ground\n\nInserts a ground symbol"));
   insGround->setToggleAction(true);
@@ -627,87 +695,74 @@ void QucsApp::initActions()
   connect(insPort, SIGNAL(toggled(bool)), SLOT(slotInsertPort(bool)));
 
   insWire = new QAction(QIcon((":/bitmaps/wire.png")),	tr("Wire"), this);
-  insWire->setShortcut(Qt::CTRL+Qt::Key_E);
   insWire->setStatusTip(tr("Inserts a wire"));
   insWire->setWhatsThis(tr("Wire\n\nInserts a wire"));
   insWire->setToggleAction(true);
   connect(insWire, SIGNAL(toggled(bool)), SLOT(slotSetWire(bool)));
 
   insLabel = new QAction(QIcon((":/bitmaps/nodename.png")), tr("Wire Label"), this);
-  insLabel->setShortcut(Qt::CTRL+Qt::Key_L);
   insLabel->setStatusTip(tr("Inserts a wire or pin label"));
   insLabel->setWhatsThis(tr("Wire Label\n\nInserts a wire or pin label"));
   insLabel->setToggleAction(true);
   connect(insLabel, SIGNAL(toggled(bool)), SLOT(slotInsertLabel(bool)));
 
   insEntity = new QAction(tr("VHDL entity"), this);
-  insEntity->setShortcut(Qt::CTRL+Qt::Key_Space);
   insEntity->setStatusTip(tr("Inserts skeleton of VHDL entity"));
   insEntity->setWhatsThis(
 	tr("VHDL entity\n\nInserts the skeleton of a VHDL entity"));
   connect(insEntity, SIGNAL(activated()), SLOT(slotInsertEntity()));
 
   callEditor = new QAction(tr("Text Editor"), this);
-  callEditor->setShortcut(Qt::CTRL+Qt::Key_1);
   callEditor->setStatusTip(tr("Starts the Qucs text editor"));
   callEditor->setWhatsThis(tr("Text editor\n\nStarts the Qucs text editor"));
   connect(callEditor, SIGNAL(activated()), SLOT(slotCallEditor()));
 
   callFilter = new QAction(tr("Filter synthesis"), this);
-  callFilter->setShortcut(Qt::CTRL+Qt::Key_2);
   callFilter->setStatusTip(tr("Starts QucsFilter"));
   callFilter->setWhatsThis(tr("Filter synthesis\n\nStarts QucsFilter"));
   connect(callFilter, SIGNAL(activated()), SLOT(slotCallFilter()));
 
   callActiveFilter = new QAction(tr("Active filter synthesis"),this);
-  callActiveFilter->setShortcut(Qt::CTRL+Qt::Key_3);
   callActiveFilter->setStatusTip(tr("Starts QucsActiveFilter"));
   callActiveFilter->setWhatsThis(tr("Active filter synthesis\n\nStarts QucsActiveFilter"));
   connect(callActiveFilter, SIGNAL(activated()), SLOT(slotCallActiveFilter()));
 
   callLine = new QAction(tr("Line calculation"), this);
-  callLine->setShortcut(Qt::CTRL+Qt::Key_4);
   callLine->setStatusTip(tr("Starts QucsTrans"));
   callLine->setWhatsThis(
 		tr("Line calculation\n\nStarts transmission line calculator"));
   connect(callLine, SIGNAL(activated()), SLOT(slotCallLine()));
 
   callLib = new QAction(tr("Component Library"), this);
-  callLib->setShortcut(Qt::CTRL+Qt::Key_5);
   callLib->setStatusTip(tr("Starts QucsLib"));
   callLib->setWhatsThis(
 		tr("Component Library\n\nStarts component library program"));
   connect(callLib, SIGNAL(activated()), SLOT(slotCallLibrary()));
 
   callMatch = new QAction(tr("Matching Circuit"), this);
-  callMatch->setShortcut(Qt::CTRL+Qt::Key_6);
   callMatch->setStatusTip(tr("Creates Matching Circuit"));
   callMatch->setWhatsThis(
 	tr("Matching Circuit\n\nDialog for Creating Matching Circuit"));
   connect(callMatch, SIGNAL(activated()), SLOT(slotCallMatch()));
 
   callAtt = new QAction(tr("Attenuator synthesis"), this);
-  callAtt->setShortcut(Qt::CTRL+Qt::Key_7);
   callAtt->setStatusTip(tr("Starts QucsAttenuator"));
   callAtt->setWhatsThis(
 	tr("Attenuator synthesis\n\nStarts attenuator calculation program"));
   connect(callAtt, SIGNAL(activated()), SLOT(slotCallAtt()));
 
   callRes = new QAction(tr("Resistor color codes"), this);
-  callRes->setShortcut(Qt::CTRL+Qt::Key_8);
   callRes->setStatusTip(tr("Starts Qucs resistor color codes"));
   callRes->setWhatsThis(
   tr("Resistor color codes\n\nStarts standard resistor color code computation program"));
   connect(callRes, SIGNAL(activated()), SLOT(slotCallRes()));
 
   simulate = new QAction(QIcon((":/bitmaps/gear.png")), tr("Simulate"), this);
-  simulate->setShortcut(Qt::Key_F2);
   simulate->setStatusTip(tr("Simulates the current schematic"));
   simulate->setWhatsThis(tr("Simulate\n\nSimulates the current schematic"));
   connect(simulate, SIGNAL(activated()), SLOT(slotSimulate()));
 
   dpl_sch = new QAction(QIcon((":/bitmaps/rebuild.png")), tr("View Data Display/Schematic"), this);
-  dpl_sch->setShortcut(Qt::Key_F4);
   dpl_sch->setStatusTip(tr("Changes to data display or schematic page"));
   dpl_sch->setWhatsThis(
 	tr("View Data Display/Schematic\n\n")+
@@ -715,14 +770,12 @@ void QucsApp::initActions()
   connect(dpl_sch, SIGNAL(activated()), SLOT(slotToPage()));
 
   dcbias = new QAction(tr("Calculate DC bias"), this);
-  dcbias->setShortcut(Qt::Key_F8);
   dcbias->setStatusTip(tr("Calculates DC bias and shows it"));
   dcbias->setWhatsThis(
 	tr("Calculate DC bias\n\nCalculates DC bias and shows it"));
   connect(dcbias, SIGNAL(activated()), SLOT(slotDCbias()));
 
   setMarker = new QAction(QIcon((":/bitmaps/marker.png")),	tr("Set Marker on Graph"), this);
-  setMarker->setShortcut(Qt::CTRL+Qt::Key_B);
   setMarker->setStatusTip(tr("Sets a marker on a diagram's graph"));
   setMarker->setWhatsThis(
 	tr("Set Marker\n\nSets a marker on a diagram's graph"));
@@ -730,14 +783,12 @@ void QucsApp::initActions()
   connect(setMarker, SIGNAL(toggled(bool)), SLOT(slotSetMarker(bool)));
 
   showMsg = new QAction(tr("Show Last Messages"), this);
-  showMsg->setShortcut(Qt::Key_F5);
   showMsg->setStatusTip(tr("Shows last simulation messages"));
   showMsg->setWhatsThis(
         tr("Show Last Messages\n\nShows the messages of the last simulation"));
   connect(showMsg, SIGNAL(activated()), SLOT(slotShowLastMsg()));
 
   showNet = new QAction(tr("Show Last Netlist"), this);
-  showNet->setShortcut(Qt::Key_F6);
   showNet->setStatusTip(tr("Shows last simulation netlist"));
   showNet->setWhatsThis(
 	tr("Show Last Netlist\n\nShows the netlist of the last simulation"));
@@ -771,7 +822,6 @@ void QucsApp::initActions()
   connect(viewOctaveDock, SIGNAL(toggled(bool)), SLOT(slotViewOctaveDock(bool)));
 
   helpIndex = new QAction(tr("Help Index..."), this);
-  helpIndex->setShortcut(Qt::Key_F1);
   helpIndex->setStatusTip(tr("Index of Qucs Help"));
   helpIndex->setWhatsThis(tr("Help Index\n\nIndex of intern Qucs help"));
   connect(helpIndex, SIGNAL(activated()), SLOT(slotHelpIndex()));

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -25,6 +25,138 @@
 #include "dialogs/vtabbeddockwidget.h"
 #include "octave_window.h"
 
+void 
+setDefaultShortcut() 
+{
+  QVector<QPair<QString, QMap<QString, QString>* > >* vec = &QucsSettings.Shortcut;
+
+  QMap<QString, QString> *filemap = new QMap<QString, QString>;
+  filemap->insert("New", QString(QKeySequence(Qt::CTRL+Qt::Key_N)));
+  filemap->insert("New Text", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_V)));
+  filemap->insert("Open", QString(QKeySequence(Qt::CTRL+Qt::Key_O)));
+  filemap->insert("Close", QString(QKeySequence(Qt::CTRL+Qt::Key_W)));
+  filemap->insert("Save", QString(QKeySequence(Qt::CTRL+Qt::Key_S)));
+  filemap->insert("Save All", QString(QKeySequence(Qt::CTRL+Qt::Key_Plus)));
+  filemap->insert("Save as", QString(QKeySequence(Qt::CTRL+Qt::Key_Minus)));
+  filemap->insert("Export as image", QString());
+  filemap->insert("Print", QString(QKeySequence(Qt::CTRL+Qt::Key_P)));
+  filemap->insert("Print Fit to Page", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_P)));
+  filemap->insert("Examples", QString());
+  filemap->insert("Document Settings", QString(QKeySequence(Qt::CTRL+Qt::Key_Period)));
+  filemap->insert("Edit Circuit Symbol", QString(QKeySequence(Qt::Key_F9)));
+  filemap->insert("Application Settings", QString(QKeySequence(Qt::CTRL+Qt::Key_Comma)));
+  filemap->insert("Refresh Search Path", QString());
+  filemap->insert("Exit", QString(QKeySequence(Qt::CTRL+Qt::Key_Q)));
+  vec->push_back(qMakePair(QString("File"), filemap));
+
+
+  QMap<QString, QString> *editmap = new QMap<QString, QString>;
+  editmap->insert("Undo", QString(QKeySequence(Qt::CTRL+Qt::Key_Z)));
+  editmap->insert("Redo", QString(QKeySequence(Qt::CTRL+Qt::Key_Y)));
+  editmap->insert("Cut", QString(QKeySequence(Qt::CTRL+Qt::Key_X)));
+  editmap->insert("Copy", QString(QKeySequence(Qt::CTRL+Qt::Key_C)));
+  editmap->insert("Paste", QString(QKeySequence(Qt::CTRL+Qt::Key_V)));
+  editmap->insert("Delete", QString(QKeySequence(Qt::Key_Delete)));
+  editmap->insert("Select", QString());
+  editmap->insert("Select All", QString(QKeySequence(Qt::CTRL+Qt::Key_A)));
+  editmap->insert("Select Markers", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_M)));
+  editmap->insert("Find", QString(QKeySequence(Qt::CTRL+Qt::Key_F)));
+  editmap->insert("Find Again", QString(QKeySequence(Qt::Key_F3)));
+  editmap->insert("Replace", QString(QKeySequence(Qt::Key_F7)));
+  editmap->insert("Rotate", QString(QKeySequence(Qt::CTRL+Qt::Key_R)));
+  editmap->insert("Mirror about X Axis", QString(QKeySequence(Qt::CTRL+Qt::Key_J)));
+  editmap->insert("Mirror about Y Axis", QString(QKeySequence(Qt::CTRL+Qt::Key_M)));
+  editmap->insert("Deactivate Activate", QString(QKeySequence(Qt::CTRL+Qt::Key_D)));
+  editmap->insert("Go into Subcircuit", QString(QKeySequence(Qt::CTRL+Qt::Key_I)));
+  editmap->insert("Pop out", QString(QKeySequence(Qt::CTRL+Qt::Key_H)));
+  vec->push_back(qMakePair(QString("Edit"), editmap));
+
+  QMap<QString, QString> *positionmap = new QMap<QString, QString>;
+  positionmap->insert("Move Component Text", QString(QKeySequence(Qt::CTRL+Qt::Key_K)));
+  positionmap->insert("Set on Grid", QString(QKeySequence(Qt::CTRL+Qt::Key_U)));
+  positionmap->insert("Center horizontally", QString());
+  positionmap->insert("Center vertically", QString());
+  positionmap->insert("Align top", QString(QKeySequence(Qt::CTRL+Qt::Key_T)));
+  positionmap->insert("Align bottom", QString());
+  positionmap->insert("Align left", QString());
+  positionmap->insert("Align right", QString());
+  positionmap->insert("Distribute horizontally", QString());
+  positionmap->insert("Distribute vertically", QString());
+  vec->push_back(qMakePair(QString("Positioning"), positionmap));
+
+  QMap<QString, QString> *insertmap = new QMap<QString, QString>;
+  insertmap->insert("Wire", QString(QKeySequence(Qt::CTRL+Qt::Key_E)));
+  insertmap->insert("Wire Label", QString(QKeySequence(Qt::CTRL+Qt::Key_L)));
+  insertmap->insert("Insert Equation", QString(QKeySequence(Qt::CTRL+Qt::Key_Less)));
+  insertmap->insert("Insert Ground", QString(QKeySequence(Qt::CTRL+Qt::Key_G)));
+  insertmap->insert("Insert Port", QString());
+  insertmap->insert("Set Marker on Graph", QString(QKeySequence(Qt::CTRL+Qt::Key_B)));
+  insertmap->insert("VHDL entity", QString(QKeySequence(Qt::CTRL+Qt::Key_Space)));
+  vec->push_back(qMakePair(QString("Insert"), insertmap));
+
+  QMap<QString, QString> *projectmap = new QMap<QString, QString>;
+  projectmap->insert("New Project", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_N)));
+  projectmap->insert("Open Project", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_O)));
+  projectmap->insert("Add Files to Project", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_A)));
+  projectmap->insert("Close Project", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_W)));
+  projectmap->insert("Delete Project", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_D)));
+  projectmap->insert("Create Library", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_L)));
+  projectmap->insert("Create Package", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_Z)));
+  projectmap->insert("Extract Package", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_X)));
+  projectmap->insert("Import Export Data", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_I)));
+  projectmap->insert("Export to CSV", QString(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_C)));
+  projectmap->insert("Build Verilog-A module", QString());
+  projectmap->insert("Load Verilog-A module", QString());
+  vec->push_back(qMakePair(QString("Project"), projectmap));
+
+  QMap<QString, QString> *toolmap = new QMap<QString, QString>;
+  toolmap->insert("Text Editor", QString(QKeySequence(Qt::CTRL+Qt::Key_1)));
+  toolmap->insert("Filter synthesis", QString(QKeySequence(Qt::CTRL+Qt::Key_2)));
+  toolmap->insert("Active filter synthesis", QString(QKeySequence(Qt::CTRL+Qt::Key_3)));
+  toolmap->insert("Line calculation", QString(QKeySequence(Qt::CTRL+Qt::Key_4)));
+  toolmap->insert("Component Library", QString(QKeySequence(Qt::CTRL+Qt::Key_5)));
+  toolmap->insert("Matching Circuit", QString(QKeySequence(Qt::CTRL+Qt::Key_6)));
+  toolmap->insert("Attenuator synthesis", QString(QKeySequence(Qt::CTRL+Qt::Key_7)));
+  toolmap->insert("Resistor color codes", QString(QKeySequence(Qt::CTRL+Qt::Key_8)));
+  vec->push_back(qMakePair(QString("Tools"), toolmap));
+
+  QMap<QString, QString> *simulationmap = new QMap<QString, QString>;
+  simulationmap->insert("Simulate", QString(QKeySequence(Qt::Key_F2)));
+  simulationmap->insert("View Data Display Schematic", QString(QKeySequence(Qt::Key_F4)));
+  simulationmap->insert("Calculate DC bias", QString(QKeySequence(Qt::Key_F8)));
+  simulationmap->insert("Show Last Messages", QString(QKeySequence(Qt::Key_F5)));
+  simulationmap->insert("Show Last Netlist", QString(QKeySequence(Qt::Key_F6)));
+  vec->push_back(qMakePair(QString("Simulation"), simulationmap));
+
+  QMap<QString, QString> *viewmap = new QMap<QString, QString>;
+  viewmap->insert("View All", QString(QKeySequence(Qt::Key_0)));
+  viewmap->insert("View 1:1", QString(QKeySequence(Qt::Key_1)));
+  viewmap->insert("Zoom in", QString(QKeySequence(Qt::Key_Plus)));
+  viewmap->insert("Zoom out", QString(QKeySequence(Qt::Key_Minus)));
+  viewmap->insert("Toolbar", QString());
+  viewmap->insert("Statusbar", QString());
+  viewmap->insert("Dock Window", QString());
+  viewmap->insert("Octave Window", QString());
+  vec->push_back(qMakePair(QString("View"), viewmap));
+
+  QMap<QString, QString> *helpmap = new QMap<QString, QString>;
+  helpmap->insert("Help Index", QString(QKeySequence(Qt::Key_F1)));
+  helpmap->insert("Getting Started", QString());
+  helpmap->insert("About Qucs", QString());
+  helpmap->insert("About Qt", QString());
+  vec->push_back(qMakePair(QString("Help"), helpmap));
+}
+
+void
+clearShortcutMap()
+{
+  QVector<QPair<QString, QMap<QString, QString>* > >::const_iterator it = QucsSettings.Shortcut.constBegin();
+  while(it != QucsSettings.Shortcut.constEnd()) {
+    delete it->second;
+    it++;
+  }
+  QucsSettings.Shortcut.clear();
+}
 
 /**
  * @brief QucsApp::initActions Initializes all QActions of the application


### PR DESCRIPTION
This is the new custom shortcut setting I write. It's a modification of the previous version, which is now in feature54shortcut branch. However, there are many differences between these two, so I suggest simple delete the previous branch.
The shortcut setting dialog is added in Application Setting->setting->"custom shortcut".

*****

Here I will explain what I did in each commits:

1. I use the object keysequenceedit implemented in previous version.
It can generate QString represent the keysequence like hit Ctrl+Alt+T will show Ctrl+Alt+T directly.

2. modify layout in qucssettingdialog

3-5. Implement default shortcut setting, load/save.
Here add a new container in QucsSettings, which record all shortcut key sequence.
It's a Vector of map<QString, QString>
The map inside is directly map QAction name to its shortcut key sequence.
Different QActions that stores in different menu will be stored in different map.

6-7. Implement the layout of qucsshortcutdialog, and fill them with data in shortcut 

8-9. Implement the set/remove/default button function.
Every time you input a key sequence, the dialog will check is there a conflict to other shortcut setting or not.
It you press "setShortcut" when there is a conflict, the conflict one will be wipe out to no shortcut.

10. Implement shortcut setting in qucs.
Collect setShortcut of each QAction into one function.

11. Implement invalidKey.
I notice that some key sequence like "ESC" should be preserved to specific action. So the shortcut dialog will store a list of invalid Key sequence, every input will be checked.

******

I think this version is a perfect version to me. Hope everyone will like my implementation.
Look forward to your comments.
