### PR TITLE
Corrected simulator process exit status check

### DIFF
--- a/qucs/qucs/dialogs/simmessage.h
+++ b/qucs/qucs/dialogs/simmessage.h
@@ -57,7 +57,7 @@ private slots:
   void slotDisplayMsg();
   void slotDisplayErr();
   void slotCloseStdin();
-  void slotSimEnded(int status);
+  void slotSimEnded(int exitCode, QProcess::ExitStatus exitStatus);
   void slotDisplayButton();
   void AbortSim();
 


### PR DESCRIPTION
This corrects issue #132 .
I have changed `SimMessage::slotSimEnded()` to check the exit status of the simulator process, so that the user is informed thru the simulation dialog when the simulator has crashed.

While I was at it, I have replaced some Qt3 compatibility functions with the proper Qt4 ones and added some Doxygen style comments.
Also I have added newlines at the end of the `ERROR:` messages, otherwise in case of multiple errors they are all in one single, long, line. Similar strings in `schematic_file.cpp`, and maybe other files, should be changed also, though.
