### PR TITLE
Fixed crash when diagrams had only one data graph.

### DIFF
--- a/qucs/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/qucs/diagrams/tabdiagram.cpp
@@ -156,8 +156,8 @@ int TabDiagram::calcDiagram()
 
   QListIterator<Graph *> ig(Graphs);
   Graph *g = 0;
-  if (ig.hasNext())
-     g= ig.next();
+  if (ig.hasNext()) // point to first graph
+    g = ig.next();
 
   if(g == 0) {  // no variables specified in diagram ?
     Str = QObject::tr("no variables");
@@ -166,7 +166,6 @@ int TabDiagram::calcDiagram()
       Texts.append(new Text(x-4, y2-2, Str)); // independent variable
     return 0;
   }
-
 
   int NumAll=0;   // how many numbers per column
   int NumLeft=0;  // how many numbers could not be written
@@ -177,64 +176,64 @@ int TabDiagram::calcDiagram()
 
   // any graph with data ?
   while(g->cPointsX.isEmpty()) {
-    g = ig.next();
-    if(g == 0) break;
-  }
-if(g) if(!g->cPointsX.isEmpty()) {
-  // ................................................
-  counting = g->cPointsX.getFirst()->count * g->countY;  // number of values
-  NumAll = counting;
-
-  invisibleCount = counting - y/tHeight;
-  if(invisibleCount <= 0)  xAxis.limit_min = 0.0;// height bigger than needed
-  else {
-    NumLeft = invisibleCount - int(xAxis.limit_min + 0.5);
-    if(invisibleCount < int(xAxis.limit_min + 0.5))
-      xAxis.limit_min = double(invisibleCount); // adjust limit of scroll bar
+    if (!ig.hasNext()) break; // no more graphs
+    g = ig.next(); // point to next graph
   }
 
-  for(DataX *pD = g->cPointsX.last(); pD!=0; pD = g->cPointsX.prev()) {
-    colWidth = 0;
-    Str = pD->Var;
-    colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
-    if(colWidth < 0)  goto funcEnd;
-    startWriting = int(xAxis.limit_min + 0.5);  // when to reach visible area
-
-    Texts.append(new Text(x-4, y2-2, Str)); // independent variable
-    if(pD->count != 0) {
-      y = y2-tHeight-5;
-      counting /= pD->count;   // how many rows to be skipped
-      for(int z1=0; z1<lastCount; z1++) {
-        px = pD->Points;
-        for(int z=pD->count; z>0; z--) {
-	  if(startWriting <= 0) { // reached visible area ?
-	    y += tHeight*startWriting;
-	    startWriting = 0;
-	    if(y < tHeight) break;  // no room for more rows ?
-	    Str = StringNum(*px, 'g', g->Precision);
-	    colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
-	    if(colWidth < 0)  goto funcEnd;
-
-            Texts.append(new Text( x, y, Str));
-            y -= tHeight*counting;
-	  }
-	  else startWriting -= counting;
-	  px++;
-        }
-	if(pD == g->cPointsX.getFirst())   // only paint one time
-	  if(y >= tHeight) if(y < y2-tHeight-5)
-            Lines.append(new Line(0, y+1, x2, y+1, QPen(Qt::black,0)));
-      }
-      lastCount *= pD->count;
+  if(!g->cPointsX.isEmpty()) { // did we find a graph with data ?
+    // ................................................
+    counting = g->cPointsX.getFirst()->count * g->countY;  // number of values
+    NumAll = counting;
+    
+    invisibleCount = counting - y/tHeight;
+    if(invisibleCount <= 0)  xAxis.limit_min = 0.0;// height bigger than needed
+    else {
+      NumLeft = invisibleCount - int(xAxis.limit_min + 0.5);
+      if(invisibleCount < int(xAxis.limit_min + 0.5))
+	xAxis.limit_min = double(invisibleCount); // adjust limit of scroll bar
     }
-    x += colWidth+15;
-    Lines.append(new Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
-  }
-  Lines.last()->style = QPen(Qt::black,2);
+    
+    for(DataX *pD = g->cPointsX.last(); pD!=0; pD = g->cPointsX.prev()) {
+      colWidth = 0;
+      Str = pD->Var;
+      colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
+      if(colWidth < 0)  goto funcEnd;
+      startWriting = int(xAxis.limit_min + 0.5);  // when to reach visible area
+      
+      Texts.append(new Text(x-4, y2-2, Str)); // independent variable
+      if(pD->count != 0) {
+	y = y2-tHeight-5;
+	counting /= pD->count;   // how many rows to be skipped
+	for(int z1=0; z1<lastCount; z1++) {
+	  px = pD->Points;
+	  for(int z=pD->count; z>0; z--) {
+	    if(startWriting <= 0) { // reached visible area ?
+	      y += tHeight*startWriting;
+	      startWriting = 0;
+	      if(y < tHeight) break;  // no room for more rows ?
+	      Str = StringNum(*px, 'g', g->Precision);
+	      colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
+	      if(colWidth < 0)  goto funcEnd;
+	      
+	      Texts.append(new Text( x, y, Str));
+	      y -= tHeight*counting;
+	    }
+	    else startWriting -= counting;
+	    px++;
+	  }
+	  if(pD == g->cPointsX.getFirst())   // only paint one time
+	    if(y >= tHeight) if(y < y2-tHeight-5)
+	      Lines.append(new Line(0, y+1, x2, y+1, QPen(Qt::black,0)));
+	}
+	lastCount *= pD->count;
+      }
+      x += colWidth+15;
+      Lines.append(new Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
+    }
+    Lines.last()->style = QPen(Qt::black,2);
+  }  // of "if no data in graphs"
 
-}  // of "if no data in graphs"
-
-
+  
   firstGraph = g;
   // ................................................
   // all dependent variables

--- a/qucs/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/qucs/diagrams/timingdiagram.cpp
@@ -151,9 +151,9 @@ int TimingDiagram::calcDiagram()
 
   QListIterator<Graph *> ig(Graphs);
   Graph *g = 0;
-  if (ig.hasNext())
-     g= ig.next();
-
+  if (ig.hasNext()) // point to first graph
+    g = ig.next();
+  
   if(g == 0) {  // no variables specified in diagram ?
     Str = QObject::tr("no variables");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
@@ -164,11 +164,13 @@ int TimingDiagram::calcDiagram()
 
 
   double *px;
-  while(g->cPointsX.isEmpty()) {  // any graph with data ?
-    g = ig.next();
-    if( !ig.hasNext()) break;
+  // any graph with data ?
+  while(g->cPointsX.isEmpty()) {
+    if (!ig.hasNext()) break; // no more graphs, exit loop
+    g = ig.next(); // point to next graph
   }
-  if(g == 0) {
+  
+  if(g->cPointsX.isEmpty()) { // no graph with data found ?
     Str = QObject::tr("no data");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth < 0)  return 0;

--- a/qucs/qucs/diagrams/truthdiagram.cpp
+++ b/qucs/qucs/diagrams/truthdiagram.cpp
@@ -99,56 +99,56 @@ int TruthDiagram::calcDiagram()
   int counting, invisibleCount=0;
   int startWriting, z;
 
-  while(g->cPointsX.isEmpty()) {  // any graph with data ?
-    g = ig.next();
-    if( ! ig.hasNext()) break;
-  }
-if(g) if(!g->cPointsX.isEmpty()) {
-  // ................................................
-  NumAll = g->cPointsX.getFirst()->count * g->countY;  // number of values
-
-  invisibleCount = NumAll - y/tHeight;
-  if(invisibleCount <= 0)  xAxis.limit_min = 0.0;// height bigger than needed
-  else {
-    if(invisibleCount < int(xAxis.limit_min + 0.5))
-      xAxis.limit_min = double(invisibleCount); // adjust limit of scroll bar
-    NumLeft = invisibleCount - int(xAxis.limit_min + 0.5);
+  // any graph with data ?
+  while(g->cPointsX.isEmpty()) {
+    if (!ig.hasNext()) break; // no more graphs, exit loop
+    g = ig.next(); // point to next graph
   }
 
-
-  colWidth = 0;
-  Texts.append(new Text(x-4, y2-2, Str)); // independent variable
-  if(NumAll != 0) {
-    z = metrics.width("1");
-    colWidth = metrics.width("0");
-    if(z > colWidth)  colWidth = z;
-    colWidth += 2;
-    counting = int(log(double(NumAll)) / log(2.0) + 0.9999); // number of bits
-
-    if((x+colWidth*counting) >= x2) {    // enough space for text ?
-      checkColumnWidth("0", metrics, 0, x2, y);
-      goto funcEnd;
+  if(!g->cPointsX.isEmpty()) { // did we find a graph with data ?
+    // ................................................
+    NumAll = g->cPointsX.getFirst()->count * g->countY;  // number of values
+    
+    invisibleCount = NumAll - y/tHeight;
+    if(invisibleCount <= 0)  xAxis.limit_min = 0.0;// height bigger than needed
+    else {
+      if(invisibleCount < int(xAxis.limit_min + 0.5))
+	xAxis.limit_min = double(invisibleCount); // adjust limit of scroll bar
+      NumLeft = invisibleCount - int(xAxis.limit_min + 0.5);
     }
 
-    y = y2-tHeight-5;
-    startWriting = x;
-    for(z=int(xAxis.limit_min + 0.5); z<NumAll; z++) {
-      if(y < tHeight) break;  // no room for more rows ?
-      startWriting = x;
-      for(int zi=counting-1; zi>=0; zi--) {
-        if(z & (1 << zi))  Str = "1";
-        else  Str = "0";
-        Texts.append(new Text( startWriting, y, Str));
-        startWriting += colWidth;
+    colWidth = 0;
+    Texts.append(new Text(x-4, y2-2, Str)); // independent variable
+    if(NumAll != 0) {
+      z = metrics.width("1");
+      colWidth = metrics.width("0");
+      if(z > colWidth)  colWidth = z;
+      colWidth += 2;
+      counting = int(log(double(NumAll)) / log(2.0) + 0.9999); // number of bits
+      
+      if((x+colWidth*counting) >= x2) {    // enough space for text ?
+	checkColumnWidth("0", metrics, 0, x2, y);
+	goto funcEnd;
       }
-      y -= tHeight;
+      
+      y = y2-tHeight-5;
+      startWriting = x;
+      for(z=int(xAxis.limit_min + 0.5); z<NumAll; z++) {
+	if(y < tHeight) break;  // no room for more rows ?
+	startWriting = x;
+	for(int zi=counting-1; zi>=0; zi--) {
+	  if(z & (1 << zi))  Str = "1";
+	  else  Str = "0";
+	  Texts.append(new Text( startWriting, y, Str));
+	  startWriting += colWidth;
+	}
+	y -= tHeight;
+      }
+      x = startWriting + 15;
     }
-    x = startWriting + 15;
-  }
-  Lines.append(new Line(x-8, y2, x-8, 0, QPen(Qt::black,2)));
-
-}  // of "if no data in graphs"
-
+    Lines.append(new Line(x-8, y2, x-8, 0, QPen(Qt::black,2)));  
+  }  // of "if no data in graphs"
+  
 
   int zi, digitWidth;
   firstGraph = g;


### PR DESCRIPTION
For timing/tab/truth diagrams corrected handling of case when there was only
one data variable to graph and no data were available.
Fixes #150 .
