### PR TITLE
qucsator : avoid taking a time step that will bring too close to a breakpoint.

### DIFF
--- a/qucs-core/src/trsolver.cpp
+++ b/qucs-core/src/trsolver.cpp
@@ -643,18 +643,32 @@ void trsolver::adjustDelta (nr_double_t t)
             }
             else
             {
-                if (delta > (t - current) && t > current)
+	      // check whether this step will bring too close to a breakpoint
+	      //   is ok if the step will go past the breakpoint, this is handled by
+	      //   the next branch
+	      if ((t - (current + delta) < deltaMin) && ((current + delta) < t))
                 {
-                    // save last valid delta and set exact step
-                    stepDelta = deltaOld;
-                    delta = t - current;
-                    good = 1;
-                }
+                    // if we take this delta we will end up too close to the breakpoint
+                    // and next step will be very tiny, possibly causing numerical issues
+                    // so reduce it so that next step will likely not end up too close
+                    // to the breakpoint
+                    delta /= 2.0; 
+		} 
                 else
-                {
-                    stepDelta = -1.0;
+	        {
+                    if (delta > (t - current) && t > current)
+                    {
+                        // save last valid delta and set exact step
+                        stepDelta = deltaOld;
+                        delta = t - current;
+                        good = 1;
+                    }
+                    else
+                    {
+                        stepDelta = -1.0;
+                    }
                 }
-            }
+	    }
             if (delta > deltaMax) delta = deltaMax;
             if (delta < deltaMin) delta = deltaMin;
         }


### PR DESCRIPTION
quick fix for #186 : the issue is related to the fact that for this particular simulation the internal time steps taken should have been submultiples of the user-requested time steps (print steps). In practice after some internal steps the simulator came very close, but not exactly on, to a print time step, probably due to numerical errors and then it attempted to take a very small time step (same order of magnitude as the machine precision) to reach the print step. This very small step likely caused to have companion circuits with extreme values.
Now, in case a step will bring too close to a print step, it will be reduced so that the next step will be larger. Might not work with a lot of corner cases, but is good enough for the #186 circuit.
While this passes all the `qucs-test` circuits, with no appreciable changes in the simulation time, it might not be the best solution, feel free to keep it on hold.
And unfortunately it does not solve the transient simulation issues of the other known problematic circuits...