### PR TITLE
followup pull #119, cmake out of tree

### DIFF
--- a/qucs/qucs/dialogs/CMakeLists.txt
+++ b/qucs/qucs/dialogs/CMakeLists.txt
@@ -1,7 +1,8 @@
 # qucs/dialogs library
 
 INCLUDE_DIRECTORIES( ${CMAKE_SOURCE_DIR}
-                     ${CMAKE_CURRENT_SOURCE_DIR} )
+                     ${CMAKE_CURRENT_SOURCE_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR} ) # ui_*.h, out of tree
 
 #INCLUDES = $(X11_INCLUDES) $(QT_INCLUDES) -I$(top_srcdir)/qucs
 


### PR DESCRIPTION
While building out of tree it complains about the missing ui_*.h header.
Headers are being created on the build/binary directory.
