### PR TITLE
Refactor project view object 

### DIFF
--- a/qucs/qucs/CMakeLists.txt
+++ b/qucs/qucs/CMakeLists.txt
@@ -112,7 +112,7 @@ SET(QUCS_SRCS
   mouseactions.cpp qucs_actions.cpp	schematic_file.cpp
   wirelabel.cpp node.cpp qucs_init.cpp
   syntax.cpp misc.cpp messagedock.cpp
-  imagewriter.cpp printerwriter.cpp
+  imagewriter.cpp printerwriter.cpp projectView.cpp
 )
 
 SET(QUCS_HDRS

--- a/qucs/qucs/Makefile.am
+++ b/qucs/qucs/Makefile.am
@@ -39,7 +39,8 @@ qucs_SOURCES = node.cpp element.cpp qucsdoc.cpp wire.cpp mouseactions.cpp   \
   qucs.cpp main.cpp wirelabel.cpp qucs_init.cpp qucs_actions.cpp            \
   viewpainter.cpp mnemo.cpp schematic.cpp schematic_element.cpp textdoc.cpp \
   schematic_file.cpp syntax.cpp module.cpp octave_window.cpp qrc_qucs.cpp   \
-  messagedock.cpp misc.cpp imagewriter.cpp printerwriter.cpp
+  messagedock.cpp misc.cpp imagewriter.cpp printerwriter.cpp \
+	projectView.cpp
 
 qrc_qucs.cpp: qucs.qrc
 	$(RCC) -o $@ $<

--- a/qucs/qucs/dialogs/librarydialog.cpp
+++ b/qucs/qucs/dialogs/librarydialog.cpp
@@ -1,19 +1,25 @@
-/***************************************************************************
-                              librarydialog.cpp
-                             -------------------
-    begin                : Sun Jun 04 2006
-    copyright            : (C) 2006 by Michael Margraf
-    email                : michael.margraf@alumni.tu-berlin.de
- ***************************************************************************/
-
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+/*
+ * librarydialog.cpp - implementation of dialog to create library
+ *
+ * Copyright (C) 2006, Michael Margraf, michael.margraf@alumni.tu-berlin.de
+ * Copyright (C) 2014, Yodalee, lc85301@gmail.com
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>
@@ -36,18 +42,17 @@
 #include <QStackedWidget>
 #include <QGroupBox>
 #include <QDebug>
+#include <QStringList>
 
 #include "librarydialog.h"
-#include "qucs.h"
 #include "main.h"
 #include "schematic.h"
 
 extern SubMap FileList;
 
-LibraryDialog::LibraryDialog(QucsApp *App_, QTreeWidgetItem *SchematicList)
-			: QDialog(App_)
+LibraryDialog::LibraryDialog(QWidget *parent, QStringList SchematicList)
+			: QDialog(parent)
 {
-  App = App_;
   setWindowTitle(tr("Create Library"));
 
   Expr.setPattern("[\\w_]+");
@@ -207,16 +212,10 @@ LibraryDialog::LibraryDialog(QucsApp *App_, QTreeWidgetItem *SchematicList)
 
   // ...........................................................
   // insert all subcircuits of into checklist
-  QTreeWidgetItem *p ;
-  for(int i=0; i < SchematicList->childCount(); i++){
-    p = SchematicList->child(i);
-    if(p->parent() == 0)
-      break;
-    if(!p->text(1).isEmpty()){
-        QCheckBox *subCheck = new QCheckBox(p->text(0));
-        checkBoxLayout->addWidget(subCheck);
-        BoxList.append(subCheck);
-    }
+  foreach(const QString &filename, SchematicList) {
+    QCheckBox *subCheck = new QCheckBox(filename);
+    checkBoxLayout->addWidget(subCheck);
+    BoxList.append(subCheck);
   }
 
   if(BoxList.isEmpty()) {

--- a/qucs/qucs/dialogs/librarydialog.cpp
+++ b/qucs/qucs/dialogs/librarydialog.cpp
@@ -50,7 +50,7 @@
 
 extern SubMap FileList;
 
-LibraryDialog::LibraryDialog(QWidget *parent, QStringList SchematicList)
+LibraryDialog::LibraryDialog(QWidget *parent)
 			: QDialog(parent)
 {
   setWindowTitle(tr("Create Library"));
@@ -95,7 +95,7 @@ LibraryDialog::LibraryDialog(QWidget *parent, QStringList SchematicList)
 
   QWidget *scrollWidget = new QWidget();
 
-  QVBoxLayout *checkBoxLayout = new QVBoxLayout();
+  checkBoxLayout = new QVBoxLayout();
   scrollWidget->setLayout(checkBoxLayout);
   scrollArea->setWidget(scrollWidget);
 
@@ -209,20 +209,6 @@ LibraryDialog::LibraryDialog(QWidget *parent, QStringList SchematicList)
   hbox2->addWidget(close);
   connect(close, SIGNAL(clicked()), SLOT(reject()));
   msgLayout->addLayout(hbox2);
-
-  // ...........................................................
-  // insert all subcircuits of into checklist
-  foreach(const QString &filename, SchematicList) {
-    QCheckBox *subCheck = new QCheckBox(filename);
-    checkBoxLayout->addWidget(subCheck);
-    BoxList.append(subCheck);
-  }
-
-  if(BoxList.isEmpty()) {
-    ButtCreateNext->setEnabled(false);
-    QLabel *noProj = new QLabel(tr("No projects!"));
-    checkBoxLayout->addWidget(noProj);
-  }
 }
 
 
@@ -230,6 +216,24 @@ LibraryDialog::~LibraryDialog()
 {
   delete all;
   delete Validator;
+}
+
+void
+LibraryDialog::fillSchematicList(QStringList &SchematicList)
+{
+  // ...........................................................
+  // insert all subcircuits of into checklist
+  if (SchematicList.size() == 0) {
+    ButtCreateNext->setEnabled(false);
+    QLabel *noProj = new QLabel(tr("No projects!"));
+    checkBoxLayout->addWidget(noProj);
+  } else {
+    foreach(const QString &filename, SchematicList) {
+      QCheckBox *subCheck = new QCheckBox(filename);
+      checkBoxLayout->addWidget(subCheck);
+      BoxList.append(subCheck);
+    }
+  }
 }
 
 // ---------------------------------------------------------------

--- a/qucs/qucs/dialogs/librarydialog.cpp
+++ b/qucs/qucs/dialogs/librarydialog.cpp
@@ -219,7 +219,7 @@ LibraryDialog::~LibraryDialog()
 }
 
 void
-LibraryDialog::fillSchematicList(QStringList &SchematicList)
+LibraryDialog::fillSchematicList(QStringList SchematicList)
 {
   // ...........................................................
   // insert all subcircuits of into checklist

--- a/qucs/qucs/dialogs/librarydialog.h
+++ b/qucs/qucs/dialogs/librarydialog.h
@@ -55,7 +55,7 @@ public:
   LibraryDialog(QWidget *);
  ~LibraryDialog();
 
-  void fillSchematicList(QStringList &);
+  void fillSchematicList(QStringList);
 
 private slots:
   void slotCreateNext();

--- a/qucs/qucs/dialogs/librarydialog.h
+++ b/qucs/qucs/dialogs/librarydialog.h
@@ -1,19 +1,25 @@
-/***************************************************************************
-                             librarydialog.h
-                            -----------------
-    begin                : Sun Jun 04 2006
-    copyright            : (C) 2006 by Michael Margraf
-    email                : michael.margraf@alumni.tu-berlin.de
- ***************************************************************************/
-
-/***************************************************************************
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+/*
+ * librarydialog.h - declaration of dialog to create library
+ *
+ * Copyright (C) 2006, Michael Margraf, michael.margraf@alumni.tu-berlin.de
+ * Copyright (C) 2014, Yodalee, lc85301@gmail.com
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef LIBRARYDIALOG_H
 #define LIBRARYDIALOG_H
@@ -32,7 +38,6 @@
 #include <QStackedWidget>
 
 class QLabel;
-class QucsApp;
 class QLineEdit;
 class QTextEdit;
 class QPushButton;
@@ -41,12 +46,13 @@ class QTreeWidgetItem;
 class QGroupBox;
 class QRegExpValidator;
 class QStackedWidget;
+class QStringList;
 
 
 class LibraryDialog : public QDialog {
    Q_OBJECT
 public:
-  LibraryDialog(QucsApp*, QTreeWidgetItem*);
+  LibraryDialog(QWidget *, QStringList);
  ~LibraryDialog();
 
 private slots:
@@ -82,7 +88,6 @@ private:
   QStringList Descriptions;
   QCheckBox *checkDescr;
 
-  QucsApp *App;
   QFile LibFile;
   QDir LibDir;
   QRegExp Expr;

--- a/qucs/qucs/dialogs/librarydialog.h
+++ b/qucs/qucs/dialogs/librarydialog.h
@@ -52,8 +52,10 @@ class QStringList;
 class LibraryDialog : public QDialog {
    Q_OBJECT
 public:
-  LibraryDialog(QWidget *, QStringList);
+  LibraryDialog(QWidget *);
  ~LibraryDialog();
+
+  void fillSchematicList(QStringList &);
 
 private slots:
   void slotCreateNext();
@@ -72,6 +74,7 @@ private:
 private:
   int curDescr;
   QVBoxLayout *all;   // the mother of all widgets
+  QVBoxLayout *checkBoxLayout;
   QStackedWidget *stackedWidgets;
   QLabel *theLabel;
   QLabel *checkedCktName;

--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -594,7 +594,7 @@ void QucsSettingsDialog::slotApply()
     if(changed)
     {
         App->readProjects();
-        App->readProjectFiles();
+        App->slotUpdateTreeview();
         App->repaint();
     }
 

--- a/qucs/qucs/dialogs/searchdialog.cpp
+++ b/qucs/qucs/dialogs/searchdialog.cpp
@@ -1,5 +1,5 @@
 /*
- * searchdialog.h - implementation of search dialog
+ * searchdialog.cpp - implementation of search dialog
  *
  * Copyright (C) 2006, Michael Margraf, michael.margraf@alumni.tu-berlin.de
  * Copyright (C) 2014, Yodalee, lc85301@gmail.com

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -1,0 +1,167 @@
+/*
+ * ProjectView.cpp - implementation of project model
+ *   the model manage the files in project directory
+ *
+ * Copyright (C) 2014, Yodalee, lc85301@gmail.com
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "projectView.h"
+#include "schematic.h"
+
+#include <QString>
+#include <QList>
+#include <QDir>
+#include <QStandardItem>
+#include <QStandardItemModel>
+
+ProjectView::ProjectView(QWidget *parent)
+  : QTreeView(parent)
+{
+  m_projPath = QString();
+  m_projPath = QString();
+  m_valid = false;
+  m_model = new QStandardItemModel(8, 2);
+
+  refresh();
+
+  this->setModel(m_model);
+}
+
+ProjectView::~ProjectView()
+{
+  delete m_model;
+}
+
+void
+ProjectView::setProjPath(const QString &path)
+{
+  m_valid = QDir(path).exists();
+
+  if (m_valid) {
+    //test path exist
+    m_projPath = path;
+    m_projName = path;
+
+    // cut off trailing '/'
+    if (m_projName.endsWith(QDir::separator())) {
+      m_projName.chop(1);
+    }
+    int i = m_projName.lastIndexOf(QDir::separator());
+    if(i > 0) {
+      m_projName = m_projName.mid(i+1);   // cut out the last subdirectory
+    }
+    m_projName.remove("_prj");
+
+    refresh();
+  }
+}
+
+// refresh using projectPath
+void
+ProjectView::refresh()
+{
+  QStringList header;
+  header << tr("Content of %1").arg(m_projName) << tr("Note");
+  m_model->setHorizontalHeaderLabels(header);
+
+  m_model->clear();
+
+  APPEND_ROW(m_model, FILETYPE1);
+  APPEND_ROW(m_model, FILETYPE2);
+  APPEND_ROW(m_model, FILETYPE3);
+  APPEND_ROW(m_model, FILETYPE4);
+  APPEND_ROW(m_model, FILETYPE5);
+  APPEND_ROW(m_model, FILETYPE6);
+  APPEND_ROW(m_model, FILETYPE7);
+  APPEND_ROW(m_model, FILETYPE8);
+
+  if (!m_valid) {
+    return;
+  }
+  
+//  QList<QVariant> data;
+//
+//  data << tr("Content of %1").arg(m_projName) << tr("Note");
+//  rootItem = new ProjectItem(data);
+//#define appendCategory(content) \
+//  ({ data.clear(); \
+//     data << content << ""; \
+//     rootItem->appendChild(new ProjectItem(data, rootItem)); \
+//  })
+//  appendCategory(FILETYPE1);
+//  appendCategory(FILETYPE2);
+//  appendCategory(FILETYPE3);
+//  appendCategory(FILETYPE4);
+//  appendCategory(FILETYPE5);
+//  appendCategory(FILETYPE6);
+//  appendCategory(FILETYPE7);
+//  appendCategory(FILETYPE8);
+//#undef appendCategory
+//
+//  int n;
+//  // put all files into "Content"-ListView
+//  QDir workPath(m_projPath);
+//  QStringList files = workPath.entryList("*", QDir::Files, QDir::Name);
+//  QStringList::iterator it;
+//  QString extName, fileName;
+//
+//#define appendFile(category) \
+//  ({ rootItem->child(category)->appendChild(new ProjectItem(columnData, rootItem->child(category))); })
+//
+//  for(it = files.begin(); it != files.end(); ++it) {
+//    fileName = (*it).toAscii();
+//    extName = QFileInfo(workPath.filePath(fileName)).completeSuffix();
+//    QList<QVariant> columnData;
+//    columnData << fileName;
+//
+//    if(extName == "dat") {
+//      appendFile(0);
+//    }
+//    else if(extName == "dpl") {
+//      appendFile(1);
+//    }
+//    else if(extName == "v") {
+//      appendFile(2);
+//    }
+//    else if(extName == "va") {
+//      appendFile(3);
+//    }
+//    else if((extName == "vhdl") || (extName == "vhd")) {
+//      appendFile(4);
+//    }
+//    else if((extName == "m") || (extName == "oct")) {
+//      appendFile(5);
+//    }
+//    else if(extName == "sch") {
+//      n = Schematic::testFile(workPath.filePath(fileName));
+//      if(n >= 0) {
+//        if(n > 0) {
+//          columnData << QString::number(n)+tr("-port");
+//        }
+//      }
+//      appendFile(6);
+//    }
+//    else {
+//      appendFile(7);
+//    }
+//  }
+//
+//#undef appendFile
+//  reset();
+}

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -25,6 +25,7 @@
 #include "schematic.h"
 
 #include <QString>
+#include <QStringList>
 #include <QDir>
 #include <QStandardItemModel>
 
@@ -146,4 +147,17 @@ ProjectView::refresh()
   }
 
   resizeColumnToContents(0);
+}
+
+QStringList
+ProjectView::exportSchematic()
+{
+  QStringList list;
+  QStandardItem *item = m_model->item(6, 0);
+  for (int i = 0; i < item->rowCount(); ++i) {
+    if (item->child(i,1)) {
+      list.append(item->child(i,0)->text());
+    }
+  }
+  return list;
 }

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -51,7 +51,7 @@ ProjectView::~ProjectView()
 void
 ProjectView::setProjPath(const QString &path)
 {
-  m_valid = QDir(path).exists();
+  m_valid = !path.isEmpty() && QDir(path).exists();
 
   if (m_valid) {
     //test path exist
@@ -67,9 +67,8 @@ ProjectView::setProjPath(const QString &path)
       m_projName = m_projName.mid(i+1);   // cut out the last subdirectory
     }
     m_projName.remove("_prj");
-
-    refresh();
   }
+  refresh();
 }
 
 // refresh using projectPath

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -1,0 +1,67 @@
+/*
+ * projectView.h - declaration of project view
+ *   and the model that manage files in project
+ *
+ * Copyright (C) 2014, Yodalee, lc85301@gmail.com
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PROJECTVIEW_H_
+#define PROJECTVIEW_H_ value
+
+#include <QTreeView>
+#include <QString>
+
+#define FILETYPE1 tr("Datasets")
+#define FILETYPE2 tr("Data Displays")
+#define FILETYPE3 tr("Verilog")
+#define FILETYPE4 tr("Verilog-A")
+#define FILETYPE5 tr("VHDL")
+#define FILETYPE6 tr("Octave")
+#define FILETYPE7 tr("Schematics")
+#define FILETYPE8 tr("Others")
+
+#define APPEND_ROW(parent, data) \
+({ \
+  QList<QStandardItem*> c; \
+  c.append(new QStandardItem(data)); \
+  parent->appendRow(c); \
+})
+
+class QStandardItemModel;
+
+class ProjectView : public QTreeView
+{
+public:
+  ProjectView (QWidget *parent);
+  virtual ~ProjectView ();
+
+  QStandardItemModel *model() { return m_model; };
+
+  //data related
+  void setProjPath(const QString &);
+  void refresh();
+private:
+  QStandardItemModel *m_model;
+
+  bool m_valid;
+  QString m_projPath;
+  QString m_projName;
+};
+
+#endif /* PROJECTVIEW_H_ */

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -56,6 +56,7 @@ public:
   //data related
   void setProjPath(const QString &);
   void refresh();
+  QStringList exportSchematic();
 private:
   QStandardItemModel *m_model;
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -51,6 +51,7 @@
 #include "messagedock.h"
 #include "wire.h"
 #include "module.h"
+#include "projectView.h"
 #include "components/components.h"
 #include "paintings/paintings.h"
 #include "diagrams/diagrams.h"
@@ -315,6 +316,12 @@ void QucsApp::initView()
 
   connect(Content, SIGNAL(itemPressed(QTreeWidgetItem*, int)),
            SLOT(slotSelectSubcircuit(QTreeWidgetItem*)));
+
+  // ----------------------------------------------------------
+  // "Content_new" Tab of the left QTabWidget
+  Content_new = new ProjectView(this);
+  TabView->addTab(Content_new, tr("Content_new"));
+  TabView->setTabToolTip(TabView->indexOf(Content_new), tr("content of current project"));
 
   // ----------------------------------------------------------
   // "Component" Tab of the left QTabWidget

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1323,6 +1323,8 @@ void QucsApp::readProjectFiles()
       temp->setText(0, (*it).ascii());
     }
   }
+
+  Content_new->refresh();
 }
 
 // ----------------------------------------------------------
@@ -1360,6 +1362,8 @@ void QucsApp::openProject(const QString& Path)
   QStringList headers;
   headers << tr("Content of ") + Name << tr("Note");
   Content->setHeaderLabels(headers);
+
+  Content_new->setProjPath(QucsSettings.QucsWorkDir.absolutePath());
 
   readProjectFiles();
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1463,8 +1463,6 @@ void QucsApp::openProject(const QString& Path)
   headers << tr("Content of ") + Name << tr("Note");
   Content->setHeaderLabels(headers);
 
-  Content_new->setProjPath(QucsSettings.QucsWorkDir.absolutePath());
-
   readProjectFiles();
 
   TabView->setCurrentPage(1);   // switch to "Content"-Tab

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -193,10 +193,6 @@ QucsApp::~QucsApp()
 // ##########     Creates the working area (QTabWidget etc.)    ##########
 // ##########                                                   ##########
 // #######################################################################
-void QucsApp::initContentListView()
-{
-}
-
 /**
  * @brief QucsApp::initView Setup the layour of all widgets
  */
@@ -1127,17 +1123,6 @@ void QucsApp::slotButtonProjNew()
 }
 
 // ----------------------------------------------------------
-// Reads all files in the project directory and sort them into the
-// content ListView
-void QucsApp::readProjectFiles()
-{
-  //Is this OK instead of the above??
-  initContentListView();
-
-  slotUpdateTreeview();
-}
-
-// ----------------------------------------------------------
 // Opens an existing project.
 void QucsApp::openProject(const QString& Path)
 {
@@ -1170,9 +1155,6 @@ void QucsApp::openProject(const QString& Path)
   octave->adjustDirectory();
 
   Content->setProjPath(QucsSettings.QucsWorkDir.absolutePath());
-
-  QStringList headers;
-  readProjectFiles();
 
   TabView->setCurrentPage(1);   // switch to "Content"-Tab
   ProjName = Name;   // remember the name of project
@@ -1235,8 +1217,7 @@ void QucsApp::slotMenuProjClose()
   QucsSettings.QucsWorkDir.setPath(QDir::homeDirPath()+QDir::convertSeparators ("/.qucs"));
   octave->adjustDirectory();
 
-  QStringList headers;
-  initContentListView();
+  Content->setProjPath("");
 
   TabView->setCurrentPage(0);   // switch to "Projects"-Tab
   ProjName = "";
@@ -1470,7 +1451,7 @@ void QucsApp::slotFileSave()
   statusBar()->message(tr("Ready."));
 
   if(!ProjName.isEmpty())
-    readProjectFiles();  // re-read the content ListView
+    slotUpdateTreeview();
 }
 
 // --------------------------------------------------------------
@@ -1582,7 +1563,7 @@ void QucsApp::slotFileSaveAs()
   slotRefreshSchPath();
 
   if(!ProjName.isEmpty())
-    readProjectFiles();  // re-read the content ListView
+    slotUpdateTreeview();
 }
 
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1234,7 +1234,7 @@ void QucsApp::slotCMenuCopy_new()
     this->updateSchNameHash();
     this->updateSpiceNameHash();
 
-    Content_new->refresh();
+    slotUpdateTreeview();
   }
 }
 
@@ -1274,7 +1274,7 @@ void QucsApp::slotCMenuRename_new()
       return;
     }
 
-    Content_new->refresh();
+    slotUpdateTreeview();
   }
 }
 
@@ -1305,7 +1305,7 @@ void QucsApp::slotCMenuDelete_new()
     }
   }
 
-  Content_new->refresh();
+  slotUpdateTreeview();
 }
 
 void QucsApp::slotCMenuInsert_new()
@@ -1422,7 +1422,7 @@ void QucsApp::readProjectFiles()
     }
   }
 
-  Content_new->refresh();
+  slotUpdateTreeview();
 }
 
 // ----------------------------------------------------------
@@ -1744,7 +1744,7 @@ bool QucsApp::saveFile(QucsDoc *Doc)
   if(Result < 0)  return false;
 
   updatePortNumber(Doc, Result);
-  Content_new->refresh();
+  slotUpdateTreeview();
   return true;
 }
 
@@ -1853,7 +1853,7 @@ bool QucsApp::saveAs()
   if(n < 0)  return false;
 
   updatePortNumber(Doc, n);
-  Content_new->refresh();
+  slotUpdateTreeview();
   return true;
 }
 
@@ -1909,6 +1909,7 @@ void QucsApp::slotFileSaveAll()
 
   // refresh the schematic file path
   slotRefreshSchPath();
+  slotUpdateTreeview();
 }
 
 // --------------------------------------------------------------
@@ -2467,10 +2468,8 @@ void QucsApp::slotChangePage(QString& DocName, QString& DataDisplay)
     }
     else {
       if(file.open(QIODevice::ReadWrite)) {  // if document doesn't exist, create
-        //TODO RECHECK!! new Q3ListViewItem(ConDisplays, DataDisplay); // add new name
-        QTreeWidgetItem *temp = new QTreeWidgetItem(ConDisplays);
-        temp->setText(0,DataDisplay);
         d->DataDisplay = Info.fileName();
+        slotUpdateTreeview();
       }
       else {
         QMessageBox::critical(this, tr("Error"), tr("Cannot create ")+Name);
@@ -3111,6 +3110,14 @@ void QucsApp::slotFileChanged(bool changed)
 {
   DocumentTab->setTabIcon(DocumentTab->currentIndex(),
       QPixmap((changed)? smallsave_xpm : empty_xpm));
+}
+
+// -----------------------------------------------------------
+// Update project view by call refresh function
+// looses the focus.
+void QucsApp::slotUpdateTreeview()
+{
+  Content_new->refresh();
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -137,6 +137,7 @@ private slots:
   void slotMenuProjDel();
   void slotListProjOpen(const QModelIndex &);
   void slotSelectSubcircuit(QTreeWidgetItem*);
+  void slotSelectSubcircuit_new(const QModelIndex &);
   void slotSelectLibComponent(QTreeWidgetItem*);
   void slotOpenContent(QTreeWidgetItem*);
   void slotOpenContent_new(const QModelIndex &);

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -139,6 +139,7 @@ private slots:
   void slotSelectSubcircuit(QTreeWidgetItem*);
   void slotSelectLibComponent(QTreeWidgetItem*);
   void slotOpenContent(QTreeWidgetItem*);
+  void slotOpenContent_new(const QModelIndex &);
   void slotSetCompView(int);
   void slotButtonProjNew();
   void slotButtonProjOpen();

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -124,12 +124,18 @@ public slots:
 
   // for menu that appears by right click in content ListView
   void slotShowContentMenu(const QPoint &);
+  void slotShowContentMenu_new(const QPoint &);
   void slotCMenuOpen();
   void slotCMenuCopy();
   void slotCMenuRename();
   void slotCMenuDelete();
-  void slotCMenuDelGroup();
   void slotCMenuInsert();
+
+  void slotCMenuOpen_new();
+  void slotCMenuCopy_new();
+  void slotCMenuRename_new();
+  void slotCMenuDelete_new();
+  void slotCMenuInsert_new();
 
 private slots:
   void slotMenuProjOpen();
@@ -163,9 +169,12 @@ public:
 
   // menu appearing by right mouse button click on content listview
   QMenu *ContentMenu;
+  QMenu *ContentMenu_new;
 
   // corresponding actions
-  QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuDelGroup, *ActionCMenuInsert;
+  QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuInsert;
+
+  QAction *ActionCMenuOpen_new, *ActionCMenuCopy_new, *ActionCMenuRename_new, *ActionCMenuDelete_new, *ActionCMenuInsert_new;
 
   QAction *fileNew, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
           *fileSaveAll, *fileClose, *fileExamples, *fileSettings, *filePrint, *fileQuit,

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -30,6 +30,7 @@ class MouseActions;
 class SearchDialog;
 class OctaveWindow;
 class MessageDock;
+class ProjectView;
 
 class QLabel;
 class QAction;
@@ -184,6 +185,7 @@ private:
 
   QListView       *Projects;
   QTreeWidget     *Content;
+  ProjectView     *Content_new;
   QTreeWidgetItem *ConSchematics, *ConSources, *ConDisplays, *ConDatasets,
                   *ConOthers, *ConVerilog, *ConVerilogA, *ConOctave;
 

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -124,18 +124,12 @@ public slots:
 
   // for menu that appears by right click in content ListView
   void slotShowContentMenu(const QPoint &);
-  void slotShowContentMenu_new(const QPoint &);
+
   void slotCMenuOpen();
   void slotCMenuCopy();
   void slotCMenuRename();
   void slotCMenuDelete();
   void slotCMenuInsert();
-
-  void slotCMenuOpen_new();
-  void slotCMenuCopy_new();
-  void slotCMenuRename_new();
-  void slotCMenuDelete_new();
-  void slotCMenuInsert_new();
 
   void slotUpdateTreeview();
 private slots:
@@ -143,11 +137,9 @@ private slots:
   void slotMenuProjClose();
   void slotMenuProjDel();
   void slotListProjOpen(const QModelIndex &);
-  void slotSelectSubcircuit(QTreeWidgetItem*);
-  void slotSelectSubcircuit_new(const QModelIndex &);
+  void slotSelectSubcircuit(const QModelIndex &);
   void slotSelectLibComponent(QTreeWidgetItem*);
-  void slotOpenContent(QTreeWidgetItem*);
-  void slotOpenContent_new(const QModelIndex &);
+  void slotOpenContent(const QModelIndex &);
   void slotSetCompView(int);
   void slotButtonProjNew();
   void slotButtonProjOpen();
@@ -170,12 +162,9 @@ public:
 
   // menu appearing by right mouse button click on content listview
   QMenu *ContentMenu;
-  QMenu *ContentMenu_new;
 
   // corresponding actions
   QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuInsert;
-
-  QAction *ActionCMenuOpen_new, *ActionCMenuCopy_new, *ActionCMenuRename_new, *ActionCMenuDelete_new, *ActionCMenuInsert_new;
 
   QAction *fileNew, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
           *fileSaveAll, *fileClose, *fileExamples, *fileSettings, *filePrint, *fileQuit,
@@ -196,10 +185,7 @@ private:
   MessageDock     *messageDock;
 
   QListView       *Projects;
-  QTreeWidget     *Content;
-  ProjectView     *Content_new;
-  QTreeWidgetItem *ConSchematics, *ConSources, *ConDisplays, *ConDatasets,
-                  *ConOthers, *ConVerilog, *ConVerilogA, *ConOctave;
+  ProjectView     *Content;
 
   QLineEdit       *CompSearch;
   QPushButton     *CompSearchClear;

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -200,7 +200,6 @@ private:
 // ********** Methods ***************************************************
   void initView();
   void initCursorMenu();
-  void initContentListView();
 
   void printCurrentDocument(bool);
   bool saveFile(QucsDoc *Doc=0);
@@ -223,7 +222,6 @@ private:
 public:
 
   void readProjects();
-  void readProjectFiles();
   void updatePathList(void); // update the list of paths, pruning non-existing paths
   void updatePathList(QStringList);
   void updateSchNameHash(void); // maps all schematic files in the path list

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -137,6 +137,7 @@ public slots:
   void slotCMenuDelete_new();
   void slotCMenuInsert_new();
 
+  void slotUpdateTreeview();
 private slots:
   void slotMenuProjOpen();
   void slotMenuProjClose();

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -36,6 +36,7 @@
 #include <QMenu>
 #include <QComboBox>
 #include <QDockWidget>
+#include <QTreeWidgetItem>
 
 #include "main.h"
 #include "qucs.h"
@@ -1238,7 +1239,18 @@ void QucsApp::slotCreateLib()
     return;
   }
 
-  LibraryDialog *d = new LibraryDialog(this, ConSchematics);
+  QStringList SchematicList;
+  QTreeWidgetItem *p;
+  for(int i=0; i < ConSchematics->childCount(); i++){
+    p = ConSchematics->child(i);
+    if(p->parent() == 0)
+      break;
+    if(!p->text(1).isEmpty()){
+      SchematicList.append(p->text(0));
+    }
+  }
+
+  LibraryDialog *d = new LibraryDialog(this, SchematicList);
   d->exec();
 }
 

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -38,6 +38,7 @@
 #include <QDockWidget>
 #include <QTreeWidgetItem>
 
+#include "projectView.h"
 #include "main.h"
 #include "qucs.h"
 #include "schematic.h"
@@ -1239,19 +1240,8 @@ void QucsApp::slotCreateLib()
     return;
   }
 
-  QStringList SchematicList;
-  QTreeWidgetItem *p;
-  for(int i=0; i < ConSchematics->childCount(); i++){
-    p = ConSchematics->child(i);
-    if(p->parent() == 0)
-      break;
-    if(!p->text(1).isEmpty()){
-      SchematicList.append(p->text(0));
-    }
-  }
-
   LibraryDialog *d = new LibraryDialog(this);
-  d->fillSchematicList(SchematicList);
+  d->fillSchematicList(Content_new->exportSchematic());
   d->exec();
 }
 

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -1250,7 +1250,8 @@ void QucsApp::slotCreateLib()
     }
   }
 
-  LibraryDialog *d = new LibraryDialog(this, SchematicList);
+  LibraryDialog *d = new LibraryDialog(this);
+  d->fillSchematicList(SchematicList);
   d->exec();
 }
 

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -952,7 +952,7 @@ void QucsApp::slotAddToProject()
   }
 
   free(Buffer);
-  readProjectFiles();  // re-read the content ListView
+  slotUpdateTreeview();
   statusBar()->message(tr("Ready."));
 }
 
@@ -1257,7 +1257,7 @@ void QucsApp::slotImportData()
 
   ImportDialog *d = new ImportDialog(this);
   if(d->exec() == QDialog::Accepted)
-    readProjectFiles();  // re-read all project files
+    slotUpdateTreeview();
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -1241,7 +1241,7 @@ void QucsApp::slotCreateLib()
   }
 
   LibraryDialog *d = new LibraryDialog(this);
-  d->fillSchematicList(Content_new->exportSchematic());
+  d->fillSchematicList(Content->exportSchematic());
   d->exec();
 }
 


### PR DESCRIPTION
This is a refactor work to main window:
The origin main window manage all the project tree view in the tab, which contaminates the view with the model logic. I create a object ProjectView which can set the project path to it. It will automatically create the TreeView of the directory. If we are going to add something special or modifying the TreeView, just modifying this class.
You can see the number of difference by 
```
git diff master --numstat
191     460     qucs/qucs/qucs.cpp
```
Actually number is just a reference, the importance is the separation of main window view with the file logic.
*******
This is not the complete refactor though. The function that addes, remove, copy files are still in main window. In the end a object of `Project Manager` may be needed, which will manage, that is locked, added, removed, modified, files in the open project.