### PR TITLE
fix crash when close file with editText focus

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1620,6 +1620,7 @@ void QucsApp::slotFileClose(int index)
 void QucsApp::closeFile(int index)
 {
     statusBar()->message(tr("Closing file..."));
+
     slotHideEdit(); // disable text edit of component property
 
     QucsDoc *Doc = getDoc(index);
@@ -1633,8 +1634,6 @@ void QucsApp::closeFile(int index)
         case 2 : return;
       }
     }
-    editText->move(QPoint(0, 0));
-    editText->hide();
 
     DocumentTab->removeTab(index);
     delete Doc;
@@ -2627,6 +2626,7 @@ void QucsApp::slotEditElement()
 // looses the focus.
 void QucsApp::slotHideEdit()
 {
+  editText->setParent(this, 0);
   editText->setHidden(true);
 }
 


### PR DESCRIPTION
Solved issue: #230 
Review = @in3otd 

The repeat steps:
1. Open a schematic file.
2. Focus on a component property, show the property edit
3. Close the file
4. The program will crash

The source:
This bug is appeared since commit eadd7b

The cause:
When click on property edit, this line
qucs_action.cpp:1221, editText->reparent(...
will change the editText to child of the open document
At this time, if the document is closed, the editText will
be deleted by Qt
After that, qucs try to access to editText will access to invalid
memory.

The fix:
To be general, now editText will child of main app every time the
slotHideEdit() called, it's a little overhead, but guarantee safe.
function slotHideEdit() {
  ...
  editText->setParent(this, 0);
}