### PR TITLE
Fixed library paths for user library components

### DIFF
--- a/qucs/qucs-lib/qucslib_common.h
+++ b/qucs/qucs-lib/qucslib_common.h
@@ -19,6 +19,7 @@
 #define _QUCSLIB_COMMON_H_
 
 #include <QFile>
+#include <QFileInfo>
 #include <QTextStream>
 #include <QDebug>
 
@@ -191,6 +192,10 @@ inline int makeModelString (QString libname, QString compname, QString compstrin
     }
 
     // construct the library model string
+    QString full_userlib = QucsSettings.QucsHomeDir.canonicalPath() // check is it user library or not ?
+            +QDir::convertSeparators ("/user_lib/")+libname;
+    QFileInfo inf(full_userlib+".lib");
+    if (inf.exists()) libname = full_userlib;
     modelstring =  "<Lib " + Prefix + " 1 0 0 " +
                    QString::number(Text_x) + " " +
                    QString::number(Text_y) + " 0 0 \"" +


### PR DESCRIPTION
This fixes the following bug. If there are user libraries in `$HOME/.qucs/user_lib` you cannot insert components from them using left-side LibraryTree dock. Components in user libraries appeared as squares. You can insert them into schematic only using Library Tool `Tools->Component Library`. 

Now this bug is fixed. User-defined components can be inserted in schematic from left-side LibraryTree dock.