### PR TITLE
Fixed issue #102

### DIFF
--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -733,6 +733,27 @@ void Schematic::paintSchToViewpainter(ViewPainter *p, bool printAll, bool toImag
       }
         }
       }
+
+    if(showBias > 0) {  // show DC bias points in schematic ?
+      int x, y, z;
+      for(Node* pn = Nodes->first(); pn != 0; pn = Nodes->next()) {
+        if(pn->Name.isEmpty()) continue;
+        x = pn->cx;
+        y = pn->cy + 4;
+        z = pn->x1;
+        if(z & 1) x -= p->Painter->fontMetrics().width(pn->Name);
+        if(!(z & 2)) {
+          y -= (p->LineSpacing>>1) + 4;
+          if(z & 1) x -= 4;
+          else x += 4;
+        }
+        if(z & 0x10)
+          p->Painter->setPen(Qt::darkGreen);  // green for currents
+        else
+          p->Painter->setPen(Qt::blue);   // blue for voltages
+        p->drawText(pn->Name, x, y);
+      }
+    }
 }
 
 // -----------------------------------------------------------


### PR DESCRIPTION
This is bugfix for issue #102. Now DC bias simulation results are exported correctly. I'm sorry. I forgot to test it last year! Now this is added.
![export](https://cloud.githubusercontent.com/assets/4920080/4937173/0f2e22f2-65c1-11e4-8a88-dc01ccbadf18.png)
