### PR TITLE
Fixed issue #139

### DIFF
--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -458,7 +458,7 @@ void ComponentDialog::updateCompPropsList()
         } else {
             last_prop = 0;
         }
-            last_prop += 3;  // remember last property for ListView
+            last_prop += 4;  // remember last property for ListView
     }
 
     QString s;


### PR DESCRIPTION
Contains fix for issue #139. Now Apply button doesn't duplicate simulation properties.
