### PR TITLE
Added recently 'saved as' files to recent opened menu

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1671,6 +1671,8 @@ bool QucsApp::saveAs()
   }
   Doc->setName(s);
   lastDirOpenSave = Info.dirPath(true);  // remember last directory and file
+  updateRecentFilesList(s);
+  slotUpdateRecentFiles();
 
   if(intoView) {    // insert new name in Content ListView ?
     if(Info.dirPath(true) == QucsSettings.QucsWorkDir.absPath())


### PR DESCRIPTION
Recently saved filenames are added to File->OpenRecent menu after File->SaveAs is executed.
