### PR TITLE
cmake: fix location of generated files

### DIFF
--- a/qucs-core/src/CMakeLists.txt
+++ b/qucs-core/src/CMakeLists.txt
@@ -452,6 +452,9 @@ INCLUDE_DIRECTORIES( ${qucs-core_SOURCE_DIR}          # generated config.h
                      ${qucs-core_SOURCE_DIR}/src/     # compat.h
                      ${qucs-core_SOURCE_DIR}/src/components # microstrip/substrate.h
                      ${qucs-core_SOURCE_DIR}/src/interface
+                     ${qucs-core_BINARY_DIR}          # cmake generated config.h
+                     ${qucs-core_BINARY_DIR}/src      # cmake generated gperfapphash.h
+                     ${qucs-core_BINARY_DIR}/src/components   # generated verilog/[].core.h
                      )
 
 #

--- a/qucs-core/src/interface/CMakeLists.txt
+++ b/qucs-core/src/interface/CMakeLists.txt
@@ -2,7 +2,9 @@
 INCLUDE_DIRECTORIES( ${qucs-core_SOURCE_DIR}
                      ${qucs-core_CURRENT_SOURCE_DIR}
                      ${qucs-core_SOURCE_DIR}/src/math
-                     ${qucs-core_SOURCE_DIR}/src/components )  # component.h
+                     ${qucs-core_SOURCE_DIR}/src/components   # component.h
+                     ${qucs-core_BINARY_DIR}/src/components   # generated verilog/[].core.h
+                     )
 
 SET( INTERFACE_SRC
   qucs_interface.cpp


### PR DESCRIPTION
- fatal error: 'config.h' file not found
- fatal error: 'gperfapphash.cpp' file not found
- fatal error: 'verilog/hicumL2V2p1.core.h' file not found
