### PR TITLE
Correct CPW formulae in QucsTranscalc and qucsator

### DIFF
--- a/qucs-core/src/components/microstrip/cpwline.h
+++ b/qucs-core/src/components/microstrip/cpwline.h
@@ -43,6 +43,7 @@ class cpwline : public qucs::circuit
   static void ellipke (nr_double_t, nr_double_t &, nr_double_t &);
   static nr_double_t ellipk (nr_double_t);
   static nr_double_t ellipa (nr_double_t);
+  static nr_double_t KoverKp(nr_double_t);
 
   static void analyseQuasiStatic (nr_double_t, nr_double_t, nr_double_t,
 				  nr_double_t, nr_double_t, int,

--- a/qucs-doc/technical/coplanar.tex
+++ b/qucs-doc/technical/coplanar.tex
@@ -103,9 +103,28 @@ C_a = 2\cdot \varepsilon_0\cdot \dfrac{K(k_1)}{K'(k_1)}
 
 In both formulae $K(k)$ and $K'(k)$ represent the complete elliptic
 integral of the first kind and its complement, and $k_1=
-\tfrac{W}{W+2s}$.  While the separate evaluation of $K$ and $K'$ is
-more or less tricky, the $K/K'$ ratio lets itself compute efficiently
-through the following formulae:
+\tfrac{W}{W+2s}$.
+
+\addvspace{12pt}
+
+$K(k)$ (and $K'(k)$) can be computed easily by using the \emph{arithmetic-geometric mean} method \cite{Abramowitz}: starting with
+\begin{equation}
+a_0 = 1, \quad b_0 = \sqrt{1 -k^2}
+\end{equation}
+the following recursion formulae are iterated
+\begin{equation}
+a_n = \dfrac{1}{2}(a_{n-1}+b_{n-1}), \quad b_n = \sqrt{a_{n-1}b_{n-1}}, \quad c_n=a_{n-1}-b_{n-1}
+\end{equation}
+until $c_N=0$ within a predetermined accuracy.\\
+$K(k)$ is then found from
+\begin{equation}
+K(k) = \dfrac{\pi}{2 a_N}
+\end{equation}
+
+\addvspace{12pt}
+
+When only the the $K/K'$ ratio is needed it can be approximated
+efficiently through the following formulae:
 \begin{equation}
 \dfrac{K(k)}{K'(k)} =
 \dfrac{\pi}{\ln\left(2\tfrac{1+\sqrt{k'}}{1-\sqrt{k'}}\right)}
@@ -119,10 +138,14 @@ through the following formulae:
 \dfrac{1}{\sqrt{2}} \le k \le 1
 \end{equation}
 
-with $k'$ being the complementary modulus: $k'=\sqrt{1-k^2}$.  While
-\cite{Collin} states that the accuracy of the above formulae is close
-to $10^{-5}$, \cite{Gupta1} claims it to be $3\cdot10^{-6}$.  It can
-be considered as exact for any practical purposes.
+with $k'$ being the complementary modulus: $k'=\sqrt{1-k^2}$.
+This formula was first derived in \cite{Hilberg}. According to
+\cite{Collin} the accuracy of the above formulae is close
+to $10^{-5}$, \cite{Gupta1} claims it to be $3\cdot10^{-6}$ while comparison
+with GNU Octave using the $ellipke()$ function shows a maximum relative error
+of about $2\cdot10^{-6}$ . More accurate approximations can be found in 
+\cite{Hilberg} and \cite{Abbott} but the above formulae can already be 
+considered as exact for any practical purpose.
 
 \addvspace{12pt}
 

--- a/qucs-doc/technical/literature.bib
+++ b/qucs-doc/technical/literature.bib
@@ -80,7 +80,7 @@
 }
 
 @book{Abramowitz,
- author    = {Milton Abramowitz and Irene A. Segun},
+ author    = {Milton Abramowitz and Irene A. Stegun},
  title     = "{Handbook of Mathematical Functions with Formulas, Graphs,
                and Mathematical Tables}",
  publisher = {Dover Publications, Inc.},
@@ -314,6 +314,19 @@
 
 
 %
+% theses
+%
+
+@MastersThesis{Abbott,
+ author  = {Jeffrey Townsley Abbott},
+ title   = {Modeling the Capacitive Behavior of Coplanar Striplines and Coplanar Waveguides Using Simple Functions},
+ school  = {Rochester Institute of Technology},
+ address = {Rochester, New York},
+ year    = {2011},
+ month   = jun,
+}
+
+%
 % internet addresses
 %
 
@@ -390,7 +403,7 @@
 }
 
 @article{Monaco,
- author  = {Vito A. Monaco and Poalo Tiberio},
+ author  = {Vito A. Monaco and Paolo Tiberio},
  title   = "{Computer-Aided Analysis of Microwave Circuits}",
  journal = IEEETMTT,
  volume  = {22},
@@ -1292,3 +1305,15 @@
  isbn    = {1-58053-834-7},
  local   = "{01262971.pdf}",
 }
+
+@article{Hilberg,
+ author  = {Wolfgang Hilberg},
+ title   = {From Approximations to Exact Relations for Characteristic Impedances},
+ journal = IEEETMTT,
+ volume  = {17},
+ number  = {5},
+ month   = may,
+ year    = {1969},
+ pages   = {259-265},
+}
+

--- a/qucs/qucs-transcalc/coplanar.h
+++ b/qucs/qucs-transcalc/coplanar.h
@@ -54,8 +54,8 @@ class coplanar : public transline {
   void show_results();
   void getProperties();
 
-  void ellipke(double, double&, double&);
   double ellipk(double);
+  double KoverKp(double);
 };
 
 


### PR DESCRIPTION
This is a fix for [bug 183 on SF] (https://sourceforge.net/p/qucs/bugs/183/).
The coplanar waveguide (CPW) characteristics formulae were incorrect, mainly due to an incorrect usage of the algorithm used to compute the complete elliptic integral of the first kind `K()`; the argument passed to the function was the elliptic modulus `k`, while the function was expecting the parameter `m=k^2`. Interestingly enough, the CPW calculations mainly need the ratio `K(k)/K(sqrt(1-k^2))`, with `k` in the range from 0 to 1 and the incorrectly used ratio `K(m)/K(1-m)` differs from that by 7% at most over the entire range and is just a few percent off for typical `k` values, so the results were not completely off.
The function computing `K(k)` was rewritten, in a slightly simpler form, to accept the elliptic modulus `k` as input parameter and another calculation for the thickness dependency of the CPW with ground configuration was corrected, in both QucsTranscalc and `qucsator`. (a long-standing issue is the code duplication between QucsTranscalc and the transmission line code in `qucsator`, we should have a common library for the transmission line functions)
The Technical Papers document was updated with a short description of the algorithm used to compute K(k) (and a couple of typos there was fixed).
Out of curiosity, a similar issue was in the documentation of GNU Octave, http://savannah.gnu.org/bugs/?45522 , and this confused me a bit at the beginning...
