### PR TITLE
fix projectView shows dot filename wrong place

### DIFF
--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -108,7 +108,7 @@ ProjectView::refresh()
 
   for(it = files.begin(); it != files.end(); ++it) {
     fileName = (*it).toAscii();
-    extName = QFileInfo(workPath.filePath(fileName)).completeSuffix();
+    extName = QFileInfo(workPath.filePath(fileName)).suffix();
 
     columnData.clear();
     columnData.append(new QStandardItem(fileName));

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -956,8 +956,8 @@ void QucsApp::slotCMenuCopy()
     }
   }
 
-  QString suffix = fileinfo.completeSuffix();
-  QString base = fileinfo.baseName();
+  QString suffix = fileinfo.suffix();
+  QString base = fileinfo.completeBaseName();
   if(base.isEmpty()) {
     base = filename;
   }
@@ -1015,8 +1015,8 @@ void QucsApp::slotCMenuRename()
     return;
   }
 
-  QString suffix = fileinfo.completeSuffix();
-  QString base = fileinfo.baseName();
+  QString suffix = fileinfo.suffix();
+  QString base = fileinfo.completeBaseName();
   if(base.isEmpty()) {
     base = filename;
   }
@@ -2195,7 +2195,7 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
   QString filename = idx.sibling(idx.row(), 0).data().toString();
   QString note = idx.sibling(idx.row(), 1).data().toString();
   QFileInfo Info(QucsSettings.QucsWorkDir.filePath(filename));
-  QString extName = Info.completeSuffix();
+  QString extName = Info.suffix();
 
   if (extName == "sch" || extName == "dpl" || extName == "vhdl" ||
       extName == "vhd" || extName == "v" || extName == "va" ||


### PR DESCRIPTION
The repeat steps:
1. Create a filename with dot like: MyFile_v0.1.sch
2. The file will shows in category "Others" in project content
   But it should be in "Schematics"

The cause:
It's caused by projectView.cpp, when it categorize files by extension
it get extension name with following line:
extName = QFileInfo(workPath.filePath(fileName)).completeSuffix();
which get the complete suffix:
complete suffic of `MyFile_v.0.1.sch` will be `0.1.sch`
which is not a '*.sch" file.

The fix:
Change completeSuffix into suffix
extName = QFileInfo(workPath.filePath(fileName)).suffix();
so filename with dot still get right extensions