### PR TITLE
remove filter-v2 from build system

### DIFF
--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -74,8 +74,6 @@ ADD_SUBDIRECTORY( qucs-attenuator )
 #ADD_SUBDIRECTORY( qucs-doc )
 ADD_SUBDIRECTORY( qucs-edit )
 ADD_SUBDIRECTORY( qucs-filter )
-# filter-v2 not completed, on OSX require libstc++, broken if default libc++ is used
-# ADD_SUBDIRECTORY( qucs-filter-v2 )
 ADD_SUBDIRECTORY( qucs-help )
 ADD_SUBDIRECTORY( qucs-lib )
 ADD_SUBDIRECTORY( qucs-transcalc )

--- a/qucs/Makefile.am
+++ b/qucs/Makefile.am
@@ -22,11 +22,6 @@
 # Boston, MA 02110-1301, USA.  
 #
 
-# Skip filter-v2 on Darwin. See configure.ac
-if !COND_MACOSX
-  FILTERV2= qucs-filter-v2
-endif
-
 SUBDIRS = \
   qucs \
 	qucs-activefilter \
@@ -39,7 +34,6 @@ SUBDIRS = \
 	qucs-transcalc \
 	translations \
 	contrib \
-	$(FILTERV2) \
 	$(RELEASEDIRS)
 
 EXTRA_DIST = autogen.sh depcomp PLATFORMS RELEASE Info.plist

--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -836,14 +836,6 @@ AC_CONFIG_FILES([Makefile
     qucs/dialogs/Makefile
     translations/Makefile])
 
-# The incomplete filter-v2 only builds withs -stdlib=libstc++
-# OSX defaults to libstc++. Skip filter-v2 on Darwin.
-# See also Makefile.am
-if test "x$MACOSX" = xno ; then
-  AC_CONFIG_FILES([ qucs-filter-v2/Makefile ])
-fi
-
-
 dnl Check for Git short SHA to tag version
 dnl The release package should also keep it on the config.h
 GIT="unknown"


### PR DESCRIPTION
Issue #161
Remove all build command on filter-v2, the source will stay there until @ra3xdh examine and extract all the useful part inside.