### PR TITLE
fix data display show wrong extension

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2120,11 +2120,11 @@ void QucsApp::slotChangePage(QString& DocName, QString& DataDisplay)
     if (ext != "vhd" && ext != "vhdl" && ext != "v" && ext != "va" &&
 	ext != "oct" && ext != "m") {
       d = new Schematic(this, Name);
-      i = DocumentTab->addTab((Schematic *)d, QPixmap(empty_xpm), Info.fileName()); 
+      i = DocumentTab->addTab((Schematic *)d, QPixmap(empty_xpm), DataDisplay);
     }
     else {
       d = new TextDoc(this, Name);
-      i = DocumentTab->addTab((TextDoc *)d, QPixmap(empty_xpm), Info.fileName());
+      i = DocumentTab->addTab((TextDoc *)d, QPixmap(empty_xpm), DataDisplay);
     }
     DocumentTab->setCurrentIndex(i);
 


### PR DESCRIPTION
The repeat steps:
1. Simulate a schematic.
2. Press goto display page at the end of simulation.
3. The corresponding Data Display tab shows extension
   .sch instead of .dpl

The cause:
it's cause by qucs.cpp:L2123
i = DocumentTab->addTab((Schematic *)d, QPixmap(empty_xpm),
    Info.fileName());
where the Info is linked to origin document "*.sch"
so the tab will show "*.sch" rather than "*.dpl"

The fix:
Change Info.fileName() into DataDisplay, which is the filename of *.dpl