### PR TITLE
Another step towards solving issue 41...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
             - texlive-font-utils
             - ps2eps
             - pgf
+            - python-tk
 
     - os: osx
       # Qt 4.8.7 official installer works up to OSX 10.10 or xcode6.4

--- a/qucs-core/src/interface/e_trsolver.cpp
+++ b/qucs-core/src/interface/e_trsolver.cpp
@@ -430,7 +430,7 @@ int e_trsolver::stepsolve_sync(nr_double_t synctime)
     error += predictor ();
 
     // restart Newton iteration
-    restart (); // restart non-linear devices
+    restartNR (); // restart non-linear devices
 
     // Attempt to solve the circuit with the given delta
     try_running () // #defined as:    do {
@@ -677,7 +677,7 @@ int e_trsolver::stepsolve_async(nr_double_t steptime)
         // restart Newton iteration
         if (rejected)
         {
-            restart ();      // restart non-linear devices
+            restartNR ();      // restart non-linear devices
             rejected = 0;
         }
 

--- a/qucs-core/src/nasolver.cpp
+++ b/qucs-core/src/nasolver.cpp
@@ -268,6 +268,8 @@ void nasolver<nr_type_t>::applyNodeset (bool nokeep)
     }
     if (xprev != NULL) *xprev = *x;
     saveSolution ();
+    // propagate the solution to the non-linear circuits
+    restartNR ();
 }
 
 /* The following function uses the gMin-stepping algorithm in order to

--- a/qucs-core/src/trsolver.cpp
+++ b/qucs-core/src/trsolver.cpp
@@ -146,7 +146,6 @@ int trsolver::dcAnalysis (void)
         logprint (LOG_ERROR, "WARNING: %s: %s analysis failed, using line search "
                   "fallback\n", getName (), getDescription ().c_str());
         applyNodeset ();
-        restart ();
         error = solve_nonlinear ();
         break;
     default:
@@ -276,7 +275,7 @@ int trsolver::solve (void)
             // restart Newton iteration
             if (rejected)
             {
-                restart ();      // restart non-linear devices
+                restartNR ();      // restart non-linear devices
                 rejected = 0;
             }
 
@@ -790,17 +789,6 @@ void trsolver::calcTR (trsolver * self)
     for (circuit * c = root; c != NULL; c = (circuit *) c->getNext ())
     {
         c->calcTR (self->current);
-    }
-}
-
-/* Goes through the list of non-linear circuit objects and runs its
-   restartDC() function. */
-void trsolver::restart (void)
-{
-    circuit * root = subnet->getRoot ();
-    for (circuit * c = root; c != NULL; c = (circuit *) c->getNext ())
-    {
-        if (c->isNonLinear ()) c->restartDC ();
     }
 }
 

--- a/qucs-core/src/trsolver.h
+++ b/qucs-core/src/trsolver.h
@@ -53,7 +53,6 @@ public:
     void initTR (void);
     void deinitTR (void);
     static void calcTR (trsolver *);
-    void restart (void);
     void initDC (void);
     static void calcDC (trsolver *);
     void initSteps (void);


### PR DESCRIPTION
**EDIT: may continue to work on this, one day...**
needed a lot of time to find a nasty bug that caused almost all transient simulations with BJT having a non-zero  `PTF` (excess phase) parameter to fail.
Now the circuit in #41 runs until `2 ms` then it fails due to the well-known issue with PWL sources; at the beginning the simulator uses small time steps, so it can cope with the source fast transitions but then it increases the time step size and cannot handle the source fast variations anymore.
It's high time to implement the breakpoints now...

While looking at the code saw also a (maybe small) issue with the initial solution (DC) propagation in the transient solver, now fixed.
