### PR TITLE
Fixed setChanged() icon update bug introduced in 0748c1089e .

### DIFF
--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -267,9 +267,9 @@ void Schematic::setName (const QString& Name_)
 void Schematic::setChanged(bool c, bool fillStack, char Op)
 {
   if((!DocChanged) && c)
-    App->DocumentTab->setTabIcon(App->DocumentTab->currentIndex(), QPixmap(smallsave_xpm));
+    App->DocumentTab->setTabIcon(App->DocumentTab->indexOf(this), QPixmap(smallsave_xpm));
   else if(DocChanged && (!c))
-    App->DocumentTab->setTabIcon(App->DocumentTab->currentIndex(), QPixmap(empty_xpm));
+    App->DocumentTab->setTabIcon(App->DocumentTab->indexOf(this), QPixmap(empty_xpm));
   DocChanged = c;
 
   showBias = -1;   // schematic changed => bias points may be invalid


### PR DESCRIPTION
sorry, I realized I did  a mistake when updating some code in `schematic.cpp` to remove the deprecated Qt3 functions: the "save needed" icon for the tabs other than the current one were not updated when doing a Save All... now the intended behavior is restored.
