### PR TITLE
fix close one tab cause multiple tabs close

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1636,8 +1636,8 @@ void QucsApp::closeFile(int index)
     editText->move(QPoint(0, 0));
     editText->hide();
 
-    delete Doc;
     DocumentTab->removeTab(index);
+    delete Doc;
 
     if(DocumentTab->count() < 1) { // if no document left, create an untitled
       Schematic *d = new Schematic(this, "");


### PR DESCRIPTION
issue #218 
this is caused in
https://github.com/yodalee/qucs/commit/576355a79a04990785dd6d233ecbe4af63d35218#diff-07a46d9c7b31a19eccbb820ca0cd3aa8R1929

the cause is related to Qt's implementation
when Qt TabWidget add a new QWidget *obj
if you directly delete the obj by call
$ delete obj
Qt will also remove the tab related to that obj automatically

The origin code is
$ delete obj
$ tab->removeTab(index)
thus close two tabs with one close click

This hotfix fix to
$ tab->removeTab(index)
$ delete obj
This is safe since removeTab will not delete the object
which is record in Qt's document