### PR TITLE
use the painter fontMetrics() to obtain the right text size

### DIFF
--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -79,7 +79,9 @@ void Component::Bounding(int& _x1, int& _y1, int& _x2, int& _y2)
 // Size of component text.
 int Component::textSize(int& _dx, int& _dy)
 {
-  QFontMetrics  metrics(QucsSettings.font);   // get size of text
+  // need to use the painter fontMetrics() to obtain proper results
+  QFontMetrics metrics = containingSchematic->fontMetrics(); // get size of text
+
   int tmp, count=0;
   _dx = _dy = 0;
   if(showName) {


### PR DESCRIPTION
On my system when doing a Move Component Text (Ctrl+K) the text bounding box shown is not right. It turns out that one needs to use the painter fontMetrics() instead on relying on the current font metrics, not sure why. Might affect Linux only, did not check on other OSs.
![qucs_0 0 19_move_text](https://cloud.githubusercontent.com/assets/9018179/4875004/2eed8e80-627d-11e4-940b-7a3790b68335.png) ![qucs_0 0 19_patched_move_text](https://cloud.githubusercontent.com/assets/9018179/4875006/3490a1c4-627d-11e4-9874-b93d2894ae28.png)
