### PR TITLE
Fixed Recent files feature

### DIFF
--- a/qucs/qucs/dialogs/simmessage.cpp
+++ b/qucs/qucs/dialogs/simmessage.cpp
@@ -135,6 +135,7 @@ SimMessage::SimMessage(QWidget *w, QWidget *parent)
   Butts->addWidget(Abort);
   connect(Abort,SIGNAL(clicked()),SLOT(reject()));
   connect(Abort,SIGNAL(clicked()),SLOT(AbortSim()));
+  connect(this,SIGNAL(rejected()),SLOT(AbortSim()));
 }
 
 /*!

--- a/qucs/qucs/imagewriter.cpp
+++ b/qucs/qucs/imagewriter.cpp
@@ -26,9 +26,10 @@
 
 #include <QtSvg>
 
-ImageWriter::ImageWriter()
+ImageWriter::ImageWriter(QString lastfile)
 {
   onlyDiagram = false;
+  lastExportFilename = lastfile;
 }
 
 ImageWriter::~ImageWriter()
@@ -118,6 +119,11 @@ ImageWriter::noGuiPrint(QWidget *doc, QString printFile, QString color)
   }
 }
 
+QString ImageWriter::getLastSavedFile()
+{
+    return lastExportFilename;
+}
+
 void
 ImageWriter::print(QWidget *doc)
 {
@@ -126,8 +132,6 @@ ImageWriter::print(QWidget *doc)
 
   int w,h,wsel,hsel,
       xmin, ymin, xmin_sel, ymin_sel;
-
-  QString lastExportFilename = QDir::homePath() + QDir::separator() + "export.png";
 
   sch->getSchWidthAndHeight(w, h, xmin, ymin);
   sch->getSelAreaWidthAndHeight(wsel, hsel, xmin_sel, ymin_sel);

--- a/qucs/qucs/imagewriter.h
+++ b/qucs/qucs/imagewriter.h
@@ -30,14 +30,17 @@ class QWidget;
 class ImageWriter
 {
 public:
-  ImageWriter ();
+  ImageWriter (QString lastfile);
   virtual ~ImageWriter ();
   void print(QWidget *);
   void noGuiPrint(QWidget *, QString printFile, QString color);
 
+  QString getLastSavedFile();
+
   void setDiagram(bool diagram) { onlyDiagram = diagram; };
 private:
   bool onlyDiagram;
+  QString lastExportFilename;
 };
 
 #endif

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -331,7 +331,7 @@ int doPrint(QString schematic, QString printFile,
     Printer->setFitToPage(true);
     Printer->noGuiPrint(sch, printFile, page, dpi, color, orientation);
   } else {
-    ImageWriter *Printer = new ImageWriter();
+    ImageWriter *Printer = new ImageWriter("");
     Printer->noGuiPrint(sch, printFile, color);
   }
   return 0;

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2783,8 +2783,9 @@ void QucsApp::slotSaveDiagramToGraphicsFile()
 
 void QucsApp::slotSaveSchematicToGraphicsFile(bool diagram)
 {
-  ImageWriter *writer = new ImageWriter();
+  ImageWriter *writer = new ImageWriter(lastExportFilename);
   writer->setDiagram(diagram);
   writer->print(DocumentTab->currentPage());
+  lastExportFilename = writer->getLastSavedFile();
   delete writer;
 }

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2765,11 +2765,14 @@ void QucsApp::updatePathList(QStringList newPathList)
 
 void QucsApp::updateRecentFilesList(QString s)
 {
+  QSettings* settings = new QSettings("qucs","qucs");
   QucsSettings.RecentDocs.removeAll(s);
   QucsSettings.RecentDocs.append(s);
   if (QucsSettings.RecentDocs.size() > MaxRecentFiles) {
     QucsSettings.RecentDocs.removeFirst();
   }
+  settings->setValue("RecentDocs",QucsSettings.RecentDocs.join("*"));
+  delete settings;
   slotUpdateRecentFiles();
 }
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2767,9 +2767,9 @@ void QucsApp::updateRecentFilesList(QString s)
 {
   QSettings* settings = new QSettings("qucs","qucs");
   QucsSettings.RecentDocs.removeAll(s);
-  QucsSettings.RecentDocs.append(s);
+  QucsSettings.RecentDocs.prepend(s);
   if (QucsSettings.RecentDocs.size() > MaxRecentFiles) {
-    QucsSettings.RecentDocs.removeFirst();
+    QucsSettings.RecentDocs.removeLast();
   }
   settings->setValue("RecentDocs",QucsSettings.RecentDocs.join("*"));
   delete settings;

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -1367,11 +1367,11 @@ void QucsApp::slotUpdateRecentFiles()
         it.remove();
     }
   }
-  int docs_cnt = QucsSettings.RecentDocs.size();
+
   for (int i = 0; i < MaxRecentFiles; ++i) {
-    if (i < docs_cnt) {
-      fileRecentAction[i]->setText(QucsSettings.RecentDocs[docs_cnt-1-i]);
-      fileRecentAction[i]->setData(QucsSettings.RecentDocs[docs_cnt-1-i]);
+    if (i < QucsSettings.RecentDocs.size()) {
+      fileRecentAction[i]->setText(QucsSettings.RecentDocs[i]);
+      fileRecentAction[i]->setData(QucsSettings.RecentDocs[i]);
       fileRecentAction[i]->setVisible(true);
     } else {
       fileRecentAction[i]->setVisible(false);

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -1367,10 +1367,11 @@ void QucsApp::slotUpdateRecentFiles()
         it.remove();
     }
   }
+  int docs_cnt = QucsSettings.RecentDocs.size();
   for (int i = 0; i < MaxRecentFiles; ++i) {
-    if (i < QucsSettings.RecentDocs.size()) {
-      fileRecentAction[i]->setText(QucsSettings.RecentDocs[i]);
-      fileRecentAction[i]->setData(QucsSettings.RecentDocs[i]);
+    if (i < docs_cnt) {
+      fileRecentAction[i]->setText(QucsSettings.RecentDocs[docs_cnt-1-i]);
+      fileRecentAction[i]->setData(QucsSettings.RecentDocs[docs_cnt-1-i]);
       fileRecentAction[i]->setVisible(true);
     } else {
       fileRecentAction[i]->setVisible(false);


### PR DESCRIPTION
Fixed some bugs in `QucsApp::updateRecentFiles()` and `QucsApp::slotUpdateRecentFiles()` after refactoring #174 .

1. Fixed reverse order of recent opened documents. Now the last opened file is first in the list. 
2. Reverted saving of recent opened docs list. Recent docs list is saved in Qucs config file.

Also this PR contains:
1. Fix in Simmessage dialog. Added SimProcess termination if window is closed by Close button.
2. Reverted saving of the last exported to image filename.