### PR TITLE
qucs-rescode: autotool s/INCLUDES/AM_CPPFLAGS

### DIFF
--- a/qucs/qucs-rescodes/Makefile.am
+++ b/qucs/qucs-rescodes/Makefile.am
@@ -44,7 +44,7 @@ qrc_qucsrescodes.cpp: qucsrescodes.qrc
 
 nodist_qucsrescodes_SOURCES = $(MOCFILES)
 
-INCLUDES = $(X11_INCLUDES) $(QT_INCLUDES)
+AM_CPPFLAGS = $(X11_INCLUDES) $(QT_INCLUDES)
 qucsrescodes_LDFLAGS = $(X11_LDFLAGS) $(QT_LDFLAGS)
 qucsrescodes_LDADD = $(X11_LIBS) $(QT_LIBS)
 


### PR DESCRIPTION
autotool complain about INCLUDE in Makefile.am change to AM_CPPFLAGS

This modification will affect old version autotool, after all in other directory, we change to AM_CPPFLAGS already.
