### PR TITLE
Change 'Export as Image' Dialog to Native

### DIFF
--- a/qucs/qucs/dialogs/exportdialog.cpp
+++ b/qucs/qucs/dialogs/exportdialog.cpp
@@ -43,7 +43,7 @@ ExportDialog::ExportDialog(int w, int h, int wsel, int hsel, QString filename_, 
     filename = filename_;
 
     lblFilename = new QLabel(tr("Save to file (Graphics format by extension)"));
-    lblResolutionX = new QLabel(tr("Width  in pixels"));
+    lblResolutionX = new QLabel(tr("Width in pixels"));
     lblResolutionY = new QLabel(tr("Height in pixels"));
     lblRatio = new QLabel(tr("Scale factor: "));
     lblFormat = new QLabel(tr("Image format:"));
@@ -52,7 +52,7 @@ ExportDialog::ExportDialog(int w, int h, int wsel, int hsel, QString filename_, 
     connect(ExportButt,SIGNAL(clicked()),this,SLOT(accept()));
     CancelButt = new QPushButton(tr("Cancel"));
     connect(CancelButt,SIGNAL(clicked()),this,SLOT(reject()));
-    SaveButt = new QPushButton(tr("File"));
+    SaveButt = new QPushButton(tr("Browse"));
     connect(SaveButt,SIGNAL(clicked()),this,SLOT(setFileName()));
 
     editFilename = new QLineEdit(filename);
@@ -156,35 +156,45 @@ int ExportDialog::Ypixels()
 
 void ExportDialog::setFileName()
 {
-    /*QString nam = dialog.getSaveFileName(this,tr("Export diagram to file"),QDir::homeDirPath(),
-                                         "SVG vector graphics (*.svg) ;;"
-                                         "PNG images (*.png) ;;"
-                                         "JPEG images (*.jpg *.jpeg)");
-    */
-    //QFileInfo inf(filename);
-    QFileDialog dialog(this, tr("Export to image"), editFilename->text(),
-                       "SVG vector graphics (*.svg) ;;"
-                       "PNG images (*.png) ;;"
-                       "JPEG images (*.jpg *.jpeg) ;;"
-                       "PDF (*.pdf) ;;"
-                       "PDF + LaTeX (*.pdf_tex) ;;"
-                       "EPS Encapsulated Postscript (*.eps)");
-    dialog.setAcceptMode(QFileDialog::AcceptSave);
-    if(dialog.exec())
-    {
-        QString nam = dialog.selectedFile();
-        QString extension;
-        if(dialog.selectedNameFilter().contains("*.png")) extension=QString(".png");
-        if(dialog.selectedNameFilter().contains("*.jpg")) extension=QString(".jpg");
-        if(dialog.selectedNameFilter().contains("*.svg")) extension=QString(".svg");
-        if(dialog.selectedNameFilter().contains("*.pdf")) extension=QString(".pdf");
-        if(dialog.selectedNameFilter().contains("*.pdf_tex")) extension=QString(".pdf_tex");
-        if(dialog.selectedNameFilter().contains("*.eps")) extension=QString(".eps");
-        if(nam.toLower().section("/",-1,-1).contains(".")) //has the user specified an extension?
-            editFilename->setText(nam); //yes, just leave unchanged
-        else
-            editFilename->setText(nam+extension); //no, add extension
+  QString selectedFilter;
+  QString currentExtension;
+  QString filterExtension;
+
+  QString fileName = QFileDialog::getSaveFileName(this, tr("Export Schematic to Image"),
+      editFilename->text(),
+      "PNG images (*.png);;"
+      "JPEG images (*.jpg *.jpeg);;"
+      "SVG vector graphics (*.svg);;"
+      "PDF (*.pdf);;"
+      "PDF + LaTeX (*.pdf_tex);;"
+      "EPS Encapsulated Postscript (*.eps)",
+      &selectedFilter);
+
+  if (fileName.isEmpty()) return;
+
+  if (selectedFilter.contains("*.png", Qt::CaseInsensitive)) filterExtension = QString(".png");
+  if (selectedFilter.contains("*.jpg", Qt::CaseInsensitive)) filterExtension = QString(".jpg");
+  if (selectedFilter.contains("*.svg", Qt::CaseInsensitive)) filterExtension = QString(".svg");
+  if (selectedFilter.contains("*.pdf", Qt::CaseInsensitive)) filterExtension = QString(".pdf");
+  if (selectedFilter.contains("*.pdf_tex", Qt::CaseInsensitive)) filterExtension = QString(".pdf_tex");
+  if (selectedFilter.contains("*.eps", Qt::CaseInsensitive)) filterExtension = QString(".eps");
+
+  QFileInfo fileInfo(fileName);
+
+  currentExtension = fileInfo.suffix();
+
+  QString allowedExtensions = "png;jpg;jpeg;svg;pdf;pdf_tex;eps";
+  QStringList extensionsList = allowedExtensions.split (';');
+
+  if (currentExtension.isEmpty()) {
+    fileName.append(filterExtension);
+  } else {
+    if (!extensionsList.contains(currentExtension)) {
+      fileName.append(filterExtension);
     }
+  }
+
+  editFilename->setText(fileName);
 }
 
 void ExportDialog::calcWidth()

--- a/qucs/qucs/imagewriter.cpp
+++ b/qucs/qucs/imagewriter.cpp
@@ -23,8 +23,11 @@
 #include "schematic.h"
 #include "imagewriter.h"
 #include "dialogs/exportdialog.h"
+#include "qucs.h"
 
 #include <QtSvg>
+
+extern QucsApp *QucsMain;
 
 ImageWriter::ImageWriter(QString lastfile)
 {
@@ -256,8 +259,9 @@ ImageWriter::print(QWidget *doc)
       }
 
       if (QFile::exists(filename)) {
-        QMessageBox::information(0, QObject::tr("Export to image"),
-            QObject::tr("Successfully exported"), QMessageBox::Ok);
+        //QMessageBox::information(0, QObject::tr("Export to image"),
+        //    QObject::tr("Successfully exported"), QMessageBox::Ok);
+        QucsMain->statusBar()->showMessage(QObject::tr("Successfully exported"), 2000);
       } 
       else {
         QMessageBox::information(0, QObject::tr("Export to image"),

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -269,8 +269,10 @@ void QucsApp::initActions()
   //mainAccel->connectItem(mainAccel->insertItem(Qt::Key_Backspace),
   //                       editDelete, SLOT(toggle()) );
 
-  exportAsImage = new QAction(tr("Export as image"),this);
+  exportAsImage = new QAction(tr("Export the schematic to an image..."),this);
   connect(exportAsImage,SIGNAL(triggered()),SLOT(slotSaveSchematicToGraphicsFile()));
+  exportAsImage->setStatusTip(tr("Exports the schematic to an image file"));
+  exportAsImage->setWhatsThis(tr("Export the schematic to an image\n\nExports the schematic to an image file"));
 
   // cursor left/right/up/down to move marker on a graph
   cursorLeft = new QShortcut(QKeySequence(Qt::Key_Left), this);


### PR DESCRIPTION
Uses static QDialog for native look for saving the schematic as an image file.