### PR TITLE
[Refactor] clear qucs app function

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1922,8 +1922,11 @@ void QucsApp::closeFile(int index)
         case 2 : return;
       }
     }
+    editText->move(QPoint(0, 0));
+    editText->hide();
 
     delete Doc;
+    DocumentTab->removeTab(index);
 
     if(DocumentTab->count() < 1) { // if no document left, create an untitled
       Schematic *d = new Schematic(this, "");

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -72,7 +72,48 @@
 #include "../qucs-lib/qucslib_common.h"
 #include "misc.h"
 
-extern const char *empty_xpm[];
+// icon for unsaved files (diskette)
+const char *smallsave_xpm[] = {
+"16 17 66 1", " 	c None",
+".	c #595963","+	c #E6E6F1","@	c #465460","#	c #FEFEFF",
+"$	c #DEDEEE","%	c #43535F","&	c #D1D1E6","*	c #5E5E66",
+"=	c #FFFFFF","-	c #C5C5DF",";	c #FCF8F9",">	c #BDBDDA",
+",	c #BFBFDC","'	c #C4C4DF",")	c #FBF7F7","!	c #D6D6E9",
+"~	c #CBCBE3","{	c #B5B5D6","]	c #BCBCDA","^	c #C6C6E0",
+"/	c #CFCFE5","(	c #CEC9DC","_	c #D8D8EA",":	c #DADAEB",
+"<	c #313134","[	c #807FB3","}	c #AEAED1","|	c #B7B7D7",
+"1	c #E2E2EF","2	c #9393C0","3	c #E3E3F0","4	c #DDD5E1",
+"5	c #E8E8F3","6	c #2F2F31","7	c #7B7BAF","8	c #8383B5",
+"9	c #151518","0	c #000000","a	c #C0C0DC","b	c #8E8FBD",
+"c	c #8989BA","d	c #E7EEF6","e	c #282829","f	c #6867A1",
+"g	c #7373A9","h	c #A7A7CD","i	c #8080B3","j	c #7B7CB0",
+"k	c #7070A8","l	c #6D6DA5","m	c #6E6EA6","n	c #6969A2",
+"o	c #7A79AF","p	c #DCDCEC","q	c #60609A","r	c #7777AC",
+"s	c #5D5D98","t	c #7676AB","u	c #484785","v	c #575793",
+"w	c #50506A","x	c #8787B8","y	c #53536E","z	c #07070E",
+"A	c #666688",
+"        .       ",
+"       .+.      ",
+"      .+@#.     ",
+"     .$%###.    ",
+"    .&*####=.   ",
+"   .-.#;#####.  ",
+"  .>,'.#)!!!!~. ",
+" .{].'^./(!_:<[.",
+".}|.1./2.3456789",
+"0a.$11.bc.defg9 ",
+" 011h11.ij9kl9  ",
+"  0_1h1h.mno9   ",
+"   0p12h9qr9    ",
+"    0hh9st9     ",
+"     09uv9w     ",
+"      0x9y      ",
+"       zA       "};
+
+const char *empty_xpm[] = {  // provides same height than "smallsave_xpm"
+"1 17 1 1", "  c None", " ", " ", " ", " ", " ",
+" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "};
+
 
 
 // IconView without dragging icon bitmap

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -189,8 +189,9 @@ QucsApp::QucsApp()
   SearchDia = new SearchDialog(this);
 
   // creates a document called "untitled"
-  // it configures itself and get appended to App->DocumentTab
-  new Schematic(this, "");
+  Schematic *d = new Schematic(this, "");
+  int i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
+  DocumentTab->setCurrentIndex(i);
 
   select->setChecked(true);  // switch on the 'select' action
   switchSchematicDoc(true);  // "untitled" document is schematic
@@ -1386,7 +1387,10 @@ void QucsApp::openProject(const QString& Path)
   Name.remove("_prj");
 
   if(!closeAllFiles()) return;   // close files and ask for saving them
-  new Schematic(this, "");
+  Schematic *d = new Schematic(this, "");
+  i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
+  DocumentTab->setCurrentIndex(i);
+
   view->drawn = false;
 
   slotResetWarnings();
@@ -1456,7 +1460,9 @@ void QucsApp::slotMenuProjClose()
   editText->setHidden(true); // disable text edit of component property
 
   if(!closeAllFiles()) return;   // close files and ask for saving them
-  new Schematic(this, "");
+  Schematic *d = new Schematic(this, "");
+  int i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
+  DocumentTab->setCurrentIndex(i);
   view->drawn = false;
 
   slotResetWarnings();
@@ -1579,7 +1585,9 @@ void QucsApp::slotFileNew()
   statusBar()->message(tr("Creating new schematic..."));
   editText->setHidden(true); // disable text edit of component property
 
-  new Schematic(this, "");
+  Schematic *d = new Schematic(this, "");
+  int i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
+  DocumentTab->setCurrentIndex(i);
 
   statusBar()->message(tr("Ready."));
 }
@@ -1589,7 +1597,9 @@ void QucsApp::slotTextNew()
 {
   statusBar()->message(tr("Creating new text editor..."));
   editText->setHidden(true); // disable text edit of component property
-  new TextDoc(this, "");
+  TextDoc *d = new TextDoc(this, "");
+  int i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
+  DocumentTab->setCurrentIndex(i);
 
   statusBar()->message(tr("Ready."));
 }
@@ -1612,10 +1622,15 @@ bool QucsApp::gotoPage(const QString& Name)
 
   QFileInfo Info(Name);
   if(Info.extension(false) == "sch" || Info.extension(false) == "dpl" ||
-     Info.extension(false) == "sym")
+     Info.extension(false) == "sym") {
     d = new Schematic(this, Name);
-  else
+    i = DocumentTab->addTab((Schematic *)d, QPixmap(empty_xpm), Info.fileName()); 
+  }
+  else {
     d = new TextDoc(this, Name);
+    i = DocumentTab->addTab((TextDoc *)d, QPixmap(empty_xpm), Info.fileName());
+  }
+  DocumentTab->setCurrentIndex(i);
 
   if(!d->load()) {    // load document if possible
     delete d;
@@ -1909,8 +1924,11 @@ void QucsApp::closeFile(int index)
 
     delete Doc;
 
-    if(DocumentTab->count() < 1)  // if no document left, create an untitled
-      new Schematic(this, "");
+    if(DocumentTab->count() < 1) { // if no document left, create an untitled
+      Schematic *d = new Schematic(this, "");
+      DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled")); 
+      DocumentTab->setCurrentIndex(0);
+    }
 
     statusBar()->message(tr("Ready."));
 }
@@ -2412,11 +2430,18 @@ void QucsApp::slotChangePage(QString& DocName, QString& DataDisplay)
     DocumentTab->setCurrentPage(z);
   else {   // no open page found ?
     QString ext = QucsDoc::fileSuffix (DataDisplay);
+
+    int i = 0;
     if (ext != "vhd" && ext != "vhdl" && ext != "v" && ext != "va" &&
-	ext != "oct" && ext != "m")
-      d = new Schematic (this, Name);
-    else
-      d = new TextDoc (this, Name);
+	ext != "oct" && ext != "m") {
+      d = new Schematic(this, Name);
+      i = DocumentTab->addTab((Schematic *)d, QPixmap(empty_xpm), Info.fileName()); 
+    }
+    else {
+      d = new TextDoc(this, Name);
+      i = DocumentTab->addTab((TextDoc *)d, QPixmap(empty_xpm), Info.fileName());
+    }
+    DocumentTab->setCurrentIndex(i);
 
     QFile file(Name);
     if(file.open(QIODevice::ReadOnly)) {      // try to load document

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1463,6 +1463,7 @@ void QucsApp::slotMenuProjClose()
   Schematic *d = new Schematic(this, "");
   int i = DocumentTab->addTab(d, QPixmap(empty_xpm), QObject::tr("untitled"));
   DocumentTab->setCurrentIndex(i);
+
   view->drawn = false;
 
   slotResetWarnings();

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2965,6 +2965,14 @@ void QucsApp::slotHideEdit()
 }
 
 // -----------------------------------------------------------
+// set document tab icon to smallsave_xpm or empty_xpm
+void QucsApp::slotFileChanged(bool changed)
+{
+  DocumentTab->setTabIcon(DocumentTab->currentIndex(),
+      QPixmap((changed)? smallsave_xpm : empty_xpm));
+}
+
+// -----------------------------------------------------------
 // Searches the qucs path list for all schematic files and creates
 // a hash for lookup later
 void QucsApp::updateSchNameHash(void)

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -56,6 +56,9 @@ typedef bool (Schematic::*pToggleFunc) ();
 typedef void (MouseActions::*pMouseFunc) (Schematic*, QMouseEvent*);
 typedef void (MouseActions::*pMouseFunc2) (Schematic*, QMouseEvent*, float, float);
 
+extern const char *smallsave_xpm[];// icon for unsaved files (diskette)
+extern const char *empty_xpm[];    // provides same height than "smallsave_xpm"
+
 class QucsApp : public QMainWindow {
   Q_OBJECT
 public:

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -56,9 +56,6 @@ typedef bool (Schematic::*pToggleFunc) ();
 typedef void (MouseActions::*pMouseFunc) (Schematic*, QMouseEvent*);
 typedef void (MouseActions::*pMouseFunc2) (Schematic*, QMouseEvent*, float, float);
 
-extern const char *smallsave_xpm[];// icon for unsaved files (diskette)
-extern const char *empty_xpm[];    // provides same height than "smallsave_xpm"
-
 class QucsApp : public QMainWindow {
   Q_OBJECT
 public:
@@ -155,6 +152,7 @@ private slots:
   void slotChangePage(QString&, QString&);
   void slotNextTab();
   void slotHideEdit();
+  void slotFileChanged(bool);
 signals:
   void signalKillEmAll();
 

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -244,6 +244,8 @@ public slots:
   void slotShowWarnings();
   void slotResetWarnings();
   void printCursorPosition(int, int);
+  void slotUpdateUndo(bool);  // update undo available state
+  void slotUpdateRedo(bool);  // update redo available state
 
 private slots:
   void slotViewToolBar(bool toggle);    // toggle the toolbar

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -990,6 +990,20 @@ void QucsApp::printCursorPosition(int x, int y)
   PositionLabel->setMinimumWidth(PositionLabel->width());
 }
 
+// --------------------------------------------------------------
+// called by document, update undo state
+void QucsApp::slotUpdateUndo(bool isEnabled)
+{
+  undo->setEnabled(isEnabled);
+}
+
+// --------------------------------------------------------------
+// called by document, update redo state
+void QucsApp::slotUpdateRedo(bool isEnabled)
+{
+  redo->setEnabled(isEnabled);
+}
+
 // ----------------------------------------------------------
 // turn Toolbar on or off
 void QucsApp::slotViewToolBar(bool toggle)

--- a/qucs/qucs/qucsdoc.cpp
+++ b/qucs/qucs/qucsdoc.cpp
@@ -20,48 +20,6 @@
 #include "qucsdoc.h"
 #include "qucs.h"
 
-// icon for unsaved files (diskette)
-const char *smallsave_xpm[] = {
-"16 17 66 1", " 	c None",
-".	c #595963","+	c #E6E6F1","@	c #465460","#	c #FEFEFF",
-"$	c #DEDEEE","%	c #43535F","&	c #D1D1E6","*	c #5E5E66",
-"=	c #FFFFFF","-	c #C5C5DF",";	c #FCF8F9",">	c #BDBDDA",
-",	c #BFBFDC","'	c #C4C4DF",")	c #FBF7F7","!	c #D6D6E9",
-"~	c #CBCBE3","{	c #B5B5D6","]	c #BCBCDA","^	c #C6C6E0",
-"/	c #CFCFE5","(	c #CEC9DC","_	c #D8D8EA",":	c #DADAEB",
-"<	c #313134","[	c #807FB3","}	c #AEAED1","|	c #B7B7D7",
-"1	c #E2E2EF","2	c #9393C0","3	c #E3E3F0","4	c #DDD5E1",
-"5	c #E8E8F3","6	c #2F2F31","7	c #7B7BAF","8	c #8383B5",
-"9	c #151518","0	c #000000","a	c #C0C0DC","b	c #8E8FBD",
-"c	c #8989BA","d	c #E7EEF6","e	c #282829","f	c #6867A1",
-"g	c #7373A9","h	c #A7A7CD","i	c #8080B3","j	c #7B7CB0",
-"k	c #7070A8","l	c #6D6DA5","m	c #6E6EA6","n	c #6969A2",
-"o	c #7A79AF","p	c #DCDCEC","q	c #60609A","r	c #7777AC",
-"s	c #5D5D98","t	c #7676AB","u	c #484785","v	c #575793",
-"w	c #50506A","x	c #8787B8","y	c #53536E","z	c #07070E",
-"A	c #666688",
-"        .       ",
-"       .+.      ",
-"      .+@#.     ",
-"     .$%###.    ",
-"    .&*####=.   ",
-"   .-.#;#####.  ",
-"  .>,'.#)!!!!~. ",
-" .{].'^./(!_:<[.",
-".}|.1./2.3456789",
-"0a.$11.bc.defg9 ",
-" 011h11.ij9kl9  ",
-"  0_1h1h.mno9   ",
-"   0p12h9qr9    ",
-"    0hh9st9     ",
-"     09uv9w     ",
-"      0x9y      ",
-"       zA       "};
-
-const char *empty_xpm[] = {  // provides same height than "smallsave_xpm"
-"1 17 1 1", "  c None", " ", " ", " ", " ", " ",
-" ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " ", " "};
-
 
 QucsDoc::QucsDoc(QucsApp *App_, const QString& Name_)
 {

--- a/qucs/qucs/qucsdoc.h
+++ b/qucs/qucs/qucsdoc.h
@@ -25,10 +25,6 @@ class QucsApp;
 class QPrinter;
 class QPainter;
 
-extern const char *smallsave_xpm[];// icon for unsaved files (diskette)
-extern const char *empty_xpm[];    // provides same height than "smallsave_xpm"
-
-
 class QucsDoc {
 public: 
   QucsDoc(QucsApp*, const QString&);

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -108,13 +108,15 @@ Schematic::Schematic(QucsApp *App_, const QString& Name_)
 
   // to repair some strange  scrolling artefacts
   connect(this, SIGNAL(horizontalSliderReleased()),
-  viewport(), SLOT(update()));
+      viewport(), SLOT(update()));
   connect(this, SIGNAL(verticalSliderReleased()),
-  viewport(), SLOT(update()));
-
-  // to prevent user from editing something that he doesn't see
-  // connect(this, SIGNAL(horizontalSliderPressed()), App, SLOT(slotHideEdit()));
-  // connect(this, SIGNAL(verticalSliderPressed()), App, SLOT(slotHideEdit()));
+      viewport(), SLOT(update()));
+  if (App_) {
+    connect(this, SIGNAL(horizontalSliderPressed()), 
+        App_, SLOT(slotHideEdit()));
+    connect(this, SIGNAL(verticalSliderPressed()),
+        App_, SLOT(slotHideEdit()));
+  }
 }
 
 Schematic::~Schematic()

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -121,10 +121,6 @@ Schematic::Schematic(QucsApp *App_, const QString& Name_)
 
 Schematic::~Schematic()
 {
-  if(App) {
-    App->editText->setParent(App, 0); // reparent QLineEdit instance used for changing component properties
-    App->DocumentTab->removeTab(App->DocumentTab->indexOf(this));  // delete tab in TabBar
-  }
 }
 
 // ---------------------------------------------------

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -112,6 +112,8 @@ Schematic::Schematic(QucsApp *App_, const QString& Name_)
   connect(this, SIGNAL(verticalSliderReleased()),
       viewport(), SLOT(update()));
   if (App_) {
+    connect(this, SIGNAL(signalCursorPosChanged(int, int)), 
+        App_, SLOT(printCursorPosition(int, int)));
     connect(this, SIGNAL(horizontalSliderPressed()), 
         App_, SLOT(slotHideEdit()));
     connect(this, SIGNAL(verticalSliderPressed()),
@@ -165,7 +167,8 @@ bool Schematic::createSubcircuitSymbol()
 // ---------------------------------------------------
 void Schematic::becomeCurrent(bool update)
 {
-  App->printCursorPosition(0, 0);
+  QString *ps;
+  emit signalCursorPosChanged(0, 0);
 
   // update appropriate menu entry
   if (symbolMode) {
@@ -515,7 +518,7 @@ void Schematic::PostPaintEvent (PE pe, int x1, int y1, int x2, int y2, int a, in
 // ---------------------------------------------------
 void Schematic::contentsMouseMoveEvent(QMouseEvent *Event)
 {
-  App->printCursorPosition(Event->pos().x(), Event->pos().y());
+  emit signalCursorPosChanged(Event->pos().x(), Event->pos().y());
   if(App->MouseMoveAction)
     (App->view->*(App->MouseMoveAction))(this, Event);
 }

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -122,6 +122,8 @@ Schematic::Schematic(QucsApp *App_, const QString& Name_)
         App_, SLOT(slotUpdateUndo(bool)));
     connect(this, SIGNAL(signalRedoState(bool)),
         App_, SLOT(slotUpdateRedo(bool)));
+    connect(this, SIGNAL(signalFileChanged(bool)),
+        App_, SLOT(slotFileChanged(bool)));
   }
 }
 
@@ -245,9 +247,9 @@ void Schematic::setName (const QString& Name_)
 void Schematic::setChanged(bool c, bool fillStack, char Op)
 {
   if((!DocChanged) && c)
-    App->DocumentTab->setTabIcon(App->DocumentTab->indexOf(this), QPixmap(smallsave_xpm));
+    emit signalFileChanged(true);
   else if(DocChanged && (!c))
-    App->DocumentTab->setTabIcon(App->DocumentTab->indexOf(this), QPixmap(empty_xpm));
+    emit signalFileChanged(false);
   DocChanged = c;
 
   showBias = -1;   // schematic changed => bias points may be invalid

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -93,56 +93,28 @@ Schematic::Schematic(QucsApp *App_, const QString& Name_)
 
   isVerilog = false;
   creatingLib = false;
-  FileInfo = QFileInfo (Name_);
-  if(App) {
-    if(Name_.isEmpty())
-      App->DocumentTab->addTab(this, QPixmap(empty_xpm),
-                            QObject::tr("untitled"));
-    else
-      App->DocumentTab->addTab(this, QPixmap(empty_xpm),
-                            FileInfo.fileName());
 
-    // calls indirectly "becomeCurrent"
-    App->DocumentTab->setCurrentIndex(App->DocumentTab->indexOf(this));
+  showFrame = 0;  // don't show
+  Frame_Text0 = tr("Title");
+  Frame_Text1 = tr("Drawn By:");
+  Frame_Text2 = tr("Date:");
+  Frame_Text3 = tr("Revision:");
 
-    showFrame = 0;  // don't show
-    Frame_Text0 = tr("Title");
-    Frame_Text1 = tr("Drawn By:");
-    Frame_Text2 = tr("Date:");
-    Frame_Text3 = tr("Revision:");
+  setVScrollBarMode(Q3ScrollView::AlwaysOn);
+  setHScrollBarMode(Q3ScrollView::AlwaysOn);
+  viewport()->setPaletteBackgroundColor(QucsSettings.BGColor);
+  viewport()->setMouseTracking(true);
+  viewport()->setAcceptDrops(true);  // enable drag'n drop
 
-    setVScrollBarMode(Q3ScrollView::AlwaysOn);
-    setHScrollBarMode(Q3ScrollView::AlwaysOn);
-    //viewport()->setPaletteBackgroundColor(QucsSettings.BGColor);
+  // to repair some strange  scrolling artefacts
+  connect(this, SIGNAL(horizontalSliderReleased()),
+  viewport(), SLOT(update()));
+  connect(this, SIGNAL(verticalSliderReleased()),
+  viewport(), SLOT(update()));
 
-    QPalette p = palette(); 
-    p.setColor(viewport()->backgroundRole(), QucsSettings.BGColor); 
-    viewport()->setPalette(p);
-
-    viewport()->setMouseTracking(true);
-    viewport()->setAcceptDrops(true);  // enable drag'n drop
-// FIXME #warning removed those signals, crashes on it...
-    /*connect(horizontalScrollBar(),
-		SIGNAL(prevLine()), SLOT(slotScrollLeft()));
-    connect(horizontalScrollBar(),
-		SIGNAL(nextLine()), SLOT(slotScrollRight()));
-    connect(verticalScrollBar(),
-		SIGNAL(prevLine()), SLOT(slotScrollUp()));
-    connect(verticalScrollBar(),
-		SIGNAL(nextLine()), SLOT(slotScrollDown()));*/
-
-    // ...........................................................
-
-    // to repair some strange  scrolling artefacts
-    connect(this, SIGNAL(horizontalSliderReleased()),
-		viewport(), SLOT(update()));
-    connect(this, SIGNAL(verticalSliderReleased()),
-		viewport(), SLOT(update()));
-
-    // to prevent user from editing something that he doesn't see
-    connect(this, SIGNAL(horizontalSliderPressed()), App, SLOT(slotHideEdit()));
-    connect(this, SIGNAL(verticalSliderPressed()), App, SLOT(slotHideEdit()));
-  } // of "if(App)"
+  // to prevent user from editing something that he doesn't see
+  // connect(this, SIGNAL(horizontalSliderPressed()), App, SLOT(slotHideEdit()));
+  // connect(this, SIGNAL(verticalSliderPressed()), App, SLOT(slotHideEdit()));
 }
 
 Schematic::~Schematic()
@@ -1344,6 +1316,9 @@ bool Schematic::load()
 
   // The undo stack of the circuit symbol is initialized when first
   // entering its edit mode.
+  
+  // have to call this to avoid crash at sizeOfAll
+  becomeCurrent(false);
 
   sizeOfAll(UsedX1, UsedY1, UsedX2, UsedY2);
   if(ViewX1 > UsedX1)  ViewX1 = UsedX1;

--- a/qucs/qucs/schematic.h
+++ b/qucs/qucs/schematic.h
@@ -148,6 +148,9 @@ public:
 
   QFileInfo getFileInfo (void) { return FileInfo; }
 
+signals:
+  void signalCursorPosChanged(int, int);
+
 protected:
   bool sizeOfFrame(int&, int&);
   void paintFrame(ViewPainter*);

--- a/qucs/qucs/schematic.h
+++ b/qucs/qucs/schematic.h
@@ -152,6 +152,7 @@ signals:
   void signalCursorPosChanged(int, int);
   void signalUndoState(bool);
   void signalRedoState(bool);
+  void signalFileChanged(bool);
 
 protected:
   bool sizeOfFrame(int&, int&);

--- a/qucs/qucs/schematic.h
+++ b/qucs/qucs/schematic.h
@@ -150,6 +150,8 @@ public:
 
 signals:
   void signalCursorPosChanged(int, int);
+  void signalUndoState(bool);
+  void signalRedoState(bool);
 
 protected:
   bool sizeOfFrame(int&, int&);

--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -57,32 +57,21 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
   Scale = (float)TextFont.pointSize();
   //TODO (not supported) setUndoDepth(QucsSettings.maxUndo);
   setLanguage (Name_);
-  QFileInfo Info (Name_);
 
-  if(App) {
-    if(Name_.isEmpty()) {
-      App->DocumentTab->addTab(this, QPixmap(empty_xpm), QObject::tr("untitled"));
-      }
-    else {
-      App->DocumentTab->addTab(this, QPixmap(empty_xpm), Info.fileName());
-    }
-    App->DocumentTab->setCurrentPage(App->DocumentTab->indexOf(this));
+  viewport()->setFocus();
 
-    viewport()->setFocus();
+  setWordWrapMode(QTextOption::NoWrap);
+  setPaletteBackgroundColor(QucsSettings.BGColor);
+  connect(this, SIGNAL(textChanged()), SLOT(slotSetChanged()));
+  connect(this, SIGNAL(cursorPositionChanged()),
+          SLOT(slotCursorPosChanged()));
 
-    setWordWrapMode(QTextOption::NoWrap);
-    setPaletteBackgroundColor(QucsSettings.BGColor);
-    connect(this, SIGNAL(textChanged()), SLOT(slotSetChanged()));
-    connect(this, SIGNAL(cursorPositionChanged()),
-            SLOT(slotCursorPosChanged()));
+  syntaxHighlight = new SyntaxHighlighter(this);
+  syntaxHighlight->setLanguage(language);
+  syntaxHighlight->setDocument(document());
 
-    syntaxHighlight = new SyntaxHighlighter(this);
-    syntaxHighlight->setLanguage(language);
-    syntaxHighlight->setDocument(document());
-
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
-    highlightCurrentLine();
-  }
+  connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
+  highlightCurrentLine();
 }
 
 /*!

--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -71,6 +71,8 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
         App_, SLOT(slotUpdateUndo(bool)));
     connect(this, SIGNAL(signalRedoState(bool)),
         App_, SLOT(slotUpdateRedo(bool)));
+    connect(this, SIGNAL(signalFileChanged(bool)),
+        App_, SLOT(slotFileChanged(bool)));
   }
 
   syntaxHighlight = new SyntaxHighlighter(this);
@@ -334,14 +336,12 @@ void TextDoc::slotCursorPosChanged()
 void TextDoc::slotSetChanged()
 {
   if((document()->isModified() && !DocChanged) || SetChanged) {
-    App->DocumentTab->setTabIconSet(this, QPixmap(smallsave_xpm));
     DocChanged = true;
   }
   else if((!document()->isModified() && DocChanged)) {
-    App->DocumentTab->setTabIconSet(this, QPixmap(empty_xpm));
     DocChanged = false;
   }
-
+  emit signalFileChanged(DocChanged);
   emit signalUndoState(document()->isUndoAvailable());
   emit signalRedoState(document()->isRedoAvailable());
 }

--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -65,6 +65,10 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
   connect(this, SIGNAL(textChanged()), SLOT(slotSetChanged()));
   connect(this, SIGNAL(cursorPositionChanged()),
           SLOT(slotCursorPosChanged()));
+  if (App_) {
+    connect(this, SIGNAL(signalCursorPosChanged(int, int)),
+        App_, SLOT(printCursorPosition(int, int)));
+  }
 
   syntaxHighlight = new SyntaxHighlighter(this);
   syntaxHighlight->setLanguage(language);
@@ -322,7 +326,7 @@ void TextDoc::slotCursorPosChanged()
   QTextCursor pos = textCursor();
   int x = pos.blockNumber();
   int y = pos.columnNumber();
-  App->printCursorPosition(x+1, y+1);
+  emit signalCursorPosChanged(x+1, y+1);
   tmpPosX = x;
   tmpPosY = y;
 }

--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -79,10 +79,7 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
  */
 TextDoc::~TextDoc()
 {
-  if(App) {
-    delete syntaxHighlight;
-    App->DocumentTab->removePage(this);  // delete tab in TabBar
-  }
+  delete syntaxHighlight;
 }
 
 /*!

--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -55,7 +55,6 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
 
   tmpPosX = tmpPosY = 1;  // set to 1 to trigger line highlighting
   Scale = (float)TextFont.pointSize();
-  //TODO (not supported) setUndoDepth(QucsSettings.maxUndo);
   setLanguage (Name_);
 
   viewport()->setFocus();
@@ -68,6 +67,10 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
   if (App_) {
     connect(this, SIGNAL(signalCursorPosChanged(int, int)),
         App_, SLOT(printCursorPosition(int, int)));
+    connect(this, SIGNAL(signalUndoState(bool)),
+        App_, SLOT(slotUpdateUndo(bool)));
+    connect(this, SIGNAL(signalRedoState(bool)),
+        App_, SLOT(slotUpdateRedo(bool)));
   }
 
   syntaxHighlight = new SyntaxHighlighter(this);
@@ -218,14 +221,8 @@ void TextDoc::becomeCurrent (bool)
   slotCursorPosChanged();
   viewport()->setFocus ();
 
-  if (document()->isUndoAvailable())
-    App->undo->setEnabled (true);
-  else
-    App->undo->setEnabled (false);
-  if (document()->isRedoAvailable ())
-    App->redo->setEnabled (true);
-  else
-    App->redo->setEnabled (false);
+  emit signalUndoState(document()->isUndoAvailable());
+  emit signalRedoState(document()->isRedoAvailable());
 
   // update appropriate menu entries
   App->symEdit->setMenuText (tr("Edit Text Symbol"));
@@ -345,8 +342,8 @@ void TextDoc::slotSetChanged()
     DocChanged = false;
   }
 
-  App->undo->setEnabled(document()->isUndoAvailable());
-  App->redo->setEnabled(document()->isRedoAvailable());
+  emit signalUndoState(document()->isUndoAvailable());
+  emit signalRedoState(document()->isRedoAvailable());
 }
 
 /*!

--- a/qucs/qucs/textdoc.h
+++ b/qucs/qucs/textdoc.h
@@ -31,9 +31,6 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
 class SyntaxHighlighter;
 class QString;
 
-extern const char *smallsave_xpm[];// icon for unsaved files (diskette)
-extern const char *empty_xpm[];    // provides same height than "smallsave_xpm"
-
 // device type flags
 #define DEV_BJT      0x0001
 #define DEV_MOS      0x0002
@@ -89,6 +86,7 @@ public:
 
 signals:
   void signalCursorPosChanged(int, int);
+  void signalFileChanged(bool);
   void signalUndoState(bool);
   void signalRedoState(bool);
 

--- a/qucs/qucs/textdoc.h
+++ b/qucs/qucs/textdoc.h
@@ -87,6 +87,9 @@ public:
 
   QMenu* createStandardContextMenu();
 
+signals:
+  void signalCursorPosChanged(int, int);
+
 public slots:
   void search(const QString &str, bool CaseSensitive, bool wordOnly, bool backward);
   void replace(const QString &str, const QString &str2, bool needConfirmed,

--- a/qucs/qucs/textdoc.h
+++ b/qucs/qucs/textdoc.h
@@ -89,6 +89,8 @@ public:
 
 signals:
   void signalCursorPosChanged(int, int);
+  void signalUndoState(bool);
+  void signalRedoState(bool);
 
 public slots:
   void search(const QString &str, bool CaseSensitive, bool wordOnly, bool backward);


### PR DESCRIPTION
This is some refactor work I did when I examine the code in `schematic.cpp`.
It's not a good habit just throw a pointer of main program in `schematic` and `textdoc`, this means that `schematic` and `textdoc` can do anything they want to mainwindow. 
In this PR, I change some of the `App` to slot in MainWindow, and connect the signal in doc class in constructor.