### PR TITLE
const (args) for calcCoordinate. dissect implicit iterator magic.

### DIFF
--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -51,11 +51,11 @@ CurveDiagram::~CurveDiagram()
 }
 
 // ------------------------------------------------------------
-void CurveDiagram::calcCoordinate(double* &, double* &yD, double* &,
-				  float *px, float *py, Axis *pa)
+void CurveDiagram::calcCoordinate(const double*, const double* yD, const double*,
+				  float *px, float *py, Axis *pa) const
 {
-  double yr = *(yD++);
-  double yi = *(yD++);
+  double yr = yD[0];
+  double yi = yD[1];
   if(xAxis.log)
     *px = float(log10(yr / xAxis.low)/log10(xAxis.up / xAxis.low)
 		*double(x2));

--- a/qucs/qucs/diagrams/curvediagram.h
+++ b/qucs/qucs/diagrams/curvediagram.h
@@ -31,7 +31,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
   void finishMarkerCoordinates(float&, float&) const;
   bool insideDiagram(float, float) const;
 

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -523,10 +523,14 @@ void Diagram::calcData(Graph *g)
       for(i=g->countY; i>0; i--) {  // every branch of curves
 	px = g->axis(0)->Points;
 	calcCoordinate(px, pz, py, &p->Scr, &(p+1)->Scr, pa);
+	++px;
+	pz += 2;
 	p += 2;
 	for(z=g->axis(0)->count-1; z>0; z--) {  // every point
 	  FIT_MEMORY_SIZE;  // need to enlarge memory block ?
 	  calcCoordinate(px, pz, py, &p->Scr, &(p+1)->Scr, pa);
+	  ++px;
+	  pz += 2;
 	  p += 2;
 	  if(Counter >= 2)   // clipping only if an axis is manual
 	    clip(p);
@@ -564,6 +568,8 @@ for(int zz=0; zz<z; zz+=2)
         px = g->axis(0)->Points;
         for(z=g->axis(0)->count; z>0; z--) {  // every point
           calcCoordinate(px, pz, py, &p->Scr, &(p+1)->Scr, pa);
+          ++px;
+          pz += 2;
           if(insideDiagram(p->Scr, (p+1)->Scr))    // within diagram ?
             p += 2;
         }
@@ -584,6 +590,8 @@ for(int zz=0; zz<60; zz+=2)
     dist = -Stroke;
     px = g->axis(0)->Points;
     calcCoordinate(px, pz, py, &xtmp, &ytmp, pa);
+    ++px;
+    pz += 2;
     (p++)->Scr = xtmp;
     assert(p!=g->end());
     (p++)->Scr = ytmp;
@@ -593,6 +601,8 @@ for(int zz=0; zz<60; zz+=2)
       dx = xtmp;
       dy = ytmp;
       calcCoordinate(px, pz, py, &xtmp, &ytmp, pa);
+      ++px;
+      pz += 2;
       dx = xtmp - dx;
       dy = ytmp - dy;
       dist += sqrt(double(dx*dx + dy*dy)); // distance between points

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -64,7 +64,7 @@ public:
   virtual Diagram* newOne();
   virtual int  calcDiagram() { return 0; };
   virtual void calcCoordinate
-               (double* &, double* &, double* &, float*, float*, Axis*) {};
+               (const double*, const double*, const double*, float*, float*, Axis*) const {};
   virtual void finishMarkerCoordinates(float&, float&) const;
   virtual void calcLimits() {};
   

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -106,6 +106,8 @@ void Marker::initText(int n)
   pz = pGraph->cPointsY + 2*n;
   for(nn=0; nn<nnn; nn++) {
     Diag->calcCoordinate(px, pz, py, &fCX, &fCY, pa);
+    ++px;
+    pz += 2;
     if(isCross) {
       px--;
       py++;

--- a/qucs/qucs/diagrams/polardiagram.cpp
+++ b/qucs/qucs/diagrams/polardiagram.cpp
@@ -50,11 +50,11 @@ PolarDiagram::~PolarDiagram()
 }
 
 // ------------------------------------------------------------
-void PolarDiagram::calcCoordinate(double* &, double* &yD, double* &,
-				  float *px, float *py, Axis*)
+void PolarDiagram::calcCoordinate(const double*, const double* yD, const double*,
+				  float *px, float *py, Axis*) const
 {
-  double yr = *(yD++);
-  double yi = *(yD++);
+  double yr = yD[0];
+  double yi = yD[1];
   *px = float((yr/yAxis.up + 1.0)*double(x2)/2.0);
   *py = float((yi/yAxis.up + 1.0)*double(y2)/2.0);
 

--- a/qucs/qucs/diagrams/polardiagram.h
+++ b/qucs/qucs/diagrams/polardiagram.h
@@ -31,7 +31,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
 };
 
 #endif

--- a/qucs/qucs/diagrams/psdiagram.cpp
+++ b/qucs/qucs/diagrams/psdiagram.cpp
@@ -52,11 +52,11 @@ PSDiagram::~PSDiagram()
 }
 
 // ------------------------------------------------------------
-void PSDiagram::calcCoordinate(double* &, double* &yD, double* &,
-                               float *px, float *py, Axis *pa)
+void PSDiagram::calcCoordinate(const double*, const double* yD, const double*,
+                               float *px, float *py, Axis *pa) const
 {
-  double yr = *(yD++);
-  double yi = *(yD++);
+  double yr = yD[0];
+  double yi = yD[1];
   *px = float((yr/pa->up + 1.0)*double(x2)/2.0);
   *py = float((yi/pa->up + 1.0)*double(y2)/2.0);
 

--- a/qucs/qucs/diagrams/psdiagram.h
+++ b/qucs/qucs/diagrams/psdiagram.h
@@ -33,7 +33,7 @@ public:
   static Element* info_sp(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
 };
 
 #endif

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -78,19 +78,19 @@ void Rect3DDiagram::calcCoefficients()
 }
 
 // ------------------------------------------------------------
-double Rect3DDiagram::calcX_2D(double x, double y, double z)
+double Rect3DDiagram::calcX_2D(double x, double y, double z) const
 {
   return (cxx * x + cxy * y + cxz * z) * scaleX;
 }
 
 // ------------------------------------------------------------
-double Rect3DDiagram::calcY_2D(double x, double y, double z)
+double Rect3DDiagram::calcY_2D(double x, double y, double z) const
 {
   return (cyx * x + cyy * y + cyz * z) * scaleY;
 }
 
 // ------------------------------------------------------------
-double Rect3DDiagram::calcZ_2D(double x, double y, double z)
+double Rect3DDiagram::calcZ_2D(double x, double y, double z) const
 {
   return czx * x + czy * y + czz * z;
 }
@@ -136,11 +136,11 @@ int Rect3DDiagram::calcCross(int *Xses, int *Yses)
 
 // ------------------------------------------------------------
 // Is needed for markers.
-void Rect3DDiagram::calcCoordinate(double* &xD, double* &zD, double* &yD,
-                                   float *px, float *py, Axis*)
+void Rect3DDiagram::calcCoordinate(const double* xD, const double* zD, const double* yD,
+                                   float *px, float *py, Axis*) const
 {
-  double x3D = *(zD++);
-  double y3D = *(zD++);
+  double x3D = zD[0];
+  double y3D = zD[1];
   double z3D;
   if(zAxis.log) {
     z3D = sqrt(x3D*x3D + y3D*y3D);

--- a/qucs/qucs/diagrams/rect3ddiagram.h
+++ b/qucs/qucs/diagrams/rect3ddiagram.h
@@ -46,7 +46,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
   void finishMarkerCoordinates(float&, float&) const;
 
   void createAxisLabels();
@@ -65,9 +65,9 @@ private:
 
   void   calcCoefficients();
   int    calcCross(int*, int*);
-  double calcX_2D(double, double, double);
-  double calcY_2D(double, double, double);
-  double calcZ_2D(double, double, double);
+  double calcX_2D(double, double, double) const;
+  double calcY_2D(double, double, double) const;
+  double calcZ_2D(double, double, double) const;
 
   static int comparePoint3D(const void*, const void*);
   static int comparePointZ(const void*, const void*);

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -53,12 +53,12 @@ RectDiagram::~RectDiagram()
 }
 
 // ------------------------------------------------------------
-void RectDiagram::calcCoordinate(double* &xD, double* &yD, double* &,
-                                 float *px, float *py, Axis *pa)
+void RectDiagram::calcCoordinate(const double* xD, const double* yD, const double*,
+                                 float *px, float *py, Axis *pa) const
 {
-  double x  = *(xD++);
-  double yr = *(yD++);
-  double yi = *(yD++);
+  double x  = *xD;
+  double yr = yD[0];
+  double yi = yD[1];
   if(xAxis.log) {
     x /= xAxis.low;
     if(x <= 0.0)  *px = -1e5;   // "negative infinity"

--- a/qucs/qucs/diagrams/rectdiagram.h
+++ b/qucs/qucs/diagrams/rectdiagram.h
@@ -31,7 +31,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
   void finishMarkerCoordinates(float&, float&) const;
   bool insideDiagram(float, float) const;
 

--- a/qucs/qucs/diagrams/smithdiagram.cpp
+++ b/qucs/qucs/diagrams/smithdiagram.cpp
@@ -53,11 +53,11 @@ SmithDiagram::~SmithDiagram()
 
 // ------------------------------------------------------------
 // calculate the screen coordinates for the graph data
-void SmithDiagram::calcCoordinate(double* &, double* &yD, double* &,
-                                  float *px, float *py, Axis*)
+void SmithDiagram::calcCoordinate(const double*, const double* yD, const double*,
+                                  float *px, float *py, Axis*) const
 {
-  double yr = *(yD++);
-  double yi = *(yD++);
+  double yr = yD[0];
+  double yi = yD[1];
   *px = float((yr/yAxis.up + 1.0)*double(x2)/2.0);
   *py = float((yi/yAxis.up + 1.0)*double(y2)/2.0);
 

--- a/qucs/qucs/diagrams/smithdiagram.h
+++ b/qucs/qucs/diagrams/smithdiagram.h
@@ -32,7 +32,7 @@ public:
   static Element* info_y(QString&, char* &, bool getNewOne=false);
   int  calcDiagram();
   void calcLimits();
-  void calcCoordinate(double* &, double* &, double* &, float*, float*, Axis*);
+  void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis*) const;
 };
 
 #endif


### PR DESCRIPTION
want to use proper iterators later on. the current calcCoordinates implementation interferes with this.
this PR is just moving code to where it belongs and adds a few decorators.