### PR TITLE
Resolve #248 - HB regression

### DIFF
--- a/qucs-core/src/hbsolver.cpp
+++ b/qucs-core/src/hbsolver.cpp
@@ -788,10 +788,10 @@ void hbsolver::createMatrixLinearY (void) {
     // ---+---
     // ZV | ..
     r = 0;
-    for (auto *e : excitations) {
+    for (auto ite = excitations.begin(); ite != excitations.end(); ++ite, r++) {
       // lower part entries
       for (f = 0; f < lnfreqs; f++) {
-	ZVL_(r, c) = excitationZ (V, e, f);
+	ZVL_(r, c) = excitationZ (V, *ite, f);
       }
     }
   }


### PR DESCRIPTION
The issue was introduced in 9bd368d1.
The 'r++' increment was left behind during the refactor.
This should fix the regression observed on the HB simulation.