### PR TITLE
264 reserved header include guard

### DIFF
--- a/qucs-core/src/acsolver.h
+++ b/qucs-core/src/acsolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __ACSOLVER_H__
-#define __ACSOLVER_H__
+#ifndef ACSOLVER_H
+#define ACSOLVER_H
 
 #include "nasolver.h"
 
@@ -55,5 +55,5 @@ class acsolver : public nasolver<nr_complex_t>
 
 } // namespace qucs
 
-#endif /* __ACSOLVER_H__ */
+#endif /* ACSOLVER_H */
 

--- a/qucs-core/src/analyses.h
+++ b/qucs-core/src/analyses.h
@@ -30,8 +30,8 @@
  *
  */
 
-#ifndef __ANALYSES_H__
-#define __ANALYSES_H__
+#ifndef ANALYSES_H
+#define ANALYSES_H
 
 #include "analysis.h"
 #include "spsolver.h"
@@ -42,4 +42,4 @@
 #include "hbsolver.h"
 #include "e_trsolver.h"
 
-#endif /* __ANALYSES_H__ */
+#endif /* ANALYSES_H */

--- a/qucs-core/src/analysis.h
+++ b/qucs-core/src/analysis.h
@@ -28,8 +28,8 @@
  * Contains the analysis class definition.
  */
 
-#ifndef __ANALYSIS_H__
-#define __ANALYSIS_H__
+#ifndef ANALYSIS_H
+#define ANALYSIS_H
 
 #include "object.h"
 #include "ptrlist.h"
@@ -279,4 +279,4 @@ protected:
 
 } // namespace qucs
 
-#endif /* __ANALYSIS_H__ */
+#endif /* ANALYSIS_H */

--- a/qucs-core/src/applications.h
+++ b/qucs-core/src/applications.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __APPLICATIONS_H__
-#define __APPLICATIONS_H__
+#ifndef APPLICATIONS_H
+#define APPLICATIONS_H
 
 // Array containing all kinds of applications.
 struct application_t qucs::eqn::applications[] = {
@@ -1076,4 +1076,4 @@ const char * checker::tag2key (int tag) {
   return key;
 }
 
-#endif /* __APPLICATIONS_H__ */
+#endif /* APPLICATIONS_H */

--- a/qucs-core/src/characteristic.h
+++ b/qucs-core/src/characteristic.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHARACTERISTIC_H__
-#define __CHARACTERISTIC_H__
+#ifndef CHARACTERISTIC_H
+#define CHARACTERISTIC_H
 
 #include "pair.h"
 
@@ -33,4 +33,4 @@ typedef class qucs::pair characteristic;
 
 } // namespace qucs
 
-#endif /* __CHARACTERISTIC_H__ */
+#endif /* CHARACTERISTIC_H */

--- a/qucs-core/src/check_citi.h
+++ b/qucs-core/src/check_citi.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_CITI_H__
-#define __CHECK_CITI_H__
+#ifndef CHECK_CITI_H
+#define CHECK_CITI_H
 
 namespace qucs {
   class dataset;
@@ -69,4 +69,4 @@ void citi_destroy (void);
 
 __END_DECLS
 
-#endif /* __CHECK_CITI_H__ */
+#endif /* CHECK_CITI_H */

--- a/qucs-core/src/check_csv.h
+++ b/qucs-core/src/check_csv.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_CSV_H__
-#define __CHECK_CSV_H__
+#ifndef CHECK_CSV_H
+#define CHECK_CSV_H
 
 namespace qucs {
   class dataset;
@@ -53,4 +53,4 @@ void csv_destroy (void);
 
 __END_DECLS
 
-#endif /* __CHECK_CSV_H__ */
+#endif /* CHECK_CSV_H */

--- a/qucs-core/src/check_dataset.h
+++ b/qucs-core/src/check_dataset.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_DATASET_H__
-#define __CHECK_DATASET_H__
+#ifndef CHECK_DATASET_H
+#define CHECK_DATASET_H
 
 namespace qucs {
   class dataset;
@@ -51,4 +51,4 @@ int dataset_check (qucs::dataset *);
 
 __END_DECLS
 
-#endif /* __CHECK_DATASET_H__ */
+#endif /* CHECK_DATASET_H */

--- a/qucs-core/src/check_mdl.h
+++ b/qucs-core/src/check_mdl.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_MDL_H__
-#define __CHECK_MDL_H__
+#ifndef CHECK_MDL_H
+#define CHECK_MDL_H
 
 namespace qucs {
   class dataset;
@@ -133,4 +133,4 @@ struct mdl_sync_t {
   struct mdl_sync_t * next;
 };
 
-#endif /* __CHECK_MDL_H__ */
+#endif /* CHECK_MDL_H */

--- a/qucs-core/src/check_netlist.h
+++ b/qucs-core/src/check_netlist.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_NETLIST_H__
-#define __CHECK_NETLIST_H__
+#ifndef CHECK_NETLIST_H
+#define CHECK_NETLIST_H
 
 #include "netdefs.h"
 
@@ -59,4 +59,4 @@ netlist_unchain_definition (struct definition_t *, struct definition_t *);
 
 __END_DECLS
 
-#endif /* __CHECK_NETLIST_H__ */
+#endif /* CHECK_NETLIST_H */

--- a/qucs-core/src/check_touchstone.h
+++ b/qucs-core/src/check_touchstone.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_TOUCHSTONE_H__
-#define __CHECK_TOUCHSTONE_H__
+#ifndef CHECK_TOUCHSTONE_H
+#define CHECK_TOUCHSTONE_H
 
 /* Touchstone (R) File Format Specification Rev 1.1
 
@@ -80,4 +80,4 @@ void touchstone_destroy (void);
 
 __END_DECLS
 
-#endif /* __CHECK_TOUCHSTONE_H__ */
+#endif /* CHECK_TOUCHSTONE_H */

--- a/qucs-core/src/check_zvr.h
+++ b/qucs-core/src/check_zvr.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_ZVR_H__
-#define __CHECK_ZVR_H__
+#ifndef CHECK_ZVR_H
+#define CHECK_ZVR_H
 
 // forward declarations
 namespace qucs {
@@ -86,4 +86,4 @@ struct zvr_data_t {
 };
 
 
-#endif /* __CHECK_ZVR_H__ */
+#endif /* CHECK_ZVR_H */

--- a/qucs-core/src/circuit.h
+++ b/qucs-core/src/circuit.h
@@ -28,8 +28,8 @@
  * Contains the circuit class definition.
  */
 
-#ifndef __CIRCUIT_H__
-#define __CIRCUIT_H__
+#ifndef CIRCUIT_H
+#define CIRCUIT_H
 
 #include "characteristic.h"
 #include "operatingpoint.h"
@@ -385,4 +385,4 @@ extern "C" {
 
 }
 
-#endif /* __CIRCUIT_H__ */
+#endif /* CIRCUIT_H */

--- a/qucs-core/src/compat.h
+++ b/qucs-core/src/compat.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COMPAT_H__
-#define __COMPAT_H__
+#ifndef COMPAT_H
+#define COMPAT_H
 
 #if HAVE_IEEEFP_H
 # include <ieeefp.h>
@@ -38,4 +38,4 @@
 #define strcasecmp stricmp
 #endif
 
-#endif /* __COMPAT_H__ */
+#endif /* COMPAT_H */

--- a/qucs-core/src/components/amplifier.h
+++ b/qucs-core/src/components/amplifier.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __AMPLIFIER_H__
-#define __AMPLIFIER_H__
+#ifndef AMPLIFIER_H
+#define AMPLIFIER_H
 
 /*! Ideal and linear amplifier
 
@@ -44,4 +44,4 @@ class amplifier : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __AMPLIFIER_H__ */
+#endif /* AMPLIFIER_H */

--- a/qucs-core/src/components/attenuator.h
+++ b/qucs-core/src/components/attenuator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __ATTENUATOR_H__
-#define __ATTENUATOR_H__
+#ifndef ATTENUATOR_H
+#define ATTENUATOR_H
 
 class attenuator : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class attenuator : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __ATTENUATOR_H__ */
+#endif /* ATTENUATOR_H */

--- a/qucs-core/src/components/biastee.h
+++ b/qucs-core/src/components/biastee.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __BIASTEE_H__
-#define __BIASTEE_H__
+#ifndef BIASTEE_H
+#define BIASTEE_H
 
 class biastee : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class biastee : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __BIASTEE_H__ */
+#endif /* BIASTEE_H */

--- a/qucs-core/src/components/capacitor.h
+++ b/qucs-core/src/components/capacitor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CAPACITOR_H__
-#define __CAPACITOR_H__
+#ifndef CAPACITOR_H
+#define CAPACITOR_H
 
 /*\brief Capacitor class */
 class capacitor : public qucs::circuit
@@ -41,4 +41,4 @@ class capacitor : public qucs::circuit
 
 };
 
-#endif /* __CAPACITOR_H__ */
+#endif /* CAPACITOR_H */

--- a/qucs-core/src/components/cccs.h
+++ b/qucs-core/src/components/cccs.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CCCS_H__
-#define __CCCS_H__
+#ifndef CCCS_H
+#define CCCS_H
 
 class cccs : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class cccs : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __CCCS_H__ */
+#endif /* CCCS_H */

--- a/qucs-core/src/components/ccvs.h
+++ b/qucs-core/src/components/ccvs.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CCVS_H__
-#define __CCVS_H__
+#ifndef CCVS_H
+#define CCVS_H
 
 class ccvs : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class ccvs : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __CCVS_H__ */
+#endif /* CCVS_H */

--- a/qucs-core/src/components/circulator.h
+++ b/qucs-core/src/components/circulator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CIRCULATOR_H__
-#define __CIRCULATOR_H__
+#ifndef CIRCULATOR_H
+#define CIRCULATOR_H
 
 class circulator : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class circulator : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __CIRCULATOR_H__ */
+#endif /* CIRCULATOR_H */

--- a/qucs-core/src/components/coaxline.h
+++ b/qucs-core/src/components/coaxline.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COAXLINE_H__
-#define __COAXLINE_H__
+#ifndef COAXLINE_H
+#define COAXLINE_H
 
 class coaxline : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class coaxline : public qucs::circuit
   nr_double_t alpha, beta, zl, fc;
 };
 
-#endif /* __COAXLINE_H__ */
+#endif /* COAXLINE_H */

--- a/qucs-core/src/components/component.h
+++ b/qucs-core/src/components/component.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COMPONENT_H__
-#define __COMPONENT_H__
+#ifndef COMPONENT_H
+#define COMPONENT_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,4 +45,4 @@
 #include "constants.h"
 #include "netdefs.h"
 
-#endif /* __COMPONENT_H__ */
+#endif /* COMPONENT_H */

--- a/qucs-core/src/components/component_id.h
+++ b/qucs-core/src/components/component_id.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COMPONENT_ID_H__
-#define __COMPONENT_ID_H__
+#ifndef COMPONENT_ID_H
+#define COMPONENT_ID_H
 
 namespace qucs {
 
@@ -193,4 +193,4 @@ enum circuit_type {
 
 } // namespace qucs
 
-#endif /* __COMPONENT_ID_H__ */
+#endif /* COMPONENT_ID_H */

--- a/qucs-core/src/components/components.h
+++ b/qucs-core/src/components/components.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COMPONENTS_H__
-#define __COMPONENTS_H__
+#ifndef COMPONENTS_H
+#define COMPONENTS_H
 
 // BUG: include all component headers.
 // components should add to the kernel, not the other way around.
@@ -185,4 +185,4 @@
 
 #include "ecvs.h"
 
-#endif /* __COMPONENTS_H__ */
+#endif /* COMPONENTS_H */

--- a/qucs-core/src/components/coupler.h
+++ b/qucs-core/src/components/coupler.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COUPLER_H__
-#define __COUPLER_H__
+#ifndef COUPLER_H
+#define COUPLER_H
 
 class coupler : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class coupler : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __COUPLER_H__ */
+#endif /* COUPLER_H */

--- a/qucs-core/src/components/cross.h
+++ b/qucs-core/src/components/cross.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CROSS_H__
-#define __CROSS_H__
+#ifndef CROSS_H
+#define CROSS_H
 
 class cross : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class cross : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __CROSS_H__ */
+#endif /* CROSS_H */

--- a/qucs-core/src/components/ctline.h
+++ b/qucs-core/src/components/ctline.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CTLINE_H__
-#define __CTLINE_H__
+#ifndef CTLINE_H
+#define CTLINE_H
 
 class ctline : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class ctline : public qucs::circuit
   void calcNoiseSP (nr_double_t);
 };
 
-#endif /* __CTLINE_H__ */
+#endif /* CTLINE_H */

--- a/qucs-core/src/components/dcblock.h
+++ b/qucs-core/src/components/dcblock.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DCBLOCK_H__
-#define __DCBLOCK_H__
+#ifndef DCBLOCK_H
+#define DCBLOCK_H
 
 class dcblock : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class dcblock : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __DCBLOCK_H__ */
+#endif /* DCBLOCK_H */

--- a/qucs-core/src/components/dcfeed.h
+++ b/qucs-core/src/components/dcfeed.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DCFEED_H__
-#define __DCFEED_H__
+#ifndef DCFEED_H
+#define DCFEED_H
 
 class dcfeed : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class dcfeed : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __DCFEED_H__ */
+#endif /* DCFEED_H */

--- a/qucs-core/src/components/devices/bjt.h
+++ b/qucs-core/src/components/devices/bjt.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __BJT_H__
-#define __BJT_H__
+#ifndef BJT_H
+#define BJT_H
 
 class bjt : public qucs::circuit
 {
@@ -63,4 +63,4 @@ class bjt : public qucs::circuit
   bool doTR;
 };
 
-#endif /* __BJT_H__ */
+#endif /* BJT_H */

--- a/qucs-core/src/components/devices/device.h
+++ b/qucs-core/src/components/devices/device.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DEVICE_H__
-#define __DEVICE_H__
+#ifndef DEVICE_H
+#define DEVICE_H
 
 namespace qucs {
 
@@ -226,4 +226,4 @@ namespace device {
 
 } // namespace qucs
 
-#endif /* __DEVICE_H__ */
+#endif /* DEVICE_H */

--- a/qucs-core/src/components/devices/diac.h
+++ b/qucs-core/src/components/devices/diac.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DIAC_H__
-#define __DIAC_H__
+#ifndef DIAC_H
+#define DIAC_H
 
 #include "devstates.h"
 
@@ -50,4 +50,4 @@ class diac : public qucs::circuit, public qucs::devstates
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __DIAC_H__ */
+#endif /* DIAC_H */

--- a/qucs-core/src/components/devices/diode.h
+++ b/qucs-core/src/components/devices/diode.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DIODE_H__
-#define __DIODE_H__
+#ifndef DIODE_H
+#define DIODE_H
 
 #include "devstates.h"
 
@@ -58,4 +58,4 @@ class diode : public qucs::circuit, public qucs::devstates
   void initModel (void);
 };
 
-#endif /* __DIODE_H__ */
+#endif /* DIODE_H */

--- a/qucs-core/src/components/devices/eqndefined.h
+++ b/qucs-core/src/components/devices/eqndefined.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __EQNDEFINED_H__
-#define __EQNDEFINED_H__
+#ifndef EQNDEFINED_H
+#define EQNDEFINED_H
 
 class eqndefined : public qucs::circuit
 {
@@ -64,4 +64,4 @@ class eqndefined : public qucs::circuit
   bool doHB;
 };
 
-#endif /* __EQNDEFINED_H__ */
+#endif /* EQNDEFINED_H */

--- a/qucs-core/src/components/devices/jfet.h
+++ b/qucs-core/src/components/devices/jfet.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __JFET_H__
-#define __JFET_H__
+#ifndef JFET_H
+#define JFET_H
 
 class jfet : public qucs::circuit
 {
@@ -55,4 +55,4 @@ class jfet : public qucs::circuit
   qucs::circuit * rd;
 };
 
-#endif /* __JFET_H__ */
+#endif /* JFET_H */

--- a/qucs-core/src/components/devices/mosfet.h
+++ b/qucs-core/src/components/devices/mosfet.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MOSFET_H__
-#define __MOSFET_H__
+#ifndef MOSFET_H
+#define MOSFET_H
 
 class mosfet : public qucs::circuit
 {
@@ -62,4 +62,4 @@ class mosfet : public qucs::circuit
   qucs::circuit * rg;
 };
 
-#endif /* __MOSFET_H__ */
+#endif /* MOSFET_H */

--- a/qucs-core/src/components/devices/thyristor.h
+++ b/qucs-core/src/components/devices/thyristor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __THYRISTOR_H__
-#define __THYRISTOR_H__
+#ifndef THYRISTOR_H
+#define THYRISTOR_H
 
 #include "devstates.h"
 
@@ -52,4 +52,4 @@ class thyristor : public qucs::circuit, public qucs::devstates
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __THYRISTOR_H__ */
+#endif /* THYRISTOR_H */

--- a/qucs-core/src/components/devices/triac.h
+++ b/qucs-core/src/components/devices/triac.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TRIAC_H__
-#define __TRIAC_H__
+#ifndef TRIAC_H
+#define TRIAC_H
 
 #include "devstates.h"
 
@@ -52,4 +52,4 @@ class triac : public qucs::circuit, public qucs::devstates
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __TRIAC_H__ */
+#endif /* TRIAC_H */

--- a/qucs-core/src/components/devices/tunneldiode.h
+++ b/qucs-core/src/components/devices/tunneldiode.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TUNNELDIODE_H__
-#define __TUNNELDIODE_H__
+#ifndef TUNNELDIODE_H
+#define TUNNELDIODE_H
 
 class tunneldiode : public qucs::circuit
 {
@@ -49,4 +49,4 @@ class tunneldiode : public qucs::circuit
   void calcId (nr_double_t, nr_double_t&, nr_double_t&);
 };
 
-#endif /* __TUNNELDIODE_H__ */
+#endif /* TUNNELDIODE_H */

--- a/qucs-core/src/components/digital/and.h
+++ b/qucs-core/src/components/digital/and.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __AND_H__
-#define __AND_H__
+#ifndef AND_H
+#define AND_H
 
 class logicand : public digital
 {
@@ -33,4 +33,4 @@ class logicand : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __AND_H__ */
+#endif /* AND_H */

--- a/qucs-core/src/components/digital/buffer.h
+++ b/qucs-core/src/components/digital/buffer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __BUFFER_H__
-#define __BUFFER_H__
+#ifndef BUFFER_H
+#define BUFFER_H
 
 class buffer : public digital
 {
@@ -33,4 +33,4 @@ class buffer : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __BUFFER_H__ */
+#endif /* BUFFER_H */

--- a/qucs-core/src/components/digital/digisource.h
+++ b/qucs-core/src/components/digital/digisource.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DIGISOURCE_H__
-#define __DIGISOURCE_H__
+#ifndef DIGISOURCE_H
+#define DIGISOURCE_H
 
 class digisource : public qucs::circuit
 {
@@ -39,4 +39,4 @@ class digisource : public qucs::circuit
   nr_double_t T;
 };
 
-#endif /* __DIGISOURCE_H__ */
+#endif /* DIGISOURCE_H */

--- a/qucs-core/src/components/digital/digital.h
+++ b/qucs-core/src/components/digital/digital.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DIGITAL_H__
-#define __DIGITAL_H__
+#ifndef DIGITAL_H
+#define DIGITAL_H
 
 class digital : public qucs::circuit
 {
@@ -60,4 +60,4 @@ class digital : public qucs::circuit
   void freeDigital (void);
 };
 
-#endif /* __DIGITAL_H__ */
+#endif /* DIGITAL_H */

--- a/qucs-core/src/components/digital/inverter.h
+++ b/qucs-core/src/components/digital/inverter.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INVERTER_H__
-#define __INVERTER_H__
+#ifndef INVERTER_H
+#define INVERTER_H
 
 class inverter : public digital
 {
@@ -33,4 +33,4 @@ class inverter : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __INVERTER_H__ */
+#endif /* INVERTER_H */

--- a/qucs-core/src/components/digital/nand.h
+++ b/qucs-core/src/components/digital/nand.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NAND_H__
-#define __NAND_H__
+#ifndef NAND_H
+#define NAND_H
 
 class logicnand : public digital
 {
@@ -33,4 +33,4 @@ class logicnand : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __NAND_H__ */
+#endif /* NAND_H */

--- a/qucs-core/src/components/digital/nor.h
+++ b/qucs-core/src/components/digital/nor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NOR_H__
-#define __NOR_H__
+#ifndef NOR_H
+#define NOR_H
 
 class logicnor : public digital
 {
@@ -33,4 +33,4 @@ class logicnor : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __NOR_H__ */
+#endif /* NOR_H */

--- a/qucs-core/src/components/digital/or.h
+++ b/qucs-core/src/components/digital/or.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __OR_H__
-#define __OR_H__
+#ifndef OR_H
+#define OR_H
 
 class logicor : public digital
 {
@@ -33,4 +33,4 @@ class logicor : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __OR_H__ */
+#endif /* OR_H */

--- a/qucs-core/src/components/digital/xnor.h
+++ b/qucs-core/src/components/digital/xnor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __XNOR_H__
-#define __XNOR_H__
+#ifndef XNOR_H
+#define XNOR_H
 
 class logicxnor : public digital
 {
@@ -33,4 +33,4 @@ class logicxnor : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __XNOR_H__ */
+#endif /* XNOR_H */

--- a/qucs-core/src/components/digital/xor.h
+++ b/qucs-core/src/components/digital/xor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __XOR_H__
-#define __XOR_H__
+#ifndef XOR_H
+#define XOR_H
 
 class logicxor : public digital
 {
@@ -33,4 +33,4 @@ class logicxor : public digital
   void calcDerivatives (void);
 };
 
-#endif /* __XOR_H__ */
+#endif /* XOR_H */

--- a/qucs-core/src/components/ecvs.h
+++ b/qucs-core/src/components/ecvs.h
@@ -31,8 +31,8 @@
   * \ingroup QucsInterface
   */
 
-#ifndef __ECVS_H__
-#define __ECVS_H__
+#ifndef ECVS_H
+#define ECVS_H
 
 class ecvs : public qucs::circuit
 {
@@ -48,4 +48,4 @@ class ecvs : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __ECVS_H__ */
+#endif /* ECVS_H */

--- a/qucs-core/src/components/ground.h
+++ b/qucs-core/src/components/ground.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __GROUND_H__
-#define __GROUND_H__
+#ifndef GROUND_H
+#define GROUND_H
 
 class ground : public qucs::circuit
 {
@@ -32,4 +32,4 @@ class ground : public qucs::circuit
   void initSP (void);
 };
 
-#endif /* __GROUND_H__ */
+#endif /* GROUND_H */

--- a/qucs-core/src/components/gyrator.h
+++ b/qucs-core/src/components/gyrator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __GYRATOR_H__
-#define __GYRATOR_H__
+#ifndef GYRATOR_H
+#define GYRATOR_H
 
 class gyrator : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class gyrator : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __GYRATOR_H__ */
+#endif /* GYRATOR_H */

--- a/qucs-core/src/components/hybrid.h
+++ b/qucs-core/src/components/hybrid.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __HYBRID_H__
-#define __HYBRID_H__
+#ifndef HYBRID_H
+#define HYBRID_H
 
 class hybrid : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class hybrid : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __HYBRID_H__ */
+#endif /* HYBRID_H */

--- a/qucs-core/src/components/iac.h
+++ b/qucs-core/src/components/iac.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IAC_H__
-#define __IAC_H__
+#ifndef IAC_H
+#define IAC_H
 
 class iac : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class iac : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __IAC_H__ */
+#endif /* IAC_H */

--- a/qucs-core/src/components/idc.h
+++ b/qucs-core/src/components/idc.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IDC_H__
-#define __IDC_H__
+#ifndef IDC_H
+#define IDC_H
 
 class idc : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class idc : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __IDC_H__ */
+#endif /* IDC_H */

--- a/qucs-core/src/components/iexp.h
+++ b/qucs-core/src/components/iexp.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __IEXP_H__
-#define __IEXP_H__
+#ifndef IEXP_H
+#define IEXP_H
 
 class iexp : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class iexp : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __IEXP_H__ */
+#endif /* IEXP_H */

--- a/qucs-core/src/components/ifile.h
+++ b/qucs-core/src/components/ifile.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IFILE_H__
-#define __IFILE_H__
+#ifndef IFILE_H
+#define IFILE_H
 
 namespace qucs {
   class dataset;
@@ -49,4 +49,4 @@ private:
   qucs::interpolator * inter;
 };
 
-#endif /* __IFILE_H__ */
+#endif /* IFILE_H */

--- a/qucs-core/src/components/iinoise.h
+++ b/qucs-core/src/components/iinoise.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IINOISE_H__
-#define __IINOISE_H__
+#ifndef IINOISE_H
+#define IINOISE_H
 
 class iinoise : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class iinoise : public qucs::circuit
   qucs::matrix calcMatrixCy (nr_double_t);
 };
 
-#endif /* __IINOISE_H__ */
+#endif /* IINOISE_H */

--- a/qucs-core/src/components/inductor.h
+++ b/qucs-core/src/components/inductor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INDUCTOR_H__
-#define __INDUCTOR_H__
+#ifndef INDUCTOR_H
+#define INDUCTOR_H
 
 class inductor : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class inductor : public qucs::circuit
   void calcHB (nr_double_t);
 };
 
-#endif /* __INDUCTOR_H__ */
+#endif /* INDUCTOR_H */

--- a/qucs-core/src/components/inoise.h
+++ b/qucs-core/src/components/inoise.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INOISE_H__
-#define __INOISE_H__
+#ifndef INOISE_H
+#define INOISE_H
 
 class inoise : public qucs::circuit
 {
@@ -34,4 +34,4 @@ class inoise : public qucs::circuit
   void calcNoiseAC (nr_double_t);
 };
 
-#endif /* __INOISE_H__ */
+#endif /* INOISE_H */

--- a/qucs-core/src/components/iprobe.h
+++ b/qucs-core/src/components/iprobe.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IPROBE_H__
-#define __IPROBE_H__
+#ifndef IPROBE_H
+#define IPROBE_H
 
 class iprobe : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class iprobe : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __IPROBE_H__ */
+#endif /* IPROBE_H */

--- a/qucs-core/src/components/ipulse.h
+++ b/qucs-core/src/components/ipulse.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IPULSE_H__
-#define __IPULSE_H__
+#ifndef IPULSE_H
+#define IPULSE_H
 
 class ipulse : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class ipulse : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __IPULSE_H__ */
+#endif /* IPULSE_H */

--- a/qucs-core/src/components/irect.h
+++ b/qucs-core/src/components/irect.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IRECT_H__
-#define __IRECT_H__
+#ifndef IRECT_H
+#define IRECT_H
 
 class irect : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class irect : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __IRECT_H__ */
+#endif /* IRECT_H */

--- a/qucs-core/src/components/isolator.h
+++ b/qucs-core/src/components/isolator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __ISOLATOR_H__
-#define __ISOLATOR_H__
+#ifndef ISOLATOR_H
+#define ISOLATOR_H
 
 class isolator : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class isolator : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __ISOLATOR_H__ */
+#endif /* ISOLATOR_H */

--- a/qucs-core/src/components/itrafo.h
+++ b/qucs-core/src/components/itrafo.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __ITRAFO_H__
-#define __ITRAFO_H__
+#ifndef ITRAFO_H
+#define ITRAFO_H
 
 class itrafo : public qucs::circuit
 {
@@ -32,4 +32,4 @@ class itrafo : public qucs::circuit
   void initSP (void);
 };
 
-#endif /* __ITRAFO_H__ */
+#endif /* ITRAFO_H */

--- a/qucs-core/src/components/ivnoise.h
+++ b/qucs-core/src/components/ivnoise.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __IVNOISE_H__
-#define __IVNOISE_H__
+#ifndef IVNOISE_H
+#define IVNOISE_H
 
 class ivnoise : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class ivnoise : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __IVNOISE_H__ */
+#endif /* IVNOISE_H */

--- a/qucs-core/src/components/microstrip/bondwire.h
+++ b/qucs-core/src/components/microstrip/bondwire.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __BONDWIRE_H__
-#define __BONDWIRE_H__
+#ifndef BONDWIRE_H
+#define BONDWIRE_H
 
 
 class bondwire : public qucs::circuit
@@ -57,4 +57,4 @@ class bondwire : public qucs::circuit
   nr_double_t temp;  /*!< ambient temperature */
 };
 
-#endif /* __BONDWIRE_H__ */
+#endif /* BONDWIRE_H */

--- a/qucs-core/src/components/microstrip/cpwgap.h
+++ b/qucs-core/src/components/microstrip/cpwgap.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CPWGAP_H__
-#define __CPWGAP_H__
+#ifndef CPWGAP_H
+#define CPWGAP_H
 
 class cpwgap : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class cpwgap : public qucs::circuit
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __CPWGAP_H__ */
+#endif /* CPWGAP_H */

--- a/qucs-core/src/components/microstrip/cpwline.h
+++ b/qucs-core/src/components/microstrip/cpwline.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __CPWLINE_H__
-#define __CPWLINE_H__
+#ifndef CPWLINE_H
+#define CPWLINE_H
 
 class cpwline : public qucs::circuit
 {
@@ -68,4 +68,4 @@ class cpwline : public qucs::circuit
   nr_double_t Zl, Er;
 };
 
-#endif /* __CPWLINE_H__ */
+#endif /* CPWLINE_H */

--- a/qucs-core/src/components/microstrip/cpwopen.h
+++ b/qucs-core/src/components/microstrip/cpwopen.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CPWOPEN_H__
-#define __CPWOPEN_H__
+#ifndef CPWOPEN_H
+#define CPWOPEN_H
 
 class cpwopen : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class cpwopen : public qucs::circuit
   nr_complex_t calcY (nr_double_t);
 };
 
-#endif /* __CPWOPEN_H__ */
+#endif /* CPWOPEN_H */

--- a/qucs-core/src/components/microstrip/cpwshort.h
+++ b/qucs-core/src/components/microstrip/cpwshort.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CPWSHORT_H__
-#define __CPWSHORT_H__
+#ifndef CPWSHORT_H
+#define CPWSHORT_H
 
 class cpwshort : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class cpwshort : public qucs::circuit
   nr_complex_t calcZ (nr_double_t);
 };
 
-#endif /* __CPWSHORT_H__ */
+#endif /* CPWSHORT_H */

--- a/qucs-core/src/components/microstrip/cpwstep.h
+++ b/qucs-core/src/components/microstrip/cpwstep.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CPWSTEP_H__
-#define __CPWSTEP_H__
+#ifndef CPWSTEP_H
+#define CPWSTEP_H
 
 class cpwstep : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class cpwstep : public qucs::circuit
   nr_complex_t calcY (nr_double_t);
 };
 
-#endif /* __CPWSTEP_H__ */
+#endif /* CPWSTEP_H */

--- a/qucs-core/src/components/microstrip/mscorner.h
+++ b/qucs-core/src/components/microstrip/mscorner.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __MSCORNER_H__
-#define __MSCORNER_H__
+#ifndef MSCORNER_H
+#define MSCORNER_H
 
 class mscorner : public qucs::circuit
 {
@@ -42,4 +42,4 @@ class mscorner : public qucs::circuit
   nr_double_t L, C, h;
 };
 
-#endif /* __MSCORNER_H__ */
+#endif /* MSCORNER_H */

--- a/qucs-core/src/components/microstrip/mscoupled.h
+++ b/qucs-core/src/components/microstrip/mscoupled.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSCOUPLED_H__
-#define __MSCOUPLED_H__
+#ifndef MSCOUPLED_H
+#define MSCOUPLED_H
 
 class mscoupled : public qucs::circuit
 {
@@ -52,4 +52,4 @@ class mscoupled : public qucs::circuit
   nr_double_t ae, be, ze, ao, bo, zo, ee, eo;
 };
 
-#endif /* __MSCOUPLED_H__ */
+#endif /* MSCOUPLED_H */

--- a/qucs-core/src/components/microstrip/mscross.h
+++ b/qucs-core/src/components/microstrip/mscross.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSCROSS_H__
-#define __MSCROSS_H__
+#ifndef MSCROSS_H
+#define MSCROSS_H
 
 class mscross : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class mscross : public qucs::circuit
   nr_double_t calcInd (nr_double_t, nr_double_t, nr_double_t);
 };
 
-#endif /* __MSCROSS_H__ */
+#endif /* MSCROSS_H */

--- a/qucs-core/src/components/microstrip/msgap.h
+++ b/qucs-core/src/components/microstrip/msgap.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __MSGAP_H__
-#define __MSGAP_H__
+#ifndef MSGAP_H
+#define MSGAP_H
 
 class msgap : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class msgap : public qucs::circuit
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __MSGAP_H__ */
+#endif /* MSGAP_H */

--- a/qucs-core/src/components/microstrip/mslange.h
+++ b/qucs-core/src/components/microstrip/mslange.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSLANGE_H__
-#define __MSLANGE_H__
+#ifndef MSLANGE_H
+#define MSLANGE_H
 
 class mslange : public qucs::circuit
 {
@@ -52,4 +52,4 @@ class mslange : public qucs::circuit
   nr_double_t ae, be, ze, ao, bo, zo, ee, eo;
 };
 
-#endif /* __MSLANGE_H__ */
+#endif /* MSLANGE_H */

--- a/qucs-core/src/components/microstrip/msline.h
+++ b/qucs-core/src/components/microstrip/msline.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSLINE_H__
-#define __MSLINE_H__
+#ifndef MSLINE_H
+#define MSLINE_H
 
 class msline : public qucs::circuit
 {
@@ -66,4 +66,4 @@ class msline : public qucs::circuit
   nr_double_t alpha, beta, zl, ereff;
 };
 
-#endif /* __MSLINE_H__ */
+#endif /* MSLINE_H */

--- a/qucs-core/src/components/microstrip/msmbend.h
+++ b/qucs-core/src/components/microstrip/msmbend.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __MSMBEND_H__
-#define __MSMBEND_H__
+#ifndef MSMBEND_H
+#define MSMBEND_H
 
 class msmbend : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class msmbend : public qucs::circuit
   qucs::matrix calcMatrixZ (nr_double_t);
 };
 
-#endif /* __MSMBEND_H__ */
+#endif /* MSMBEND_H */

--- a/qucs-core/src/components/microstrip/msopen.h
+++ b/qucs-core/src/components/microstrip/msopen.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __MSOPEN_H__
-#define __MSOPEN_H__
+#ifndef MSOPEN_H
+#define MSOPEN_H
 
 class msopen : public qucs::circuit
 {
@@ -39,4 +39,4 @@ class msopen : public qucs::circuit
   nr_complex_t calcY (nr_double_t);
 };
 
-#endif /* __MSOPEN_H__ */
+#endif /* MSOPEN_H */

--- a/qucs-core/src/components/microstrip/msrstub.h
+++ b/qucs-core/src/components/microstrip/msrstub.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSRSTUB_H__
-#define __MSRSTUB_H__
+#ifndef MSRSTUB_H
+#define MSRSTUB_H
 
 class msrstub : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class msrstub : public qucs::circuit
   nr_complex_t calcZ (nr_double_t);
 };
 
-#endif /* __MSRSTUB_H__ */
+#endif /* MSRSTUB_H */

--- a/qucs-core/src/components/microstrip/msstep.h
+++ b/qucs-core/src/components/microstrip/msstep.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __MSSTEP_H__
-#define __MSSTEP_H__
+#ifndef MSSTEP_H
+#define MSSTEP_H
 
 class msstep : public qucs::circuit
 {
@@ -38,4 +38,4 @@ class msstep : public qucs::circuit
   qucs::matrix calcMatrixZ (nr_double_t);
 };
 
-#endif /* __MSSTEP_H__ */
+#endif /* MSSTEP_H */

--- a/qucs-core/src/components/microstrip/mstee.h
+++ b/qucs-core/src/components/microstrip/mstee.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSTEE_H__
-#define __MSTEE_H__
+#ifndef MSTEE_H
+#define MSTEE_H
 
 namespace qucs {
   class circuit;
@@ -58,4 +58,4 @@ class mstee : public qucs::circuit
   qucs::circuit * line2;
 };
 
-#endif /* __MSTEE_H__ */
+#endif /* MSTEE_H */

--- a/qucs-core/src/components/microstrip/msvia.h
+++ b/qucs-core/src/components/microstrip/msvia.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MSVIA_H__
-#define __MSVIA_H__
+#ifndef MSVIA_H
+#define MSVIA_H
 
 class msvia : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class msvia : public qucs::circuit
   nr_complex_t Z;
 };
 
-#endif /* __MSVIA_H__ */
+#endif /* MSVIA_H */

--- a/qucs-core/src/components/microstrip/substrate.h
+++ b/qucs-core/src/components/microstrip/substrate.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SUBSTRATE_H__
-#define __SUBSTRATE_H__
+#ifndef SUBSTRATE_H
+#define SUBSTRATE_H
 
 #include "object.h"
 
@@ -39,4 +39,4 @@ class substrate : public qucs::object
 
 } // namespace qucs
 
-#endif /* __SUBSTRATE_H__ */
+#endif /* SUBSTRATE_H */

--- a/qucs-core/src/components/mutual.h
+++ b/qucs-core/src/components/mutual.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MUTUAL_H__
-#define __MUTUAL_H__
+#ifndef MUTUAL_H
+#define MUTUAL_H
 
 class mutual : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class mutual : public qucs::circuit
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __MUTUAL_H__ */
+#endif /* MUTUAL_H */

--- a/qucs-core/src/components/mutual2.h
+++ b/qucs-core/src/components/mutual2.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MUTUAL2_H__
-#define __MUTUAL2_H__
+#ifndef MUTUAL2_H
+#define MUTUAL2_H
 
 class mutual2 : public qucs::circuit
 {
@@ -40,4 +40,4 @@ class mutual2 : public qucs::circuit
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __MUTUAL2_H__ */
+#endif /* MUTUAL2_H */

--- a/qucs-core/src/components/mutualx.h
+++ b/qucs-core/src/components/mutualx.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MUTUALX_H__
-#define __MUTUALX_H__
+#ifndef MUTUALX_H
+#define MUTUALX_H
 
 class mutualx : public qucs::circuit
 {
@@ -41,4 +41,4 @@ class mutualx : public qucs::circuit
   qucs::matrix calcMatrixY (nr_double_t);
 };
 
-#endif /* __MUTUALX_H__ */
+#endif /* MUTUALX_H */

--- a/qucs-core/src/components/opamp.h
+++ b/qucs-core/src/components/opamp.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __OPAMP_H__
-#define __OPAMP_H__
+#ifndef OPAMP_H
+#define OPAMP_H
 
 class opamp : public qucs::circuit
 {
@@ -41,4 +41,4 @@ class opamp : public qucs::circuit
   nr_double_t gv;
 };
 
-#endif /* __OPAMP_H__ */
+#endif /* OPAMP_H */

--- a/qucs-core/src/components/open.h
+++ b/qucs-core/src/components/open.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __OPEN_H__
-#define __OPEN_H__
+#ifndef OPEN_H
+#define OPEN_H
 
 class open : public qucs::circuit
 {
@@ -32,4 +32,4 @@ class open : public qucs::circuit
   void initSP (void);
 };
 
-#endif /* __OPEN_H__ */
+#endif /* OPEN_H */

--- a/qucs-core/src/components/pac.h
+++ b/qucs-core/src/components/pac.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PAC_H__
-#define __PAC_H__
+#ifndef PAC_H
+#define PAC_H
 
 class pac : public qucs::circuit
 {
@@ -39,4 +39,4 @@ class pac : public qucs::circuit
   void calcHB (nr_double_t);
 };
 
-#endif /* __PAC_H__ */
+#endif /* PAC_H */

--- a/qucs-core/src/components/phaseshifter.h
+++ b/qucs-core/src/components/phaseshifter.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PHASESHIFTER_H__
-#define __PHASESHIFTER_H__
+#ifndef PHASESHIFTER_H
+#define PHASESHIFTER_H
 
 class phaseshifter : public qucs::circuit
 {
@@ -34,4 +34,4 @@ class phaseshifter : public qucs::circuit
   void initAC (void);
 };
 
-#endif /* __PHASESHIFTER_H__ */
+#endif /* PHASESHIFTER_H */

--- a/qucs-core/src/components/rectline.h
+++ b/qucs-core/src/components/rectline.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __RECTLINE_H__
-#define __RECTLINE_H__
+#ifndef RECTLINE_H
+#define RECTLINE_H
 
 /*! A TE10 rectangular waveguide component
     \note Evanecent mode are not implemented
@@ -59,4 +59,4 @@ class rectline : public qucs::circuit
   nr_double_t rho;
 };
 
-#endif /* __RECTLINE_H__ */
+#endif /* RECTLINE_H */

--- a/qucs-core/src/components/relais.h
+++ b/qucs-core/src/components/relais.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __RELAIS_H__
-#define __RELAIS_H__
+#ifndef RELAIS_H
+#define RELAIS_H
 
 class relais : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class relais : public qucs::circuit
   nr_double_t r;
 };
 
-#endif /* __RELAIS_H__ */
+#endif /* RELAIS_H */

--- a/qucs-core/src/components/resistor.h
+++ b/qucs-core/src/components/resistor.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __RESISTOR_H__
-#define __RESISTOR_H__
+#ifndef RESISTOR_H
+#define RESISTOR_H
 
 class resistor : public qucs::circuit
 {
@@ -45,4 +45,4 @@ class resistor : public qucs::circuit
   void initModel (void);
 };
 
-#endif /* __RESISTOR_H__ */
+#endif /* RESISTOR_H */

--- a/qucs-core/src/components/rfedd.h
+++ b/qucs-core/src/components/rfedd.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __RFEDD_H__
-#define __RFEDD_H__
+#ifndef RFEDD_H
+#define RFEDD_H
 
 class rfedd : public qucs::circuit
 {
@@ -58,4 +58,4 @@ class rfedd : public qucs::circuit
   void * feqn;
 };
 
-#endif /* __RFEDD_H__ */
+#endif /* RFEDD_H */

--- a/qucs-core/src/components/rlcg.h
+++ b/qucs-core/src/components/rlcg.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __RLCG_H__
-#define __RLCG_H__
+#ifndef RLCG_H
+#define RLCG_H
 
 class rlcg : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class rlcg : public qucs::circuit
   nr_complex_t z;
 };
 
-#endif /* __RLCG_H__ */
+#endif /* RLCG_H */

--- a/qucs-core/src/components/short.h
+++ b/qucs-core/src/components/short.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SHORT_H__
-#define __SHORT_H__
+#ifndef SHORT_H
+#define SHORT_H
 
 class ashort : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class ashort : public qucs::circuit
   void initHB (void);
 };
 
-#endif /* __SHORT_H__ */
+#endif /* SHORT_H */

--- a/qucs-core/src/components/spfile.h
+++ b/qucs-core/src/components/spfile.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SPFILE_H__
-#define __SPFILE_H__
+#ifndef SPFILE_H
+#define SPFILE_H
 
 namespace qucs {
   class vector;
@@ -90,4 +90,4 @@ class spfile : public qucs::circuit
   int  interpolType;
 };
 
-#endif /* __SPFILE_H__ */
+#endif /* SPFILE_H */

--- a/qucs-core/src/components/strafo.h
+++ b/qucs-core/src/components/strafo.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __STRAFO_H__
-#define __STRAFO_H__
+#ifndef STRAFO_H
+#define STRAFO_H
 
 class strafo : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class strafo : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __STRAFO_H__ */
+#endif /* STRAFO_H */

--- a/qucs-core/src/components/tee.h
+++ b/qucs-core/src/components/tee.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TEE_H__
-#define __TEE_H__
+#ifndef TEE_H
+#define TEE_H
 
 class tee : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class tee : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __TEE_H__ */
+#endif /* TEE_H */

--- a/qucs-core/src/components/tline.h
+++ b/qucs-core/src/components/tline.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TLINE_H__
-#define __TLINE_H__
+#ifndef TLINE_H
+#define TLINE_H
 
 class tline : public qucs::circuit
 {
@@ -39,4 +39,4 @@ class tline : public qucs::circuit
   void calcNoiseSP (nr_double_t);
 };
 
-#endif /* __TLINE_H__ */
+#endif /* TLINE_H */

--- a/qucs-core/src/components/tline4p.h
+++ b/qucs-core/src/components/tline4p.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TLINE4P_H__
-#define __TLINE4P_H__
+#ifndef TLINE4P_H
+#define TLINE4P_H
 
 class tline4p : public qucs::circuit
 {
@@ -39,4 +39,4 @@ class tline4p : public qucs::circuit
   void calcNoiseSP (nr_double_t);
 };
 
-#endif /* __TLINE4P_H__ */
+#endif /* TLINE4P_H */

--- a/qucs-core/src/components/trafo.h
+++ b/qucs-core/src/components/trafo.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TRAFO_H__
-#define __TRAFO_H__
+#ifndef TRAFO_H
+#define TRAFO_H
 
 class trafo : public qucs::circuit
 {
@@ -35,4 +35,4 @@ class trafo : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __TRAFO_H__ */
+#endif /* TRAFO_H */

--- a/qucs-core/src/components/tswitch.h
+++ b/qucs-core/src/components/tswitch.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TSWITCH_H__
-#define __TSWITCH_H__
+#ifndef TSWITCH_H
+#define TSWITCH_H
 
 class tswitch : public qucs::circuit
 {
@@ -44,4 +44,4 @@ class tswitch : public qucs::circuit
   bool repeat;
 };
 
-#endif /* __TSWITCH_H__ */
+#endif /* TSWITCH_H */

--- a/qucs-core/src/components/twistedpair.h
+++ b/qucs-core/src/components/twistedpair.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TWISTEDPAIR_H__
-#define __TWISTEDPAIR_H__
+#ifndef TWISTEDPAIR_H
+#define TWISTEDPAIR_H
 
 class twistedpair : public qucs::circuit
 {
@@ -48,4 +48,4 @@ class twistedpair : public qucs::circuit
   nr_double_t zl, ereff, alpha, beta, len, angle;
 };
 
-#endif /* __TWISTEDPAIR_H__ */
+#endif /* TWISTEDPAIR_H */

--- a/qucs-core/src/components/vac.h
+++ b/qucs-core/src/components/vac.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VAC_H__
-#define __VAC_H__
+#ifndef VAC_H
+#define VAC_H
 
 class vac : public qucs::circuit
 {
@@ -38,4 +38,4 @@ class vac : public qucs::circuit
   void calcHB (nr_double_t);
 };
 
-#endif /* __VAC_H__ */
+#endif /* VAC_H */

--- a/qucs-core/src/components/vam.h
+++ b/qucs-core/src/components/vam.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VAM_H__
-#define __VAM_H__
+#ifndef VAM_H
+#define VAM_H
 
 class vam : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class vam : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VAM_H__ */
+#endif /* VAM_H */

--- a/qucs-core/src/components/vccs.h
+++ b/qucs-core/src/components/vccs.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VCCS_H__
-#define __VCCS_H__
+#ifndef VCCS_H
+#define VCCS_H
 
 class vccs : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class vccs : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VCCS_H__ */
+#endif /* VCCS_H */

--- a/qucs-core/src/components/vcvs.h
+++ b/qucs-core/src/components/vcvs.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VCVS_H__
-#define __VCVS_H__
+#ifndef VCVS_H
+#define VCVS_H
 
 class vcvs : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class vcvs : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VCVS_H__ */
+#endif /* VCVS_H */

--- a/qucs-core/src/components/vdc.h
+++ b/qucs-core/src/components/vdc.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VDC_H__
-#define __VDC_H__
+#ifndef VDC_H
+#define VDC_H
 
 class vdc : public qucs::circuit
 {
@@ -38,4 +38,4 @@ class vdc : public qucs::circuit
   void calcHB (nr_double_t);
 };
 
-#endif /* __VDC_H__ */
+#endif /* VDC_H */

--- a/qucs-core/src/components/verilog/analogfunction.xml
+++ b/qucs-core/src/components/verilog/analogfunction.xml
@@ -1105,12 +1105,12 @@ double $(module)_d_$(function) (<admst:join select="variable[input='yes']" separ
  *
  */
 
-#ifndef __$(module)_ANALOGFUNCTION_H__
-#define __$(module)_ANALOGFUNCTION_H__
+#ifndef $(module)_ANALOGFUNCTION_H
+#define $(module)_ANALOGFUNCTION_H
 
 <admst:text format="\n"/>
 <admst:apply-templates select="/module" match="analogfunctionH"/>
-#endif /* __$(module)_ANALOGFUNCTION_H__ */
+#endif /* $(module)_ANALOGFUNCTION_H */
 <admst:text format="\n"/>
 </admst:open>
 <admst:message format="$(filename).$(module).analogfunction.h created\n"/>

--- a/qucs-core/src/components/verilog/analogfunction.xml
+++ b/qucs-core/src/components/verilog/analogfunction.xml
@@ -38,6 +38,7 @@
 
 <admst:for-each select="/module">
 <!-- definition of variables -->
+<admst:variable name="MODULE" path="upper-case(/module)"/>
 <admst:value-of select="name"/>
 <admst:variable name="module" select="%s"/>
 </admst:for-each>
@@ -1105,12 +1106,12 @@ double $(module)_d_$(function) (<admst:join select="variable[input='yes']" separ
  *
  */
 
-#ifndef $(module)_ANALOGFUNCTION_H
-#define $(module)_ANALOGFUNCTION_H
+#ifndef $(MODULE)_ANALOGFUNCTION_H
+#define $(MODULE)_ANALOGFUNCTION_H
 
 <admst:text format="\n"/>
 <admst:apply-templates select="/module" match="analogfunctionH"/>
-#endif /* $(module)_ANALOGFUNCTION_H */
+#endif /* $(MODULE)_ANALOGFUNCTION_H */
 <admst:text format="\n"/>
 </admst:open>
 <admst:message format="$(filename).$(module).analogfunction.h created\n"/>

--- a/qucs-core/src/components/verilog/qucsMODULEcore.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEcore.xml
@@ -786,8 +786,9 @@ using qucs::matrix;
  */
 
 <admst:for-each select="/module">
-#ifndef $(module)_H
-#define $(module)_H
+<admst:variable name="MODULE" path="upper-case(/module)"/>
+#ifndef $(MODULE)_H
+#define $(MODULE)_H
 
 class $(module) : public qucs::circuit
 {
@@ -914,7 +915,7 @@ class $(module) : public qucs::circuit
 <admst:text format="\n"/>
 };
 
-#endif /* $(module)_H */
+#endif /* $(MODULE)_H */
 
 </admst:for-each>
 

--- a/qucs-core/src/components/verilog/qucsMODULEcore.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEcore.xml
@@ -786,8 +786,8 @@ using qucs::matrix;
  */
 
 <admst:for-each select="/module">
-#ifndef __$(module)_H__
-#define __$(module)_H__
+#ifndef $(module)_H
+#define $(module)_H
 
 class $(module) : public qucs::circuit
 {
@@ -914,7 +914,7 @@ class $(module) : public qucs::circuit
 <admst:text format="\n"/>
 };
 
-#endif /* __$(module)_H__ */
+#endif /* $(module)_H */
 
 </admst:for-each>
 

--- a/qucs-core/src/components/verilog/qucsMODULEdefs.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEdefs.xml
@@ -284,8 +284,8 @@
  *
  */
 
-#ifndef __$(module)_DEFS_H__
-#define __$(module)_DEFS_H__
+#ifndef $(module)_DEFS_H
+#define $(module)_DEFS_H
 
 
 <!-- find temp and tnom parameters -->
@@ -345,7 +345,7 @@ struct define_t $module::cirdef =
   { &quot;$module&quot;,
     $nbr_nodes, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_NONLINEAR, PROP_DEF };
 
-#endif /* __$(module)_DEFS_H__ */
+#endif /* $(module)_DEFS_H */
 
 </admst:for-each>
 

--- a/qucs-core/src/components/verilog/qucsMODULEdefs.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEdefs.xml
@@ -230,6 +230,7 @@
 <!-- handling of device: starting point -->
 <admst:for-each select="/module">
 <!-- definition of variables -->
+<admst:variable name="MODULE" path="upper-case(/module)"/>
 <admst:value-of select="name"/>
 <admst:variable name="module" select="%s"/>
 <admst:count select="node[location='external' and name!='GND']"/>
@@ -284,8 +285,8 @@
  *
  */
 
-#ifndef $(module)_DEFS_H
-#define $(module)_DEFS_H
+#ifndef $(MODULE)_DEFS_H
+#define $(MODULE)_DEFS_H
 
 
 <!-- find temp and tnom parameters -->
@@ -345,7 +346,7 @@ struct define_t $module::cirdef =
   { &quot;$module&quot;,
     $nbr_nodes, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_NONLINEAR, PROP_DEF };
 
-#endif /* $(module)_DEFS_H */
+#endif /* $(MODULE)_DEFS_H */
 
 </admst:for-each>
 

--- a/qucs-core/src/components/verilog/qucsMODULEgui.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEgui.xml
@@ -72,6 +72,7 @@
 <!-- handling of device: starting point -->
 <admst:for-each select="/module">
 <!-- definition of variables -->
+<admst:variable name="MODULE" path="upper-case(/module)"/>
 <admst:value-of select="name"/>
 <admst:variable name="module" select="%s"/>
 <admst:count select="node"/>
@@ -349,8 +350,8 @@
  */
 
 <admst:text format="\n"/>
-<admst:text format="#ifndef $module"/>_H\n
-<admst:text format="#define $module"/>_H\n\n
+<admst:text format="#ifndef $MODULE"/>_H\n
+<admst:text format="#define $MODULE"/>_H\n\n
 <admst:text format="#include &quot;component.h&quot;\n\n"/>
 
 <admst:choose>
@@ -369,7 +370,7 @@
 </admst:if>
 <admst:text format="  protected:\n    void createSymbol();\n};\n\n"/>
 
-<admst:text format="#endif /* $(module)_H */\n"/>
+<admst:text format="#endif /* $(MODULE)_H */\n"/>
 
 </admst:open>
 <admst:message format="$module.gui.cpp and $module.gui.h: files created\n"/>

--- a/qucs-core/src/components/vexp.h
+++ b/qucs-core/src/components/vexp.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __VEXP_H__
-#define __VEXP_H__
+#ifndef VEXP_H
+#define VEXP_H
 
 class vexp : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class vexp : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VEXP_H__ */
+#endif /* VEXP_H */

--- a/qucs-core/src/components/vfile.h
+++ b/qucs-core/src/components/vfile.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __VFILE_H__
-#define __VFILE_H__
+#ifndef VFILE_H
+#define VFILE_H
 
 namespace qucs {
   class dataset;
@@ -50,4 +50,4 @@ private:
   qucs::interpolator * inter;
 };
 
-#endif /* __VFILE_H__ */
+#endif /* VFILE_H */

--- a/qucs-core/src/components/vnoise.h
+++ b/qucs-core/src/components/vnoise.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VNOISE_H__
-#define __VNOISE_H__
+#ifndef VNOISE_H
+#define VNOISE_H
 
 class vnoise : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class vnoise : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __VNOISE_H__ */
+#endif /* VNOISE_H */

--- a/qucs-core/src/components/vpm.h
+++ b/qucs-core/src/components/vpm.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VPM_H__
-#define __VPM_H__
+#ifndef VPM_H
+#define VPM_H
 
 class vpm : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class vpm : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VPM_H__ */
+#endif /* VPM_H */

--- a/qucs-core/src/components/vprobe.h
+++ b/qucs-core/src/components/vprobe.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VPROBE_H__
-#define __VPROBE_H__
+#ifndef VPROBE_H
+#define VPROBE_H
 
 class vprobe : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class vprobe : public qucs::circuit
   void saveOperatingPoints (void);
 };
 
-#endif /* __VPROBE_H__ */
+#endif /* VPROBE_H */

--- a/qucs-core/src/components/vpulse.h
+++ b/qucs-core/src/components/vpulse.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VPULSE_H__
-#define __VPULSE_H__
+#ifndef VPULSE_H
+#define VPULSE_H
 
 class vpulse : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class vpulse : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VPULSE_H__ */
+#endif /* VPULSE_H */

--- a/qucs-core/src/components/vrect.h
+++ b/qucs-core/src/components/vrect.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VRECT_H__
-#define __VRECT_H__
+#ifndef VRECT_H
+#define VRECT_H
 
 class vrect : public qucs::circuit
 {
@@ -36,4 +36,4 @@ class vrect : public qucs::circuit
   void calcTR (nr_double_t);
 };
 
-#endif /* __VRECT_H__ */
+#endif /* VRECT_H */

--- a/qucs-core/src/components/vvnoise.h
+++ b/qucs-core/src/components/vvnoise.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VVNOISE_H__
-#define __VVNOISE_H__
+#ifndef VVNOISE_H
+#define VVNOISE_H
 
 class vvnoise : public qucs::circuit
 {
@@ -37,4 +37,4 @@ class vvnoise : public qucs::circuit
   void initTR (void);
 };
 
-#endif /* __VVNOISE_H__ */
+#endif /* VVNOISE_H */

--- a/qucs-core/src/constants.h
+++ b/qucs-core/src/constants.h
@@ -30,8 +30,8 @@
    @defgroup qucsPhysConstants Qucs Physical Constants
 */
 
-#ifndef __CONSTANTS_H__
-#define __CONSTANTS_H__
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
 
 #include "consts.h"
 #include "precision.h"
@@ -108,4 +108,4 @@ static const double GMin = NR_TINY;
 
 } // namespace qucs
 
-#endif /* __CONSTANTS_H__ */
+#endif /* CONSTANTS_H */

--- a/qucs-core/src/consts.h
+++ b/qucs-core/src/consts.h
@@ -30,8 +30,8 @@
  @defgroup qucsMathConstants Qucs Math Constants
 */
 
-#ifndef __CONSTS_H__
-#define __CONSTS_H__
+#ifndef CONSTS_H
+#define CONSTS_H
 
 #include <cmath>
 
@@ -91,4 +91,4 @@ static const double limitexp = 80.0;
 
 } // namespace qucs
 
-#endif /* __CONSTS_H__ */
+#endif /* CONSTS_H */

--- a/qucs-core/src/converter/check_spice.h
+++ b/qucs-core/src/converter/check_spice.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CHECK_SPICE_H__
-#define __CHECK_SPICE_H__
+#ifndef CHECK_SPICE_H
+#define CHECK_SPICE_H
 
 #include "netdefs.h"
 
@@ -65,4 +65,4 @@ extern int spice_errors;
 
 __END_DECLS
 
-#endif /* __CHECK_SPICE_H__ */
+#endif /* CHECK_SPICE_H */

--- a/qucs-core/src/converter/check_vcd.h
+++ b/qucs-core/src/converter/check_vcd.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __CHECK_VCD_H__
-#define __CHECK_VCD_H__
+#ifndef CHECK_VCD_H
+#define CHECK_VCD_H
 
 /* Externalize variables used by the scanner and parser. */
 extern int vcd_lineno;
@@ -185,4 +185,4 @@ struct dataset_variable {
   struct dataset_variable * next;
 };
 
-#endif /* __CHECK_VCD_H__ */
+#endif /* CHECK_VCD_H */

--- a/qucs-core/src/converter/csv_producer.h
+++ b/qucs-core/src/converter/csv_producer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __CSV_PRODUCER_H__
-#define __CSV_PRODUCER_H__
+#ifndef CSV_PRODUCER_H
+#define CSV_PRODUCER_H
 
 #include "logging.h"
 #include "strlist.h"
@@ -39,4 +39,4 @@ extern FILE * csv_out;
 /* Available functions of the producers. */
 void csv_producer (char * variable, const char * sep = ";");
 
-#endif /* __CSV_PRODUCER_H__ */
+#endif /* CSV_PRODUCER_H */

--- a/qucs-core/src/converter/matlab_producer.h
+++ b/qucs-core/src/converter/matlab_producer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MATLAB_PRODUCER_H__
-#define __MATLAB_PRODUCER_H__
+#ifndef MATLAB_PRODUCER_H
+#define MATLAB_PRODUCER_H
 
 #include "logging.h"
 #include "strlist.h"
@@ -39,4 +39,4 @@ extern FILE * matlab_out;
 /* Available functions of the producers. */
 void matlab_producer (void);
 
-#endif /* __MATLAB_PRODUCER_H__ */
+#endif /* MATLAB_PRODUCER_H */

--- a/qucs-core/src/converter/qucs_producer.h
+++ b/qucs-core/src/converter/qucs_producer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __QUCS_PRODUCER_H__
-#define __QUCS_PRODUCER_H__
+#ifndef QUCS_PRODUCER_H
+#define QUCS_PRODUCER_H
 namespace qucs {
   class dataset;
 }
@@ -40,4 +40,4 @@ void qucslib_producer (void);
 void qucsdata_producer_vcd (void);
 void qucsdata_producer (qucs::dataset *);
 
-#endif /* __QUCS_PRODUCER_H__ */
+#endif /* QUCS_PRODUCER_H */

--- a/qucs-core/src/converter/touchstone_producer.h
+++ b/qucs-core/src/converter/touchstone_producer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TOUCHSTONE_PRODUCER_H__
-#define __TOUCHSTONE_PRODUCER_H__
+#ifndef TOUCHSTONE_PRODUCER_H
+#define TOUCHSTONE_PRODUCER_H
 
 #include "logging.h"
 #include "strlist.h"
@@ -39,4 +39,4 @@ extern FILE * touchstone_out;
 /* Available functions of the producers. */
 void touchstone_producer (const char * variable);
 
-#endif /* __TOUCHSTONE_PRODUCER_H__ */
+#endif /* TOUCHSTONE_PRODUCER_H */

--- a/qucs-core/src/dataset.h
+++ b/qucs-core/src/dataset.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DATASET_H__
-#define __DATASET_H__
+#ifndef DATASET_H
+#define DATASET_H
 
 #include "object.h"
 
@@ -82,4 +82,4 @@ class dataset : public object
 
 } // namespace qucs
 
-#endif /* __DATASET_H__ */
+#endif /* DATASET_H */

--- a/qucs-core/src/dcsolver.h
+++ b/qucs-core/src/dcsolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DCSOLVER_H__
-#define __DCSOLVER_H__
+#ifndef DCSOLVER_H
+#define DCSOLVER_H
 
 #include "nasolver.h"
 
@@ -48,5 +48,5 @@ class dcsolver : public nasolver<nr_double_t>
 
 } // namespace qucs
 
-#endif /* __DCSOLVER_H__ */
+#endif /* DCSOLVER_H */
 

--- a/qucs-core/src/devstates.h
+++ b/qucs-core/src/devstates.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DEVSTATES_H__
-#define __DEVSTATES_H__
+#ifndef DEVSTATES_H
+#define DEVSTATES_H
 
 namespace qucs {
 
@@ -55,4 +55,4 @@ class devstates
 
 } // namespace qucs
 
-#endif /* __DEVSTATES_H__ */
+#endif /* DEVSTATES_H */

--- a/qucs-core/src/differentiate.h
+++ b/qucs-core/src/differentiate.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __DIFFERENTIATE_H__
-#define __DIFFERENTIATE_H__
+#ifndef DIFFERENTIATE_H
+#define DIFFERENTIATE_H
 
 namespace qucs {
 
@@ -115,4 +115,4 @@ extern struct differentiation_t differentiations[];
 
 } // namespace qucs
 
-#endif /* __DIFFERENTIATE_H__ */
+#endif /* DIFFERENTIATE_H */

--- a/qucs-core/src/environment.h
+++ b/qucs-core/src/environment.h
@@ -28,8 +28,8 @@
  * Contains the environment class definition.
  */
 
-#ifndef __ENVIRONMENT_H__
-#define __ENVIRONMENT_H__
+#ifndef ENVIRONMENT_H
+#define ENVIRONMENT_H
 
 #include <list>
 #include <string>
@@ -127,4 +127,4 @@ class environment
 
 } // namespace qucs
 
-#endif /* __ENVIRONMENT_H__ */
+#endif /* ENVIRONMENT_H */

--- a/qucs-core/src/eqnsys.h
+++ b/qucs-core/src/eqnsys.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __EQNSYS_H__
-#define __EQNSYS_H__
+#ifndef EQNSYS_H
+#define EQNSYS_H
 
 #include <limits>
 
@@ -138,4 +138,4 @@ class eqnsys
 
 #include "eqnsys.cpp"
 
-#endif /* __EQNSYS_H__ */
+#endif /* EQNSYS_H */

--- a/qucs-core/src/equation.h
+++ b/qucs-core/src/equation.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __EQUATION_H__
-#define __EQUATION_H__
+#ifndef EQUATION_H
+#define EQUATION_H
 
 #include "object.h"
 #include "complex.h"
@@ -361,4 +361,4 @@ private:
 
 } // namespace qucs
 
-#endif /* __EQUATION_H__ */
+#endif /* EQUATION_H */

--- a/qucs-core/src/evaluate.h
+++ b/qucs-core/src/evaluate.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __EVALUATE_H__
-#define __EVALUATE_H__
+#ifndef EVALUATE_H
+#define EVALUATE_H
 
 namespace qucs {
 
@@ -808,4 +808,4 @@ extern struct application_t applications[];
 
 } // namespace qucs
 
-#endif /* __EVALUATE_H__ */
+#endif /* EVALUATE_H */

--- a/qucs-core/src/exception.h
+++ b/qucs-core/src/exception.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __EXCEPTION_H__
-#define __EXCEPTION_H__
+#ifndef EXCEPTION_H
+#define EXCEPTION_H
 
 namespace qucs {
 
@@ -65,4 +65,4 @@ class exception
 
 } /* namespace qucs */
 
-#endif /* __EXCEPTION_H__ */
+#endif /* EXCEPTION_H */

--- a/qucs-core/src/exceptionstack.h
+++ b/qucs-core/src/exceptionstack.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __EXCEPTIONSTACK_H__
-#define __EXCEPTIONSTACK_H__
+#ifndef EXCEPTIONSTACK_H
+#define EXCEPTIONSTACK_H
 
 namespace qucs {
 
@@ -57,4 +57,4 @@ extern exceptionstack estack;
 #define top_exception()      estack.top ()
 #define pop_exception()      estack.pop ()
 
-#endif /* __EXCEPTIONSTACK_H__ */
+#endif /* EXCEPTIONSTACK_H */

--- a/qucs-core/src/fourier.h
+++ b/qucs-core/src/fourier.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __FOURIER_H__
-#define __FOURIER_H__
+#ifndef FOURIER_H
+#define FOURIER_H
 
 namespace qucs {
 
@@ -56,4 +56,4 @@ namespace fourier {
 
 } // namespace qucs
 
-#endif /* __FOURIER_H__ */
+#endif /* FOURIER_H */

--- a/qucs-core/src/hash.h
+++ b/qucs-core/src/hash.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __HASH_H__
-#define __HASH_H__
+#ifndef HASH_H
+#define HASH_H
 
 namespace qucs {
 
@@ -173,4 +173,4 @@ class hashiterator
 
 #include "hash.cpp"
 
-#endif /* __HASH_H__ */
+#endif /* HASH_H */

--- a/qucs-core/src/hbsolver.h
+++ b/qucs-core/src/hbsolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __HBSOLVER_H__
-#define __HBSOLVER_H__
+#ifndef HBSOLVER_H
+#define HBSOLVER_H
 
 #include <vector>
 
@@ -139,4 +139,4 @@ class hbsolver : public analysis
 
 } // namespace qucs
 
-#endif /* __HBSOLVER_H__ */
+#endif /* HBSOLVER_H */

--- a/qucs-core/src/history.h
+++ b/qucs-core/src/history.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __HISTORY_H__
-#define __HISTORY_H__
+#ifndef HISTORY_H
+#define HISTORY_H
 
 #include <memory>
 #include <vector>
@@ -134,4 +134,4 @@ public:
 
 } // namespace qucs
 
-#endif /* __HISTORY_H__ */
+#endif /* HISTORY_H */

--- a/qucs-core/src/input.h
+++ b/qucs-core/src/input.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INPUT_H__
-#define __INPUT_H__
+#ifndef INPUT_H
+#define INPUT_H
 
 namespace qucs {
 
@@ -61,4 +61,4 @@ extern int netlist_check;
 
 }
 
-#endif /* __INPUT_H__ */
+#endif /* INPUT_H */

--- a/qucs-core/src/integrator.h
+++ b/qucs-core/src/integrator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INTEGRATOR_H__
-#define __INTEGRATOR_H__
+#ifndef INTEGRATOR_H
+#define INTEGRATOR_H
 
 #include "states.h"
 
@@ -66,4 +66,4 @@ class integrator : public states<nr_double_t>
 
 } // namespace qucs
 
-#endif /* __INTEGRATOR_H__ */
+#endif /* INTEGRATOR_H */

--- a/qucs-core/src/interface/class_handle.hpp
+++ b/qucs-core/src/interface/class_handle.hpp
@@ -30,8 +30,8 @@
 */
 
 
-#ifndef __CLASS_HANDLE_HPP__
-#define __CLASS_HANDLE_HPP__
+#ifndef CLASS_HANDLE_HPP
+#define CLASS_HANDLE_HPP
 #include <stdint.h>
 #include <string>
 #include <cstring>
@@ -82,4 +82,4 @@ template<class base> inline void destroyObject(const mxArray *in)
     mexUnlock();
 }
 
-#endif // __CLASS_HANDLE_HPP__
+#endif // CLASS_HANDLE_HPP

--- a/qucs-core/src/interface/e_trsolver.h
+++ b/qucs-core/src/interface/e_trsolver.h
@@ -31,8 +31,8 @@
   * \ingroup QucsInterface
   */
 
-#ifndef __E_TRSOLVER_H__
-#define __E_TRSOLVER_H__
+#ifndef E_TRSOLVER_H
+#define E_TRSOLVER_H
 
 #include "qucs_interface.h"
 #include "trsolver.h"
@@ -209,5 +209,5 @@ private:
 
 } // namespace qucs
 
-#endif /* __e_trsolver_H__ */
+#endif /* e_trsolver_H */
 

--- a/qucs-core/src/interface/qucs_interface.h
+++ b/qucs-core/src/interface/qucs_interface.h
@@ -32,8 +32,8 @@
   * \defgroup QucsInterface
   */
 
-#ifndef __QUCS_INTERFACE_H__
-#define __QUCS_INTERFACE_H__
+#ifndef QUCS_INTERFACE_H
+#define QUCS_INTERFACE_H
 
 
 namespace qucs
@@ -239,4 +239,4 @@ private:
 
 } // namespace qucs
 
-#endif /* __QUCS_INTERFACE_H__ */
+#endif /* QUCS_INTERFACE_H */

--- a/qucs-core/src/interpolator.h
+++ b/qucs-core/src/interpolator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __INTERPOLATOR_H__
-#define __INTERPOLATOR_H__
+#ifndef INTERPOLATOR_H
+#define INTERPOLATOR_H
 
 // Type of data and interpolators.
 #define INTERPOL_LINEAR  1
@@ -79,4 +79,4 @@ private:
 
 } // namespace qucs
 
-#endif /* __INTERPOLATOR_H__ */
+#endif /* INTERPOLATOR_H */

--- a/qucs-core/src/libqucsator.h
+++ b/qucs-core/src/libqucsator.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __LIBQUCSATOR_H__
-#define __LIBQUCSATOR_H__
+#ifndef LIBQUCSATOR_H
+#define LIBQUCSATOR_H
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -46,4 +46,4 @@
 #include "check_dataset.h"
 #include "check_touchstone.h"
 
-#endif /* __LIBQUCSATOR_H__ */
+#endif /* LIBQUCSATOR_H */

--- a/qucs-core/src/logging.h
+++ b/qucs-core/src/logging.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __LOGGING_H__
-#define __LOGGING_H__
+#ifndef LOGGING_H
+#define LOGGING_H
 
 #define LOG_ERROR  0
 #define LOG_STATUS 1
@@ -40,4 +40,4 @@ extern int progressbar_gui;
 
 __END_DECLS
 
-#endif /* __LOGGING_H__ */
+#endif /* LOGGING_H */

--- a/qucs-core/src/math/complex.h
+++ b/qucs-core/src/math/complex.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __COMPLEX_H__
-#define __COMPLEX_H__
+#ifndef COMPLEX_H
+#define COMPLEX_H
 
 #include <complex>
 #include "real.h"
@@ -160,4 +160,4 @@ bool operator <  (const nr_complex_t, const nr_complex_t);
 
 } // namespace qucs
 
-#endif /* __COMPLEX_H__ */
+#endif /* COMPLEX_H */

--- a/qucs-core/src/math/fspecial.h
+++ b/qucs-core/src/math/fspecial.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __FSPECIAL_H__
-#define __FSPECIAL_H__
+#ifndef FSPECIAL_H
+#define FSPECIAL_H
 
 namespace fspecial {
 
@@ -45,4 +45,4 @@ namespace fspecial {
 
 } // namespace
 
-#endif /* __FSPECIAL_H__ */
+#endif /* FSPECIAL_H */

--- a/qucs-core/src/math/matrix.h
+++ b/qucs-core/src/math/matrix.h
@@ -26,8 +26,8 @@
    \brief Dense matrix class header file
 */
 
-#ifndef __MATRIX_H__
-#define __MATRIX_H__
+#ifndef MATRIX_H
+#define MATRIX_H
 
 namespace qucs {
 
@@ -219,4 +219,4 @@ class matrix
 
 } // namespace qucs
 
-#endif /* __MATRIX_H__ */
+#endif /* MATRIX_H */

--- a/qucs-core/src/math/precision.h
+++ b/qucs-core/src/math/precision.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PRECISION_H__
-#define __PRECISION_H__
+#ifndef PRECISION_H
+#define PRECISION_H
 
 #include <limits>
 
@@ -47,4 +47,4 @@
 
 
 
-#endif /* __PRECISION_H__ */
+#endif /* PRECISION_H */

--- a/qucs-core/src/math/real.h
+++ b/qucs-core/src/math/real.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __REAL_H__
-#define __REAL_H__
+#ifndef REAL_H
+#define REAL_H
 
 #include <cmath>
 
@@ -143,4 +143,4 @@ nr_double_t   abs (const nr_double_t);
 
 } // namespace qucs
 
-#endif /* __REAL_H__ */
+#endif /* REAL_H */

--- a/qucs-core/src/matvec.h
+++ b/qucs-core/src/matvec.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MATVEC_H__
-#define __MATVEC_H__
+#ifndef MATVEC_H
+#define MATVEC_H
 
 namespace qucs {
 
@@ -170,4 +170,4 @@ class matvec
 
 } // namespace qucs
 
-#endif /* __MATVEC_H__ */
+#endif /* MATVEC_H */

--- a/qucs-core/src/module.cpp
+++ b/qucs-core/src/module.cpp
@@ -330,13 +330,13 @@ static const char * def_prefix =
 " * \n"
 " */\n"
 "\n"
-"#ifndef __QUCSDEFS_H__\n"
-"#define __QUCSDEFS_H__\n";
+"#ifndef QUCSDEFS_H\n"
+"#define QUCSDEFS_H\n";
 
 // header suffix
 static const char * def_suffix =
 "\n"
-"#endif /* __QUCSDEFS_H__ */\n";
+"#endif /* QUCSDEFS_H */\n";
 
 // start of list of definitions
 static const char * def_start =

--- a/qucs-core/src/module.h
+++ b/qucs-core/src/module.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __MODULE_H__
-#define __MODULE_H__
+#ifndef MODULE_H
+#define MODULE_H
 
 #include <list>
 
@@ -74,4 +74,4 @@ class module
 
 } // namespace qucs
 
-#endif /* __MODULE_H__ */
+#endif /* MODULE_H */

--- a/qucs-core/src/nasolution.h
+++ b/qucs-core/src/nasolution.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NASOLUTION_H__
-#define __NASOLUTION_H__
+#ifndef NASOLUTION_H
+#define NASOLUTION_H
 
 #include <string>
 #include <unordered_map>
@@ -54,4 +54,4 @@ template <typename T>
 } // namespace qucs
 
 
-#endif /* __NASOLUTION_H__ */
+#endif /* NASOLUTION_H */

--- a/qucs-core/src/nasolver.h
+++ b/qucs-core/src/nasolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NASOLVER_H__
-#define __NASOLVER_H__
+#ifndef NASOLVER_H
+#define NASOLVER_H
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -154,4 +154,4 @@ private:
 
 #include "nasolver.cpp"
 
-#endif /* __NASOLVER_H__ */
+#endif /* NASOLVER_H */

--- a/qucs-core/src/net.h
+++ b/qucs-core/src/net.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NET_H__
-#define __NET_H__
+#ifndef NET_H
+#define NET_H
 
 #include <string>
 #include "ptrlist.h"
@@ -108,4 +108,4 @@ class net : public object
 
 } // namespace qucs
 
-#endif /* __NET_H__ */
+#endif /* NET_H */

--- a/qucs-core/src/netdefs.h
+++ b/qucs-core/src/netdefs.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NETDEFS_H__
-#define __NETDEFS_H__
+#ifndef NETDEFS_H
+#define NETDEFS_H
 
 namespace qucs {
 class environment;
@@ -197,4 +197,4 @@ struct define_t {
 #define create_pair() \
   ((struct pair_t *) calloc (sizeof (struct pair_t), 1))
 
-#endif /* __NETDEFS_H__ */
+#endif /* NETDEFS_H */

--- a/qucs-core/src/node.h
+++ b/qucs-core/src/node.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NODE_H__
-#define __NODE_H__
+#ifndef NODE_H
+#define NODE_H
 
 namespace qucs {
 
@@ -59,4 +59,4 @@ class node : public object
 
 } // namespace qucs
 
-#endif /* __NODE_H__ */
+#endif /* NODE_H */

--- a/qucs-core/src/nodelist.h
+++ b/qucs-core/src/nodelist.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NODELIST_H__
-#define __NODELIST_H__
+#ifndef NODELIST_H
+#define NODELIST_H
 
 #include <vector>
 #include <list>
@@ -141,4 +141,4 @@ class nodelist
 
 } // namespace qucs
 
-#endif /* __NODELIST_H__ */
+#endif /* NODELIST_H */

--- a/qucs-core/src/nodeset.h
+++ b/qucs-core/src/nodeset.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __NODESET_H__
-#define __NODESET_H__
+#ifndef NODESET_H
+#define NODESET_H
 
 namespace qucs {
 
@@ -51,4 +51,4 @@ class nodeset
 
 } // namespace qucs
 
-#endif /* __NODESET_H__ */
+#endif /* NODESET_H */

--- a/qucs-core/src/object.h
+++ b/qucs-core/src/object.h
@@ -28,8 +28,8 @@
   *
   */
 
-#ifndef __OBJECT_H__
-#define __OBJECT_H__
+#ifndef OBJECT_H
+#define OBJECT_H
 
 #include <string>
 #include "property.h"
@@ -89,4 +89,4 @@ class object
 
 } // namespace qucs
 
-#endif /* __OBJECT_H__ */
+#endif /* OBJECT_H */

--- a/qucs-core/src/operatingpoint.h
+++ b/qucs-core/src/operatingpoint.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __OPERATINGPOINT_H__
-#define __OPERATINGPOINT_H__
+#ifndef OPERATINGPOINT_H
+#define OPERATINGPOINT_H
 
 #include "pair.h"
 
@@ -33,4 +33,4 @@ typedef class qucs::pair operatingpoint;
 
 } // namespace qucs
 
-#endif /* __OPERATINGPOINT_H__ */
+#endif /* OPERATINGPOINT_H */

--- a/qucs-core/src/pair.h
+++ b/qucs-core/src/pair.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PAIR_H__
-#define __PAIR_H__
+#ifndef PAIR_H
+#define PAIR_H
 
 #include <utility>
 #include <string>
@@ -69,4 +69,4 @@ class pair
 
 } // namespace qucs
 
-#endif /* __PAIR_H__ */
+#endif /* PAIR_H */

--- a/qucs-core/src/parasweep.h
+++ b/qucs-core/src/parasweep.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PARASWEEP_H__
-#define __PARASWEEP_H__
+#ifndef PARASWEEP_H
+#define PARASWEEP_H
 
 namespace qucs {
 
@@ -51,4 +51,4 @@ class parasweep : public analysis
 
 } // namespace qucs
 
-#endif /* __PARASWEEP_H__ */
+#endif /* PARASWEEP_H */

--- a/qucs-core/src/poly.h
+++ b/qucs-core/src/poly.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __POLY_H__
-#define __POLY_H__
+#ifndef POLY_H
+#define POLY_H
 
 namespace qucs {
 
@@ -50,4 +50,4 @@ class poly
 
 } // namespace qucs
 
-#endif /* __POLY_H__ */
+#endif /* POLY_H */

--- a/qucs-core/src/property.h
+++ b/qucs-core/src/property.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PROPERTY_H__
-#define __PROPERTY_H__
+#ifndef PROPERTY_H
+#define PROPERTY_H
 
 #include <string>
 #include <unordered_map>
@@ -73,4 +73,4 @@ typedef std::unordered_map<std::string, property> properties;
  
 } // namespace qucs
 
-#endif /* __PROPERTY_H__ */
+#endif /* PROPERTY_H */

--- a/qucs-core/src/ptrlist.h
+++ b/qucs-core/src/ptrlist.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __PTRLIST_H__
-#define __PTRLIST_H__
+#ifndef PTRLIST_H
+#define PTRLIST_H
 
 #include <list>
 
@@ -33,4 +33,4 @@ template <typename T>
 using ptrlist = std::list<T *>;
 
 }
-#endif /* __PTRLIST_H__ */
+#endif /* PTRLIST_H */

--- a/qucs-core/src/range.h
+++ b/qucs-core/src/range.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __RANGE_H__
-#define __RANGE_H__
+#ifndef RANGE_H
+#define RANGE_H
 
 namespace qucs {
 
@@ -51,4 +51,4 @@ class range
 
 } // namespace qucs
 
-#endif /* __RANGE_H__ */
+#endif /* RANGE_H */

--- a/qucs-core/src/receiver.h
+++ b/qucs-core/src/receiver.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __RECEIVER_H__
-#define __RECEIVER_H__
+#ifndef RECEIVER_H
+#define RECEIVER_H
 
 #include <cstdint>
 
@@ -54,4 +54,4 @@ namespace emi {
 
 } // namespace qucs
 
-#endif /* __RECEIVER_H__ */
+#endif /* RECEIVER_H */

--- a/qucs-core/src/spline.h
+++ b/qucs-core/src/spline.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SPLINE_H__
-#define __SPLINE_H__
+#ifndef SPLINE_H
+#define SPLINE_H
 
 #include <vector>
 #include "tvector.h"
@@ -77,4 +77,4 @@ class spline
 
 } // namespace qucs
 
-#endif /* __SPLINE_H__ */
+#endif /* SPLINE_H */

--- a/qucs-core/src/spsolver.h
+++ b/qucs-core/src/spsolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SPSOLVER_H__
-#define __SPSOLVER_H__
+#ifndef SPSOLVER_H
+#define SPSOLVER_H
 
 #include <string>
 
@@ -82,4 +82,4 @@ class spsolver : public analysis
 
 } // namespace qucs
 
-#endif /* __SPSOLVER_H__ */
+#endif /* SPSOLVER_H */

--- a/qucs-core/src/states.h
+++ b/qucs-core/src/states.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __STATES_H__
-#define __STATES_H__
+#ifndef STATES_H
+#define STATES_H
 
 namespace qucs {
 
@@ -69,4 +69,4 @@ class states
 
 #include "states.cpp"
 
-#endif /* __STATES_H__ */
+#endif /* STATES_H */

--- a/qucs-core/src/strlist.h
+++ b/qucs-core/src/strlist.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __STRLIST_H__
-#define __STRLIST_H__
+#ifndef STRLIST_H
+#define STRLIST_H
 
 namespace qucs {
 
@@ -88,4 +88,4 @@ class strlistiterator
 
 } // namespace qucs
 
-#endif /* __STRLIST_H__ */
+#endif /* STRLIST_H */

--- a/qucs-core/src/sweep.h
+++ b/qucs-core/src/sweep.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __SWEEP_H__
-#define __SWEEP_H__
+#ifndef SWEEP_H
+#define SWEEP_H
 
 namespace qucs {
 
@@ -106,4 +106,4 @@ class lstsweep : public sweep
 
 } // namespace qucs
 
-#endif /* __SWEEP_H__ */
+#endif /* SWEEP_H */

--- a/qucs-core/src/tmatrix.h
+++ b/qucs-core/src/tmatrix.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TMATRIX_H__
-#define __TMATRIX_H__
+#ifndef TMATRIX_H
+#define TMATRIX_H
 
 #include <assert.h>
 
@@ -101,4 +101,4 @@ class tmatrix
 
 #include "tmatrix.cpp"
 
-#endif /* __TMATRIX_H__ */
+#endif /* TMATRIX_H */

--- a/qucs-core/src/transient.h
+++ b/qucs-core/src/transient.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TRANSIENT_H__
-#define __TRANSIENT_H__
+#ifndef TRANSIENT_H
+#define TRANSIENT_H
 
 namespace qucs {
 
@@ -63,4 +63,4 @@ namespace transient {
 
 } // namespace qucs
 
-#endif /* __TRANSIENT_H__ */
+#endif /* TRANSIENT_H */

--- a/qucs-core/src/tridiag.h
+++ b/qucs-core/src/tridiag.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TRIDIAG_H__
-#define __TRIDIAG_H__
+#ifndef TRIDIAG_H
+#define TRIDIAG_H
 
 #include <vector>
 //#include "tvector.h"
@@ -88,4 +88,4 @@ class tridiag
 
 #include "tridiag.cpp"
 
-#endif /* __TRIDIAG_H__ */
+#endif /* TRIDIAG_H */

--- a/qucs-core/src/trsolver.h
+++ b/qucs-core/src/trsolver.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TRSOLVER_H__
-#define __TRSOLVER_H__
+#ifndef TRSOLVER_H
+#define TRSOLVER_H
 
 #include "nasolver.h"
 #include "states.h"
@@ -104,4 +104,4 @@ protected:
 
 } // namespace qucs
 
-#endif /* __TRSOLVER_H__ */
+#endif /* TRSOLVER_H */

--- a/qucs-core/src/tvector.h
+++ b/qucs-core/src/tvector.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __TVECTOR_H__
-#define __TVECTOR_H__
+#ifndef TVECTOR_H
+#define TVECTOR_H
 
 #include <vector>
 #include <assert.h>
@@ -158,4 +158,4 @@ class tvector
   
 #include "tvector.cpp"
 
-#endif /* __TVECTOR_H__ */
+#endif /* TVECTOR_H */

--- a/qucs-core/src/valuelist.h
+++ b/qucs-core/src/valuelist.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VALUELIST_H__
-#define __VALUELIST_H__
+#ifndef VALUELIST_H
+#define VALUELIST_H
 
 #include <unordered_map>
 #include <string>
@@ -33,4 +33,4 @@ namespace qucs {
     using  valuelist= std::unordered_map<std::string,T>;
 }
 
-#endif /* __VALUELIST_H__ */
+#endif /* VALUELIST_H */

--- a/qucs-core/src/variable.h
+++ b/qucs-core/src/variable.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef __VARIABLE_H__
-#define __VARIABLE_H__
+#ifndef VARIABLE_H
+#define VARIABLE_H
 
 #include <string>
 
@@ -108,4 +108,4 @@ class variable
 
 } // namespace qucs
 
-#endif /* __VARIABLE_H__ */
+#endif /* VARIABLE_H */

--- a/qucs-core/src/vector.h
+++ b/qucs-core/src/vector.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef __VECTOR_H__
-#define __VECTOR_H__
+#ifndef VECTOR_H
+#define VECTOR_H
 
 #include <limits>
 
@@ -333,4 +333,4 @@ vector deg2rad     (vector);
 
 } // namespace qucs
 
-#endif /* __VECTOR_H__ */
+#endif /* VECTOR_H */

--- a/qucs/qucs-activefilter/qf_matrix.h
+++ b/qucs/qucs-activefilter/qf_matrix.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_MATRIX_H
-#define _QF_MATRIX_H
+#ifndef QF_MATRIX_H
+#define QF_MATRIX_H
 
 class qf_matrix
 {
@@ -47,4 +47,4 @@ class qf_matrix
   qf_double_t * data;
 };
 
-#endif // _QF_MATRIX_H
+#endif // QF_MATRIX_H

--- a/qucs/qucs-activefilter/qf_poly.h
+++ b/qucs/qucs-activefilter/qf_poly.h
@@ -17,8 +17,8 @@
 #include <QtCore>
 #include <complex>
 
-#ifndef _QF_POLY_H
-#define _QF_POLY_H
+#ifndef QF_POLY_H
+#define QF_POLY_H
 
 /* Headers for R[X] arithmetic */
 
@@ -138,5 +138,5 @@ inline qf_double_t ROUND_ROOT (qf_double_t k) {
 #define RADIX2		(RADIX*RADIX)
 #define MAX_ITERATIONS	60
 
-#endif // _QF_POLY_H
+#endif // QF_POLY_H
 

--- a/qucs/qucs-filter-v2/qf_api.h
+++ b/qucs/qucs-filter-v2/qf_api.h
@@ -1,5 +1,5 @@
-# ifndef  _QF_API_H
-# define  _QF_API_H
+# ifndef  QF_API_H
+# define  QF_API_H
 
 // Identify each filter by a unique bit
 

--- a/qucs/qucs-filter-v2/qf_bessel.h
+++ b/qucs/qucs-filter-v2/qf_bessel.h
@@ -1,7 +1,7 @@
 // Bessel filters
 
-#ifndef	_QF_BESSEL_H
-#define	_QF_BESSEL_H
+#ifndef	QF_BESSEL_H
+#define	QF_BESSEL_H
 
 class qf_bessel: public qf_filter {
 
@@ -47,4 +47,4 @@ struct qf_filter_api qf_bessel_api =
 }; 
 
   # endif // _QF_API
-# endif	  // _QF_BESSEL_H
+# endif	  // QF_BESSEL_H

--- a/qucs/qucs-filter-v2/qf_blinch.h
+++ b/qucs/qucs-filter-v2/qf_blinch.h
@@ -1,5 +1,5 @@
-# ifndef  _QF_BLINCH_H
-# define  _QF_BLINCH_H
+# ifndef  QF_BLINCH_H
+# define  QF_BLINCH_H
 
 /*
 static qf_double_t pole2 [36] = {
@@ -93,4 +93,4 @@ struct	qf_filter_api qf_blinch_api =
   QF_LOWPASS | QF_HIGHPASS | QF_BANDPASS | QF_BANDSTOP | QF_ZIGZAG,
 };
   # endif // _QF_API
-# endif // _QF_BLINCH_H
+# endif // QF_BLINCH_H

--- a/qucs/qucs-filter-v2/qf_butcheb.h
+++ b/qucs/qucs-filter-v2/qf_butcheb.h
@@ -4,8 +4,8 @@
 // These filters are the easiest to compute, since the values of the
 // standard lowpass prototype are given by simple formulae. There is, thus,
 // no need to rely on the complex polynomial machinery used elsewhere.
-#ifndef _QF_BUTCHEB_H
-#define	_QF_BUTCHEB_H
+#ifndef QF_BUTCHEB_H
+#define	QF_BUTCHEB_H
 
 // A general class common to both filters
 
@@ -92,4 +92,4 @@ struct qf_filter_api	qf_cheb_api = {
 };
 
   # endif //_QF_API
-# endif	  //_QF_BUTCHEB_H
+# endif	  //QF_BUTCHEB_H

--- a/qucs/qucs-filter-v2/qf_cauer.h
+++ b/qucs/qucs-filter-v2/qf_cauer.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef  _QF_CAUER_H
-#define  _QF_CAUER_H
+#ifndef  QF_CAUER_H
+#define  QF_CAUER_H
 
 class qf_cauer: public qf_filter {
 
@@ -86,4 +86,4 @@ struct qf_filter_api qf_cauer_api =
 };
 
   # endif // _QF_API
-# endif	  // _QF_CAUER_H
+# endif	  // QF_CAUER_H

--- a/qucs/qucs-filter-v2/qf_comp.h
+++ b/qucs/qucs-filter-v2/qf_comp.h
@@ -1,5 +1,5 @@
-# ifndef _QF_COMP_H
-# define _QF_COMP_H
+# ifndef QF_COMP_H
+# define QF_COMP_H
 
 #include <vector>
 #include <list>
@@ -222,4 +222,4 @@ struct qf_pslc : public qf_cmplc {
   void		dump	(unsigned, unsigned, Q3TextStream&, Q3TextStream&);
 };
 
-# endif //_QF_COMP_H
+# endif //QF_COMP_H

--- a/qucs/qucs-filter-v2/qf_filter.h
+++ b/qucs/qucs-filter-v2/qf_filter.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-# ifndef _QF_FILTER_H
-# define _QF_FILTER_H
+# ifndef QF_FILTER_H
+# define QF_FILTER_H
 
 # ifdef	_QF_QUCSFILTER_TEST
 # define PACKAGE_VERSION "Qf test"

--- a/qucs/qucs-filter-v2/qf_icheb.h
+++ b/qucs/qucs-filter-v2/qf_icheb.h
@@ -1,5 +1,5 @@
-#ifndef	_QF_ICHEB_H
-#define	_QF_ICHEB_H
+#ifndef	QF_ICHEB_H
+#define	QF_ICHEB_H
 // Icheb : inverse chebychev filters
 
 class qf_icheb : public qf_filter {
@@ -42,4 +42,4 @@ struct	qf_filter_api	qf_icheb_api = {
 };
 
   # endif // _QF_API
-#endif // _QF_ICHEB_H
+#endif // QF_ICHEB_H

--- a/qucs/qucs-filter-v2/qf_legendre.h
+++ b/qucs/qucs-filter-v2/qf_legendre.h
@@ -1,6 +1,6 @@
 // Headers for legendre filters
-#ifndef _QF_LGNDR_H
-#define	_QF_LGNDR_H
+#ifndef QF_LGNDR_H
+#define	QF_LGNDR_H
 
 class qf_lgndr : public qf_filter {
   private:
@@ -40,4 +40,4 @@ struct	qf_filter_api	    qf_lgndr_api = {
 };
 
   # endif // _QF_API
-# endif	  // _QF_LGNDR_H
+# endif	  // QF_LGNDR_H

--- a/qucs/qucs-filter-v2/qf_matrix.h
+++ b/qucs/qucs-filter-v2/qf_matrix.h
@@ -1,5 +1,5 @@
-#ifndef _QF_MATRIX_H
-  #define _QF_MATRIX_H
+#ifndef QF_MATRIX_H
+  #define QF_MATRIX_H
 
 #ifdef	_QF_MATRIX_DEBUG
   #define IL

--- a/qucs/qucs-filter-v2/qf_poly.h
+++ b/qucs/qucs-filter-v2/qf_poly.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_POLY_H
-#define _QF_POLY_H
+#ifndef QF_POLY_H
+#define QF_POLY_H
 
 /* Headers for R[X] arithmetic */
 
@@ -131,4 +131,4 @@ qf_poly		operator -  (qf_poly&, qf_poly&);
 qf_double_t	setroottol  (qf_double_t&);
 qf_double_t	setrootprec (qf_double_t&);
 
-#endif	// _QF_POLY_H
+#endif	// QF_POLY_H

--- a/qucs/qucs-filter-v2/qf_tform.h
+++ b/qucs/qucs-filter-v2/qf_tform.h
@@ -1,7 +1,7 @@
 //Added by qt3to4:
 #include <Q3TextStream>
-# ifndef  _QF_TFORM_H
-# define  _QF_TFORM_H
+# ifndef  QF_TFORM_H
+# define  QF_TFORM_H
 // Headers for standard transformations
 // Those transformations are : lowpass (no transform), highpass
 // standard bandpass (geometrical type) and bandstop (inverse bandpass)
@@ -231,4 +231,4 @@ struct	qf_tform_api	  qf_bandstop_api = {
 };
 
   # endif // _QF_API
-# endif	  // _QF_TFORM_H
+# endif	  // QF_TFORM_H

--- a/qucs/qucs-filter-v2/qf_zigzag.h
+++ b/qucs/qucs-filter-v2/qf_zigzag.h
@@ -1,7 +1,7 @@
 // Definitions for qf_zigzag.cpp
 
-#ifndef _QF_ZIGZAG_H
-#define	_QF_ZIGZAG_H
+#ifndef QF_ZIGZAG_H
+#define	QF_ZIGZAG_H
 
 #include <vector>
 //Added by qt3to4:
@@ -56,4 +56,4 @@ struct	qf_tform_api	    qf_zigzag_api = {
 };
 
   # endif // _QF_API
-#endif	  // _QF_ZIGZAG_H
+#endif	  // QF_ZIGZAG_H

--- a/qucs/qucs-filter/qf_cauer.h
+++ b/qucs/qucs-filter/qf_cauer.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_CAUER_H
-#define _QF_CAUER_H
+#ifndef QF_CAUER_H
+#define QF_CAUER_H
 
 const qf_double_t SN_ACC = 1e-5;	// Accuracy of sn(x) is SN_ACC^2
 const qf_double_t K_ERR1 = 1e-8;	// Accuracy of K(k)
@@ -61,4 +61,4 @@ public:
   void dump (void);		// Dumps to cout
 };
 
-#endif // _QF_CAUER_H
+#endif // QF_CAUER_H

--- a/qucs/qucs-filter/qf_filter.h
+++ b/qucs/qucs-filter/qf_filter.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_FILTER_H
-#define _QF_FILTER_H
+#ifndef QF_FILTER_H
+#define QF_FILTER_H
 
 // Header for filter
 
@@ -115,4 +115,4 @@ private:
   std::string num2str (qf_double_t);
 };
 
-#endif // _QF_FILTER_H
+#endif // QF_FILTER_H

--- a/qucs/qucs-filter/qf_matrix.h
+++ b/qucs/qucs-filter/qf_matrix.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_MATRIX_H
-#define _QF_MATRIX_H
+#ifndef QF_MATRIX_H
+#define QF_MATRIX_H
 
 class qf_matrix
 {
@@ -47,4 +47,4 @@ class qf_matrix
   qf_double_t * data;
 };
 
-#endif // _QF_MATRIX_H
+#endif // QF_MATRIX_H

--- a/qucs/qucs-filter/qf_poly.h
+++ b/qucs/qucs-filter/qf_poly.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QF_POLY_H
-#define _QF_POLY_H
+#ifndef QF_POLY_H
+#define QF_POLY_H
 
 /* Headers for R[X] arithmetic */
 
@@ -134,4 +134,4 @@ inline qf_double_t ROUND_ROOT (qf_double_t k) {
 #define RADIX2		(RADIX*RADIX)
 #define MAX_ITERATIONS	60
 
-#endif // _QF_POLY_H
+#endif // QF_POLY_H

--- a/qucs/qucs-help/htmldatafetcher.h
+++ b/qucs/qucs-help/htmldatafetcher.h
@@ -17,8 +17,8 @@
  * Boston, MA 02110-1301, USA.                                             *
  ***************************************************************************/
 
-#ifndef __HDF_H
-#define __HDF_H
+#ifndef HDF_H
+#define HDF_H
 #include <QStringList>
 #include <QMap>
 #include <QFile>

--- a/qucs/qucs-lib/qucslib_common.h
+++ b/qucs/qucs-lib/qucslib_common.h
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef _QUCSLIB_COMMON_H_
-#define _QUCSLIB_COMMON_H_
+#ifndef QUCSLIB_COMMON_H
+#define QUCSLIB_COMMON_H
 
 #include <QFile>
 #include <QFileInfo>
@@ -318,4 +318,4 @@ inline int parseComponentLibrary (QString libPath, ComponentLibrary &library, LI
 
 }
 
-#endif // _QUCSLIB_COMMON_H_
+#endif /* QUCSLIB_COMMON_H */

--- a/qucs/qucs-transcalc/c_microstrip.h
+++ b/qucs/qucs-transcalc/c_microstrip.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef _C_MICROSTRIP_H_
-#define _C_MICROSTRIP_H_
+#ifndef C_MICROSTRIP_H
+#define C_MICROSTRIP_H
 
 class c_microstrip : public transline {
  public:
@@ -99,4 +99,4 @@ class c_microstrip : public transline {
   microstrip * aux_ms;
 };
 
-#endif /* _C_MICROSTRIP_H_ */
+#endif /* C_MICROSTRIP_H */

--- a/qucs/qucs-transcalc/coax.h
+++ b/qucs/qucs-transcalc/coax.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __COAX_H
-#define __COAX_H
+#ifndef COAX_H
+#define COAX_H
 
 class coax : public transline {
  public:
@@ -58,4 +58,4 @@ class coax : public transline {
   void show_results();
 };
 
-#endif /* __COAX_H */
+#endif /* COAX_H */

--- a/qucs/qucs-transcalc/coplanar.h
+++ b/qucs/qucs-transcalc/coplanar.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __COPLANAR_H
-#define __COPLANAR_H
+#ifndef COPLANAR_H
+#define COPLANAR_H
 
 class coplanar : public transline {
  public:
@@ -64,4 +64,4 @@ class groundedCoplanar : public coplanar {
   groundedCoplanar();
 };
 
-#endif /* __COPLANAR_H */
+#endif /* COPLANAR_H */

--- a/qucs/qucs-transcalc/microstrip.h
+++ b/qucs/qucs-transcalc/microstrip.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __MICROSTRIP_H
-#define __MICROSTRIP_H
+#ifndef MICROSTRIP_H
+#define MICROSTRIP_H
 
 class microstrip : public transline {
  public:
@@ -90,4 +90,4 @@ class microstrip : public transline {
   void show_results();
 };
 
-#endif /* __MICROSTRIP_H */
+#endif /* MICROSTRIP_H */

--- a/qucs/qucs-transcalc/rectwaveguide.h
+++ b/qucs/qucs-transcalc/rectwaveguide.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __RECTWAVEGUIDE_H
-#define __RECTWAVEGUIDE_H
+#ifndef RECTWAVEGUIDE_H
+#define RECTWAVEGUIDE_H
 
 class rectwaveguide : public transline {
  public:
@@ -62,4 +62,4 @@ class rectwaveguide : public transline {
   void show_results ();
 };
 
-#endif /* __RECTWAVEGUIDE_H */
+#endif /* RECTWAVEGUIDE_H */

--- a/qucs/qucs-transcalc/transline.h
+++ b/qucs/qucs-transcalc/transline.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef __TRANSLINE_H
-#define __TRANSLINE_H
+#ifndef TRANSLINE_H
+#define TRANSLINE_H
 
 class QucsTranscalc;
 
@@ -58,4 +58,4 @@ class transline {
   QucsTranscalc * app;
 };
 
-#endif /* __TRANSLINE_H */
+#endif /* TRANSLINE_H */

--- a/qucs/qucs-transcalc/units.h
+++ b/qucs/qucs-transcalc/units.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef __UNITS_H
-#define __UNITS_H
+#ifndef UNITS_H
+#define UNITS_H
 
 #include <cmath>
 
@@ -72,4 +72,4 @@ static const double MAX_ERROR = 0.000001;
 #define ANG_RAD 1
 
 
-#endif /* __UNITS_H */
+#endif /* UNITS_H */

--- a/qucs/qucs/components/DLS_1ton.h
+++ b/qucs/qucs/components/DLS_1ton.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef DLS_1ton_H
-#define DLS_1ton_H
+#ifndef DLS_1TON_H
+#define DLS_1TON_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class DLS_1ton : public Component
     void createSymbol();
 };
 
-#endif /* DLS_1ton_H */
+#endif /* DLS_1TON_H */

--- a/qucs/qucs/components/DLS_nto1.h
+++ b/qucs/qucs/components/DLS_nto1.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef DLS_nto1_H
-#define DLS_nto1_H
+#ifndef DLS_NTO1_H
+#define DLS_NTO1_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class DLS_nto1 : public Component
     void createSymbol();
 };
 
-#endif /* DLS_nto1_H */
+#endif /* DLS_NTO1_H */

--- a/qucs/qucs/components/andor4x2.h
+++ b/qucs/qucs/components/andor4x2.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef andor4x2_H
-#define andor4x2_H
+#ifndef ANDOR4X2_H
+#define ANDOR4X2_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class andor4x2 : public Component
     QString verilogCode(int);
 };
 
-#endif /* andor4x2_H */
+#endif /* ANDOR4X2_H */

--- a/qucs/qucs/components/andor4x3.h
+++ b/qucs/qucs/components/andor4x3.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef andor4x3_H
-#define andor4x3_H
+#ifndef ANDOR4X3_H
+#define ANDOR4X3_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class andor4x3 : public Component
     QString verilogCode(int);
 };
 
-#endif /* andor4x3_H */
+#endif /* ANDOR4X3_H */

--- a/qucs/qucs/components/andor4x4.h
+++ b/qucs/qucs/components/andor4x4.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef andor4x4_H
-#define andor4x4_H
+#ifndef ANDOR4X4_H
+#define ANDOR4X4_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class andor4x4 : public Component
     QString verilogCode(int);
 };
 
-#endif /* andor4x4_H */
+#endif /* ANDOR4X4_H */

--- a/qucs/qucs/components/binarytogrey4bit.h
+++ b/qucs/qucs/components/binarytogrey4bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef binarytogrey4bit_H
-#define binarytogrey4bit_H
+#ifndef BINARYTOGREY4BIT_H
+#define BINARYTOGREY4BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class binarytogrey4bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* binarytogrey4bit_H */
+#endif /* BINARYTOGREY4BIT_H */

--- a/qucs/qucs/components/comp_1bit.h
+++ b/qucs/qucs/components/comp_1bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef comp_1bit_H
-#define comp_1bit_H
+#ifndef COMP_1BIT_H
+#define COMP_1BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class comp_1bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* comp_1bit_H */
+#endif /* COMP_1BIT_H */

--- a/qucs/qucs/components/comp_2bit.h
+++ b/qucs/qucs/components/comp_2bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef comp_2bit_H
-#define comp_2bit_H
+#ifndef COMP_2BIT_H
+#define COMP_2BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class comp_2bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* comp_2bit_H */
+#endif /* COMP_2BIT_H */

--- a/qucs/qucs/components/comp_4bit.h
+++ b/qucs/qucs/components/comp_4bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef comp_4bit_H
-#define comp_4bit_H
+#ifndef COMP_4BIT_H
+#define COMP_4BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class comp_4bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* comp_4bit_H */
+#endif /* COMP_4BIT_H */

--- a/qucs/qucs/components/dff_SR.h
+++ b/qucs/qucs/components/dff_SR.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef dff_SR_H
-#define dff_SR_H
+#ifndef DFF_SR_H
+#define DFF_SR_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class dff_SR : public Component
     QString verilogCode(int);
 };
 
-#endif /* dff_SR_H */
+#endif /* DFF_SR_H */

--- a/qucs/qucs/components/dmux2to4.h
+++ b/qucs/qucs/components/dmux2to4.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef dmux2to4_H
-#define dmux2to4_H
+#ifndef DMUX2TO4_H
+#define DMUX2TO4_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class dmux2to4 : public Component
     QString verilogCode(int);
 };
 
-#endif /* dmux2to4_H */
+#endif /* DMUX2TO4_H */

--- a/qucs/qucs/components/dmux3to8.h
+++ b/qucs/qucs/components/dmux3to8.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef dmux3to8_H
-#define dmux3to8_H
+#ifndef DMUX3TO8_H
+#define DMUX3TO8_H
 #include "component.h"
 
 class dmux3to8 : public Component
@@ -25,4 +25,4 @@ class dmux3to8 : public Component
     QString verilogCode(int);
 };
 
-#endif /* dmux3to8_H */
+#endif /* DMUX3TO8_H */

--- a/qucs/qucs/components/dmux4to16.h
+++ b/qucs/qucs/components/dmux4to16.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef dmux4to16_H
-#define dmux4to16_H
+#ifndef DMUX4TO16_H
+#define DMUX4TO16_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class dmux4to16 : public Component
     QString verilogCode(int);
 };
 
-#endif /* dmux4to16_H */
+#endif /* DMUX4TO16_H */

--- a/qucs/qucs/components/fa1b.h
+++ b/qucs/qucs/components/fa1b.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef fa1b_H
-#define fa1b_H
+#ifndef FA1B_H
+#define FA1B_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class fa1b : public Component
     QString verilogCode(int);
 };
 
-#endif /* fa1b_H */
+#endif /* FA1B_H */

--- a/qucs/qucs/components/fa2b.h
+++ b/qucs/qucs/components/fa2b.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef fa2b_H
-#define fa2b_H
+#ifndef FA2B_H
+#define FA2B_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class fa2b : public Component
     QString verilogCode(int);
 };
 
-#endif /* fa2b_H */
+#endif /* FA2B_H */

--- a/qucs/qucs/components/gatedDlatch.h
+++ b/qucs/qucs/components/gatedDlatch.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef gatedDlatch_H
-#define gatedDlatch_H
+#ifndef GATEDDLATCH_H
+#define GATEDDLATCH_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class gatedDlatch : public Component
     QString verilogCode(int);
 };
 
-#endif /* gatedDlatch_H */
+#endif /* GATEDDLATCH_H */

--- a/qucs/qucs/components/greytobinary4bit.h
+++ b/qucs/qucs/components/greytobinary4bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef greytobinary4bit_H
-#define greytobinary4bit_H
+#ifndef GREYTOBINARY4BIT_H
+#define GREYTOBINARY4BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class greytobinary4bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* greytobinary4bit_H */
+#endif /* GREYTOBINARY4BIT_H */

--- a/qucs/qucs/components/ha1b.h
+++ b/qucs/qucs/components/ha1b.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef ha1b_H
-#define ha1b_H
+#ifndef HA1B_H
+#define HA1B_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class ha1b : public Component
     QString verilogCode(int);
 };
 
-#endif /* ha1b_H */
+#endif /* HA1B_H */

--- a/qucs/qucs/components/hpribin4bit.h
+++ b/qucs/qucs/components/hpribin4bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef hpribin4bit_H
-#define hpribin4bit_H
+#ifndef HPRIBIN4BIT_H
+#define HPRIBIN4BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class hpribin4bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* hpribin4bit_H */
+#endif /* HPRIBIN4BIT_H */

--- a/qucs/qucs/components/jkff_SR.h
+++ b/qucs/qucs/components/jkff_SR.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef jkff_SR_H
-#define jkff_SR_H
+#ifndef JKFF_SR_H
+#define JKFF_SR_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class jkff_SR : public Component
     QString verilogCode(int);
 };
 
-#endif /* jkff_SR_H */
+#endif /* JKFF_SR_H */

--- a/qucs/qucs/components/log_amp.h
+++ b/qucs/qucs/components/log_amp.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef log_amp_H
-#define log_amp_H
+#ifndef LOG_AMP_H
+#define LOG_AMP_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class log_amp : public Component
     void createSymbol();
 };
 
-#endif /* log_amp_H */
+#endif /* LOG_AMP_H */

--- a/qucs/qucs/components/logic_0.h
+++ b/qucs/qucs/components/logic_0.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef logic_0_H
-#define logic_0_H
+#ifndef LOGIC_0_H
+#define LOGIC_0_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class logic_0 : public Component
     QString verilogCode(int);
 };
 
-#endif /* logic_0_H */
+#endif /* LOGIC_0_H */

--- a/qucs/qucs/components/logic_1.h
+++ b/qucs/qucs/components/logic_1.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef logic_1_H
-#define logic_1_H
+#ifndef LOGIC_1_H
+#define LOGIC_1_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class logic_1 : public Component
     QString verilogCode(int);
 };
 
-#endif /* logic_1_H */
+#endif /* LOGIC_1_H */

--- a/qucs/qucs/components/mod_amp.h
+++ b/qucs/qucs/components/mod_amp.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef mod_amp_H
-#define mod_amp_H
+#ifndef MOD_AMP_H
+#define MOD_AMP_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class mod_amp : public Component
     void createSymbol();
 };
 
-#endif /* mod_amp_H */
+#endif /* MOD_AMP_H */

--- a/qucs/qucs/components/mux2to1.h
+++ b/qucs/qucs/components/mux2to1.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef mux2to1_H
-#define mux2to1_H
+#ifndef MUX2TO1_H
+#define MUX2TO1_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class mux2to1 : public Component
     QString verilogCode(int);
 };
 
-#endif /* mux2to1_H */
+#endif /* MUX2TO1_H */

--- a/qucs/qucs/components/mux4to1.h
+++ b/qucs/qucs/components/mux4to1.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef mux4to1_H
-#define mux4to1_H
+#ifndef MUX4TO1_H
+#define MUX4TO1_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class mux4to1 : public Component
     QString verilogCode(int);
 };
 
-#endif /* mux4to1_H */
+#endif /* MUX4TO1_H */

--- a/qucs/qucs/components/mux8to1.h
+++ b/qucs/qucs/components/mux8to1.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef mux8to1_H
-#define mux8to1_H
+#ifndef MUX8TO1_H
+#define MUX8TO1_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class mux8to1 : public Component
     QString verilogCode(int);
 };
 
-#endif /* mux8to1_H */
+#endif /* MUX8TO1_H */

--- a/qucs/qucs/components/nigbt.h
+++ b/qucs/qucs/components/nigbt.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef nigbt_H
-#define nigbt_H
+#ifndef NIGBT_H
+#define NIGBT_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class nigbt : public Component
     void createSymbol();
 };
 
-#endif /* nigbt_H */
+#endif /* NIGBT_H */

--- a/qucs/qucs/components/pad2bit.h
+++ b/qucs/qucs/components/pad2bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef pad2bit_H
-#define pad2bit_H
+#ifndef PAD2BIT_H
+#define PAD2BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class pad2bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* pad2bit_H */
+#endif /* PAD2BIT_H */

--- a/qucs/qucs/components/pad3bit.h
+++ b/qucs/qucs/components/pad3bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef pad3bit_H
-#define pad3bit_H
+#ifndef PAD3BIT_H
+#define PAD3BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class pad3bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* pad3bit_H */
+#endif /* PAD3BIT_H */

--- a/qucs/qucs/components/pad4bit.h
+++ b/qucs/qucs/components/pad4bit.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef pad4bit_H
-#define pad4bit_H
+#ifndef PAD4BIT_H
+#define PAD4BIT_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class pad4bit : public Component
     QString verilogCode(int);
 };
 
-#endif /* pad4bit_H */
+#endif /* PAD4BIT_H */

--- a/qucs/qucs/components/photodiode.h
+++ b/qucs/qucs/components/photodiode.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef photodiode_H
-#define photodiode_H
+#ifndef PHOTODIODE_H
+#define PHOTODIODE_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class photodiode : public Component
     void createSymbol();
 };
 
-#endif /* photodiode_H */
+#endif /* PHOTODIODE_H */

--- a/qucs/qucs/components/phototransistor.h
+++ b/qucs/qucs/components/phototransistor.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef phototransistor_H
-#define phototransistor_H
+#ifndef PHOTOTRANSISTOR_H
+#define PHOTOTRANSISTOR_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class phototransistor : public Component
     void createSymbol();
 };
 
-#endif /* phototransistor_H */
+#endif /* PHOTOTRANSISTOR_H */

--- a/qucs/qucs/components/potentiometer.h
+++ b/qucs/qucs/components/potentiometer.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef potentiometer_H
-#define potentiometer_H
+#ifndef POTENTIOMETER_H
+#define POTENTIOMETER_H
 
 #include "component.h"
 
@@ -24,4 +24,4 @@ class potentiometer : public Component
     void createSymbol();
 };
 
-#endif /* potentiometer_H */
+#endif /* POTENTIOMETER_H */

--- a/qucs/qucs/components/tff_SR.h
+++ b/qucs/qucs/components/tff_SR.h
@@ -8,8 +8,8 @@
  * 
  */
 
-#ifndef tff_SR_H
-#define tff_SR_H
+#ifndef TFF_SR_H
+#define TFF_SR_H
 
 #include "component.h"
 
@@ -26,4 +26,4 @@ class tff_SR : public Component
     QString verilogCode(int);
 };
 
-#endif /* tff_SR_H */
+#endif /* TFF_SR_H */

--- a/qucs/qucs/components/vacomponent.h
+++ b/qucs/qucs/components/vacomponent.h
@@ -49,4 +49,4 @@ QString getData(QString filename);
 double getDouble(QScriptValue data, QString prop);
 QString getString(QScriptValue data, QString prop);
 
-#endif /* vacomponent_H */
+#endif /* VACOMPONENT_H */

--- a/qucs/qucs/imagewriter.h
+++ b/qucs/qucs/imagewriter.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef IMAGEWRITER_H_
-#define IMAGEWRITER_H_ value
+#ifndef IMAGEWRITER_H
+#define IMAGEWRITER_H
 
 #include <QString>
 
@@ -47,4 +47,4 @@ private:
   void updateMinMax(int &xmin, int &xmax, int &ymin, int &ymax, int x1, int x2, int y1m, int y2);
 };
 
-#endif
+#endif /* IMAGEWRITER_H */

--- a/qucs/qucs/module.h
+++ b/qucs/qucs/module.h
@@ -72,4 +72,4 @@ class Category
   QList<Module *> Content;
 };
 
-#endif /* __MODULE_H__ */
+#endif /* MODULE_H */

--- a/qucs/qucs/printerwriter.h
+++ b/qucs/qucs/printerwriter.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef PRINTERWRITER_H_
-#define PRINTERWRITER_H_ value
+#ifndef PRINTERWRITER_H
+#define PRINTERWRITER_H
 
 #include <QPrinter>
 #include <QString>
@@ -43,4 +43,4 @@ private:
   QPrinter *Printer;
 };
 
-#endif
+#endif /* PRINTERWRITER_H */

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -21,8 +21,8 @@
  *
  */
 
-#ifndef PROJECTVIEW_H_
-#define PROJECTVIEW_H_ value
+#ifndef PROJECTVIEW_H
+#define PROJECTVIEW_H
 
 #include <QTreeView>
 #include <QString>
@@ -57,4 +57,4 @@ private:
   QString m_projName;
 };
 
-#endif /* PROJECTVIEW_H_ */
+#endif /* PROJECTVIEW_H */


### PR DESCRIPTION
Fix all header include guards. The leading underscore is reserved to the C++ implementation. Uppercase is a common convention. This closes issue #264.
