### PR TITLE
fix saveAs not update filename in tabwidget

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1530,7 +1530,7 @@ bool QucsApp::saveAs()
     break;
   }
   Doc->setName(s);
-  DocumentTab->setTabText(DocumentTab->indexOf(this), misc::properFileName(s));
+  DocumentTab->setTabText(DocumentTab->indexOf(w), misc::properFileName(s));
   lastDirOpenSave = Info.dirPath(true);  // remember last directory and file
   updateRecentFilesList(s);
 


### PR DESCRIPTION
The cause:
DocumentTab->setTabText(DocumentTab->indexOf(This), misc::properFileName(s));

setTabText should apply to TabWidget which contain widget 'w'
However here is apply to widget contain This, that is, main app
*******************

The fix:
indexOf should search for 'w'
DocumentTab->setTabText(DocumentTab->indexOf(w), misc::properFileName(s));