### PR TITLE
load language setting dynamically

### DIFF
--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -466,8 +466,11 @@ void QucsSettingsDialog::slotApply()
 
     QucsSettings.font=Font;
 
-    QucsSettings.Language =
-        LanguageCombo->currentText().section('(',1,1).remove(')');
+    if (QucsSettings.Language != LanguageCombo->currentText().section('(', 1, 1).remove(')')) {
+      QucsSettings.Language =
+          LanguageCombo->currentText().section('(',1,1).remove(')');
+      App->updateLanguage();
+    }
 
     if(QucsSettings.Comment != ColorComment->paletteForegroundColor())
     {

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -985,13 +985,6 @@ int main(int argc, char *argv[])
   QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
   QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
 
-  QTranslator tor( 0 );
-  QString lang = QucsSettings.Language;
-  if(lang.isEmpty())
-    lang = QTextCodec::locale();
-  tor.load( QString("qucs_") + lang, QucsSettings.LangDir);
-  a.installTranslator( &tor );
-
   // This seems to be neccessary on a few system to make strtod()
   // work properly !???!
   setlocale (LC_NUMERIC, "C");
@@ -1091,6 +1084,5 @@ int main(int argc, char *argv[])
   qInstallMsgHandler(qucsMessageOutput);
   QucsMain->show();
   int result = a.exec();
-  //saveApplSettings(QucsMain);
   return result;
 }

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -90,6 +90,9 @@ QucsApp::QucsApp()
 {
   setCaption("Qucs " PACKAGE_VERSION);
 
+  // set up translation
+  updateLanguage();
+
   spiceExtensions << "*.sp" << "*.cir" << "*.spc" << "*.spi";
 
   QucsFileFilter =
@@ -3017,6 +3020,18 @@ void QucsApp::updateSpiceNameHash(void)
     foreach (QFileInfo spicefile, spicefilesList) {
         spiceNameHash[spicefile.completeBaseName()] = spicefile.absoluteFilePath();
     }
+}
+
+// -----------------------------------------------------------
+// update language
+void
+QucsApp::updateLanguage()
+{
+  QString lang = QucsSettings.Language;
+  if(lang.isEmpty())
+    lang = QTextCodec::locale();
+  appTranslator.load( QString("qucs_") + lang, QucsSettings.LangDir);
+  qApp->installTranslator( &appTranslator );
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -22,6 +22,7 @@
 #include <QString>
 #include <Q3PtrList>
 #include <QHash>
+#include <QTranslator>
 
 class QucsDoc;
 class Schematic;
@@ -191,8 +192,9 @@ private:
   QTreeWidgetItem *ConSchematics, *ConSources, *ConDisplays, *ConDatasets,
                   *ConOthers, *ConVerilog, *ConVerilogA, *ConOctave;
 
-
   QComboBox       *CompChoose;
+
+  QTranslator     appTranslator;
 
 // ********** Properties ************************************************
   Q3PtrList<QString> HierarchyHistory; // keeps track of "go into subcircuit"
@@ -223,6 +225,7 @@ private:
 
 public:
 
+  void updateLanguage();
   void readProjects();
   void readProjectFiles();
   void updatePathList(void); // update the list of paths, pruning non-existing paths


### PR DESCRIPTION
This is just a demo branch, DO NOT MERGE THIS.
You can try change language in setting dialog, then change a components category. You will find that components' name change to language you choose. 
However, the names of the menu and action don't change, since we have to call setText(tr("..."))
after language being set. That is, we have to write qucs_action.cpp like this:

```
function init_action(){
  QAction file = new ......
  .....
}

function setup_text() {
  file->setText...
  ....
```

so that we can call setup_text() after language changed. This will be a hard work, maybe we can do that during QScrollView change?
