### PR TITLE
Fixed zoom in schematic

### DIFF
--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -414,7 +414,7 @@ void Schematic::drawContents(QPainter *p, int, int, int, int)
 {
   ViewPainter Painter;
   Painter.init(p, Scale, -ViewX1, -ViewY1, contentsX(),
-	       contentsY(), 1.0, 1.0, QucsSettings.DrawInAntiAliasing);
+	       contentsY(), QucsSettings.DrawInAntiAliasing);
 
   paintGrid(&Painter, contentsX(), contentsY(),
             visibleWidth(), visibleHeight());

--- a/qucs/qucs/viewpainter.cpp
+++ b/qucs/qucs/viewpainter.cpp
@@ -33,8 +33,9 @@ ViewPainter::~ViewPainter()
 }
 
 // -------------------------------------------------------------
-void ViewPainter::init(QPainter *p, float Scale_, int DX_, int DY_, int dx_, int dy_,
-    float FontScale_, float PrintScale_, bool DrawInAntiAliasing)
+void ViewPainter::init(QPainter *p, float Scale_, int DX_, int DY_, 
+		       int dx_, int dy_, bool DrawInAntiAliasing, 
+		       float FontScale_, float PrintScale_)
 {
   Painter = p;
   Scale = Scale_;

--- a/qucs/qucs/viewpainter.h
+++ b/qucs/qucs/viewpainter.h
@@ -37,8 +37,9 @@ public:
   ViewPainter(QPainter *p=0);
  ~ViewPainter();
 
-  void init(QPainter*, float, int, int, int, int, float FontScale_=0.0,
-	    float PrintScale_=1.0, bool DrawInAntiAliasing = true);
+ void init(QPainter*, float, int, int, int, int, 
+	   bool DrawInAntiAliasing = true, 
+	   float FontScale_=0.0, float PrintScale_=1.0);
   void map(int, int, int&, int&);
   void drawPoint(int, int);
   void drawLine (int, int, int, int);


### PR DESCRIPTION
...when I modified the yodalee code to fix the antialiasing stuff I actually borked the zoom function, sorry. I did specify a wrong default value for an optional argument to `ViewPainter::init()`; I have now moved the unused arguments to the end, so there is no need to specify a value for them anymore.
