### PR TITLE
move q3dict to qhash in modules

### DIFF
--- a/qucs/qucs/module.cpp
+++ b/qucs/qucs/module.cpp
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 #include <QtGui>
-#include <Q3Dict>
+#include <QHash>
 #include <QString>
 #include <QStringList>
 #include <Q3PtrList>
@@ -28,7 +28,7 @@
 #include "module.h"
 
 // Global category and component lists.
-Q3Dict<Module> Module::Modules;
+QHash<QString, Module *> Module::Modules;
 Q3PtrList<Category> Category::Categories;
 
 QMap<QString, QString> Module::vaComponents;
@@ -69,14 +69,14 @@ void Module::registerComponent (QString category, pInfoFunc info) {
 
   // put into category and the component hash
   intoCategory (m);
-  if (!Modules.find (Model))
+  if (!Modules.contains (Model))
     Modules.insert (Model, m);
 }
 
 // Returns instantiated component based on the given "Model" name.  If
 // there is no such component registers the function returns NULL.
 Component * Module::getComponent (QString Model) {
-  Module * m = Modules.find (Model);
+  Module * m = Modules.find(Model).value();
   if (m) {
     QString Name;
     char * File;
@@ -129,7 +129,7 @@ void Module::registerDynamicComponents()
      // put into category and the component hash
      intoCategory (m);
 
-     if (!Modules.find (Model))
+     if (!Modules.contains (Model))
          Modules.insert (Model, m);
 
    } // while
@@ -437,6 +437,13 @@ void Module::registerModules (void) {
 void Module::unregisterModules (void) {
   Category::Categories.setAutoDelete (true);
   Category::Categories.clear ();
+
+  //remove all modules by iterator, require in qhash
+  QHashIterator<QString, Module *> it( Modules );
+  while(it.hasNext()) {
+    it.next();
+    delete it.value();
+  }
   Modules.clear ();
 }
 

--- a/qucs/qucs/module.h
+++ b/qucs/qucs/module.h
@@ -19,7 +19,7 @@
 #define MODULE_H
 
 #include <Q3PtrList>
-#include <Q3Dict>
+#include <QHash>
 #include <QMap>
 
 // function typedefs for circuits and analyses
@@ -39,7 +39,7 @@ class Module
   static void registerDynamicComponents(void);
 
  public:
-  static Q3Dict<Module> Modules;
+  static QHash<QString, Module *> Modules;
   static QMap<QString, QString> vaComponents;
 
  public:

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -1544,14 +1544,17 @@ void QucsApp::slotLoadModule()
       // remove all modules before registering/loaded again
       // look for modules in the category,
       // \todo investigate if it is leaking objects somewhere
-      QStringList remove;
-      Q3DictIterator<Module> it( Module::Modules );
-      for( ; it.current(); ++it ){
-        if (it.current()->category == QObject::tr("verilog-a user devices"))
-          remove << it.currentKey();
+      QStringList removeList;
+      QHashIterator<QString, Module *> it( Module::Modules );
+      while(it.hasNext()) {
+        it.next();
+        if (it.value()->category == QObject::tr("verlog-a user devices")) {
+          removeList << it.key();
+          delete it.value();
+        }
       }
-      for (int i = 0; i < remove.size(); ++i){
-        Module::Modules.remove(remove.at(i));
+      for (int i = 0; i < removeList.size(); ++i){
+        Module::Modules.remove(removeList.at(i));
       }
 
       if (! Module::vaComponents.isEmpty()) {


### PR DESCRIPTION
Replace Q3Dict in modules to QHash, only a simple interface change. The larger change is that we have to release memory of object of QHash value by ourselves.
