### PR TITLE
Fix regression on EDD component.

### DIFF
--- a/qucs-core/src/equation.cpp
+++ b/qucs-core/src/equation.cpp
@@ -572,7 +572,7 @@ void assignment::add (assignment * f)
     else if (isZero (body))
     {
         delete body;
-        //body = factor;
+        body = factor;
     }
     else if (isZero (factor))
     {


### PR DESCRIPTION
Error introduced in 6a073cf.
A few lines of code were commented out to silece compiler warnings.
One line should not be commented out.
This commit reverts the situation.

Closes issue #296