### PR TITLE
Fixed errors due to numerical precision.

### DIFF
--- a/qucs-core/src/components/vrect.cpp
+++ b/qucs-core/src/components/vrect.cpp
@@ -52,7 +52,11 @@ void vrect::initDC (void) {
   nr_double_t tf = getPropertyDouble ("Tf");
   if (tr > th) tr = th;
   if (tf > tl) tf = tl;
-  nr_double_t a  = (th + (tf - tr) / 2) / (th + tl);
+  // DC value defined as 0.0 instead of
+  // (th + (tf - tr) / 2) / (th + tl) previously used
+  // so that the transient starting value will also be 0, 
+  // otherwise a discontinuity occurs
+  nr_double_t a  = 0.0;
   nr_double_t u  = getPropertyDouble ("U") * a;
   allocMatrixMNA ();
   voltageSource (VSRC_1, NODE_1, NODE_2, u);

--- a/qucs/qucs/components/switch.cpp
+++ b/qucs/qucs/components/switch.cpp
@@ -35,6 +35,8 @@ Switch::Switch()
 		QObject::tr("simulation temperature in degree Celsius")));
   Props.append(new Property("MaxDuration", "1e-6", false,
 		QObject::tr("Max possible switch transition time (transition time 1/100 smallest value in 'time', or this number)")));
+  Props.append(new Property("Transition", "spline", false,
+		QObject::tr("Resistance transition shape")+" [abrupt, linear, spline]"));
 
   createSymbol();
   tx = x1+4;


### PR DESCRIPTION
...this fixes #34 , hopefully :wink:

The current `tswitch` model had some issues with numerical precision, in the calculation of time differences and of the current switch resistance.

Below is a long explanation (and some questions), for those interested; you need to read it while looking at the [code of `calcTR` of `tswitch.cpp`] (https://github.com/Qucs/qucs/blob/master/qucs-core/src/components/tswitch.cpp#L102)

 In the code, `t` is the current simulation time, `duration` is the switch transition time, then there is a variable `ts=t-duration`and the calculation of the current switch resistance is  based on `ts` and another variable, `tdiff`. When a switching point has not yet been reached, this latter is defined as `tdiff=t-ts` ; from the definitions above it would seem that `tdiff=t-ts=t-t+duration==duration` but due to numerical errors this is not always the case...

As an example, for the circuit in #34, `duration=9.9999999999999995e-07` and when `t=6.5536000000000002e-06` (this is **not** a switching point for the switch), `ts=t-duration=5.5536000000000005e-06` and `tdiff=t-ts=9.9999999999999974e-07` that is `2.1e-22` less than the theoretical value. How could two `double` values differ by so little, when the theoretical machine epsilon for this type is around `2E-16` I do not know. Maybe these variables are kept in registers with higher precision?
The numbers above means that now `tdiff/duration = 0.99999999999999978` instead of `1.0` and 
when computing the switch resistance with a linear approximation (see below why I am not using the cubical spline approximation in this example) `r = roff - ( (roff - ron) * (tdiff / duration) )` with `roff=1e12` and `ron=0` the approx above results in `r=0.000244140625` instead of zero.
At this point `qucsator` realizes that the time point needs to be recomputed (a component suddenly changed value and the current solution is no longer valid) and starts backtracking the solution until `t=3.4844950090878202e-06`, where `ts=2.4844950090878201e-06` and `tdiff=9.9999999999999995e-07` so that `tdiff/duration=1.0` and `r=0`.
At this point `qucsator` is happy again and the simulation time starts going forward again but with smaller steps... but when reaching `t = 3.89988502726346e-06` we have `ts = 2.8998850272634602e-06`, so `tdiff = 9.9999999999999974e-07` and again `r=0.000244140625`. Here `qucsator` starts backtracking again, finds again a good solution, steps forward a little, finds a bad solution and continues like this for a while until the time step becomes too small and the results become `nan` everywhere.
To avoid all this I have simply set the initial value of `ts` well in the past, as I think this was also the original idea.

Another numerical issue was present in the calculation of the current switch resistance using the cubic spline formula; there were two terms computed using higher order powers of small time differences multiplied with very high resistance values which were then subtracted and this made the results sometimes incorrect. For example this made the switch `r` equal to `-2.441406e-04` (negative!) instead of zero when `tdiff==duration`. I have now rearranged the terms to try to minimize the errors and the computed resistance results seems ok.

Out of curiosity, here are the simulation details when using the cubic spline resistance model :

````
NOTIFY: TR1: average time-step 2.88392e-06, 79 rejections
NOTIFY: TR1: average NR-iterations 2.03037, 0 non-convergences
````
run time:

````
real	0m0.219s
user	0m0.214s
sys	0m0.003s
````

And when using the linear resistance model :

````
NOTIFY: TR1: average time-step 2.69407e-06, 73 rejections
NOTIFY: TR1: average NR-iterations 2.02622, 0 non-convergences
````
run time:

````
real	0m0.234s
user	0m0.226s
sys	0m0.004s
````

The cubic spline model seems slightly better, but when stepping thru the code of the actual simulation, for both cases you can see `qucsator` having to backtrack significantly and reducing a lot the time step when the switch changes state, I am even  more convinced we should try to implement the *breakpoints* so `qucsator` will not be caught by surprise when a planned discontinuity appears...