### PR TITLE
Fix names of docked widgets

### DIFF
--- a/qucs/qucs/messagedock.cpp
+++ b/qucs/qucs/messagedock.cpp
@@ -56,7 +56,7 @@ MessageDock::MessageDock(QucsApp *App_): QWidget()
 
     builderTabs->insertTab(1,cppOutput,tr("Compiler"));
 
-    msgDock = new QDockWidget();
+    msgDock = new QDockWidget(tr("admsXml Dock"));
     msgDock->setWidget(builderTabs);
     App_->addDockWidget(Qt::BottomDockWidgetArea, msgDock);
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -222,7 +222,7 @@ void QucsApp::initView()
   DocumentTab->setMovable (true);
 #endif
 
-  dock = new QDockWidget(this);
+  dock = new QDockWidget(tr("Main Dock"),this);
   TabView = new QTabWidget(dock);
   TabView->setTabPosition(QTabWidget::West);
 
@@ -364,15 +364,12 @@ void QucsApp::initView()
 
   // ----------------------------------------------------------
   // Octave docking window
-  //octDock = new Q3DockWindow(Q3DockWindow::InDock, this);
-  //octDock->setCloseMode(Q3DockWindow::Always);
-  octDock = new QDockWidget();
+  octDock = new QDockWidget(tr("Octave Dock"));
 
   connect(octDock, SIGNAL(visibilityChanged(bool)), SLOT(slotToggleOctave(bool)));
   octave = new OctaveWindow(octDock);
   this->addDockWidget(Qt::BottomDockWidgetArea, octDock);
   this->setCorner(Qt::BottomLeftCorner  , Qt::LeftDockWidgetArea);
-  //| Qt::BottomRightCorner
 
   // ............................................
 


### PR DESCRIPTION
Pressing right-clik on the toolbar brings a context menu to control
the visibility of docked widgets (toobar, docks,...).
Some widgets where unamed and the context menu was blank.
This patch add names to the widgets.

Close issue #253