### PR TITLE
support for multiple simulators

### DIFF
--- a/qucs/Makefile.am
+++ b/qucs/Makefile.am
@@ -21,6 +21,7 @@
 # the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
 # Boston, MA 02110-1301, USA.  
 #
+ACLOCAL_AMFLAGS=-Im4
 
 SUBDIRS = \
   qucs \

--- a/qucs/autogen.sh
+++ b/qucs/autogen.sh
@@ -31,6 +31,8 @@ echo "done."
 echo -n "Creating config.h.in... "
 autoheader
 echo "done."
+echo "Running libtoolize"
+libtoolize || exit 1
 echo -n "Creating Makefile.in(s)... "
 ${AUTOMAKE:-automake} -a -f -c
 echo "done."

--- a/qucs/autogen.sh
+++ b/qucs/autogen.sh
@@ -25,6 +25,11 @@
 here=`pwd`
 cd `dirname $0`
 
+case `uname` in
+  *Darwin*) LIBTOOLIZE=glibtoolize ;;
+  *) LIBTOOLIZE=libtoolize ;;
+esac
+
 echo -n "Creating aclocal.m4... "
 ${ACLOCAL:-aclocal} -I m4
 echo "done."
@@ -32,7 +37,7 @@ echo -n "Creating config.h.in... "
 autoheader
 echo "done."
 echo "Running libtoolize"
-libtoolize || exit 1
+$LIBTOOLIZE || exit 1
 echo -n "Creating Makefile.in(s)... "
 ${AUTOMAKE:-automake} -a -f -c
 echo "done."

--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -16,6 +16,7 @@ AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([no-define])
 AM_MAINTAINER_MODE
 AC_PREFIX_DEFAULT([/usr/local])
+AC_CONFIG_MACRO_DIR([m4])
 
 dnl Checks for programs.
 AC_PROG_CXX(clang++ g++)

--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -20,8 +20,8 @@ AC_PREFIX_DEFAULT([/usr/local])
 dnl Checks for programs.
 AC_PROG_CXX(clang++ g++)
 AC_PROG_CC
-AC_PROG_RANLIB
 AC_CHECK_TOOL(AR, ar, :)
+LT_INIT()
 
 dnl Check for debugging option.
 AC_ARG_ENABLE([debug],

--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -834,6 +834,7 @@ AC_CONFIG_FILES([Makefile
     qucs/diagrams/Makefile
     qucs/paintings/Makefile
     qucs/dialogs/Makefile
+    qucs/sim/Makefile
     translations/Makefile])
 
 dnl Check for Git short SHA to tag version

--- a/qucs/qucs/CMakeLists.txt
+++ b/qucs/qucs/CMakeLists.txt
@@ -132,6 +132,7 @@ SET(QUCS_SRCS
   wirelabel.cpp node.cpp qucs_init.cpp
   syntax.cpp misc.cpp messagedock.cpp
   imagewriter.cpp printerwriter.cpp projectView.cpp
+  sim/qucsator.cpp
 )
 
 SET(QUCS_HDRS

--- a/qucs/qucs/Makefile.am
+++ b/qucs/qucs/Makefile.am
@@ -40,7 +40,7 @@ qucs_SOURCES = qucs.cpp node.cpp element.cpp qucsdoc.cpp wire.cpp mouseactions.c
   viewpainter.cpp mnemo.cpp schematic.cpp schematic_element.cpp textdoc.cpp \
   schematic_file.cpp syntax.cpp module.cpp octave_window.cpp qrc_qucs.cpp   \
   messagedock.cpp misc.cpp imagewriter.cpp printerwriter.cpp \
-	projectView.cpp sim/qucsator.cpp
+	projectView.cpp
 
 qrc_qucs.cpp: qucs.qrc
 	$(RCC) -o $@ $<
@@ -52,6 +52,9 @@ qucs_LDFLAGS = $(X11_LDFLAGS) $(QT_LDFLAGS)
 qucs_LDADD = components/libcomponents.a diagrams/libdiagrams.a \
   paintings/libpaintings.a dialogs/libdialogs.a \
   $(X11_LIBS) $(QT_LIBS)
+
+# adding sim/qucsator.la does not work. this is a workaround.
+qucs_LDADD+= sim/qucsator_la-qucsator.o
 
 noinst_HEADERS = $(MOCHEADERS) main.h wire.h qucsdoc.h element.h node.h \
   wirelabel.h viewpainter.h mnemo.h mouseactions.h syntax.h module.h misc.h

--- a/qucs/qucs/Makefile.am
+++ b/qucs/qucs/Makefile.am
@@ -22,7 +22,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-SUBDIRS = components diagrams paintings dialogs octave
+SUBDIRS = components diagrams paintings dialogs octave sim
 
 if COND_WIN32
 bin_SCRIPTS = qucsdigi.bat qucsveri.bat qucsdigilib.bat
@@ -35,12 +35,12 @@ bin_PROGRAMS = qucs
 MOCHEADERS = qucs.h schematic.h textdoc.h octave_window.h messagedock.h
 MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 
-qucs_SOURCES = node.cpp element.cpp qucsdoc.cpp wire.cpp mouseactions.cpp   \
-  qucs.cpp main.cpp wirelabel.cpp qucs_init.cpp qucs_actions.cpp            \
+qucs_SOURCES = qucs.cpp node.cpp element.cpp qucsdoc.cpp wire.cpp mouseactions.cpp   \
+  main.cpp wirelabel.cpp qucs_init.cpp qucs_actions.cpp            \
   viewpainter.cpp mnemo.cpp schematic.cpp schematic_element.cpp textdoc.cpp \
   schematic_file.cpp syntax.cpp module.cpp octave_window.cpp qrc_qucs.cpp   \
   messagedock.cpp misc.cpp imagewriter.cpp printerwriter.cpp \
-	projectView.cpp
+	projectView.cpp sim/qucsator.cpp
 
 qrc_qucs.cpp: qucs.qrc
 	$(RCC) -o $@ $<

--- a/qucs/qucs/components/EKV26MOS.cpp
+++ b/qucs/qucs/components/EKV26MOS.cpp
@@ -270,7 +270,7 @@ void EKV26MOS::createSymbol()
   x2 =  20; y2 =  30;
 }
 
-QString EKV26MOS::netlist()
+QString EKV26MOS::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/EKV26MOS.h
+++ b/qucs/qucs/components/EKV26MOS.h
@@ -23,7 +23,7 @@ class EKV26MOS : public MultiViewComponent
     static Element* info_pmos(QString&, char* &, bool getNewOne=false);
   protected:
     void createSymbol();
-    QString netlist();
+    QString netlist() const;
 };
 
 #endif /* EKV26MOS_H */

--- a/qucs/qucs/components/bjt.cpp
+++ b/qucs/qucs/components/bjt.cpp
@@ -91,7 +91,7 @@ void BJT::createSymbol()
 }
 
 // -------------------------------------------------------
-QString BJT::netlist()
+QString BJT::netlist() const
 {
   QString s = "BJT:"+Name;
 

--- a/qucs/qucs/components/bjt.h
+++ b/qucs/qucs/components/bjt.h
@@ -31,7 +31,7 @@ public:
 
 protected:
   void createSymbol();
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -611,42 +611,13 @@ void Component::mirrorY()
 }
 
 // -------------------------------------------------------
+/*!
+ * obsolete function. still used for some special components
+ * just indicate that it's obsolete, so the netlister knows.
+ */
 QString Component::netlist() const
 {
-  QString s = Model+":"+Name;
-
-  // output all node names
-  foreach(Port *p1, Ports)
-    s += " "+p1->Connection->Name;   // node names
-
-  // output all properties
-  for(Property *p2 = Props.first(); p2 != 0; p2 = Props.next())
-    if(p2->Name != "Symbol")
-      s += " "+p2->Name+"=\""+p2->Value+"\"";
-
-  return s + '\n';
-}
-
-// -------------------------------------------------------
-QString Component::getNetlist() const
-{
-  switch(isActive) {
-    case COMP_IS_ACTIVE:
-      return netlist();
-    case COMP_IS_OPEN:
-      return QString("");
-  }
-
-  // Component is shortened.
-  int z=0;
-  QListIterator<Port *> iport(Ports);
-  Port *pp = iport.next();
-  QString Node1 = pp->Connection->Name;
-  QString s = "";
-  while (iport.hasNext())
-    s += "R:" + Name + "." + QString::number(z++) + " " +
-      Node1 + " " + iport.next()->Connection->Name + " R=\"0\"\n";
-  return s;
+  return "obsolete";
 }
 
 // -------------------------------------------------------

--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -611,7 +611,7 @@ void Component::mirrorY()
 }
 
 // -------------------------------------------------------
-QString Component::netlist()
+QString Component::netlist() const
 {
   QString s = Model+":"+Name;
 
@@ -628,7 +628,7 @@ QString Component::netlist()
 }
 
 // -------------------------------------------------------
-QString Component::getNetlist()
+QString Component::getNetlist() const
 {
   switch(isActive) {
     case COMP_IS_ACTIVE:
@@ -1314,7 +1314,7 @@ GateComponent::GateComponent()
 }
 
 // -------------------------------------------------------
-QString GateComponent::netlist()
+QString GateComponent::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/component.h
+++ b/qucs/qucs/components/component.h
@@ -35,7 +35,7 @@ public:
 
   virtual Component* newOne();
   virtual void recreate(Schematic*) {};
-  QString getNetlist() const;
+  QString getNetlist() const {return netlist();}
   QString get_VHDL_Code(int);
   QString get_Verilog_Code(int);
   void    paint(ViewPainter*);
@@ -75,6 +75,13 @@ public:
   #define COMP_IS_OPEN    0
   #define COMP_IS_ACTIVE  1
   #define COMP_IS_SHORTEN 2
+  bool isShort() const{return isActive==COMP_IS_SHORTEN;}
+  bool isOpen() const{return isActive==COMP_IS_OPEN;}
+  QString type() const{return Model;}
+  QString label() const{return Name;}
+  Q3PtrList<Property> const& params() const{return Props;}
+  QList<Port*>const& ports() const{return Ports;}
+// private: // not yet
   int  isActive; // should it be used in simulation or not ?
   int  tx, ty;   // upper left corner of text (position)
   bool showName;

--- a/qucs/qucs/components/component.h
+++ b/qucs/qucs/components/component.h
@@ -35,7 +35,7 @@ public:
 
   virtual Component* newOne();
   virtual void recreate(Schematic*) {};
-  QString getNetlist();
+  QString getNetlist() const;
   QString get_VHDL_Code(int);
   QString get_Verilog_Code(int);
   void    paint(ViewPainter*);
@@ -58,7 +58,7 @@ public:
   bool mirroredX;   // is it mirrored about X axis or not
   int  rotated;     // rotation angle divided by 90 degrees
 
-  virtual QString getSubcircuitFile() { return ""; }
+  virtual QString getSubcircuitFile() const { return ""; }
   // set the pointer scematic associated with the component
   virtual void setSchematic (Schematic* p) { containingSchematic = p; }
   virtual Schematic* getSchematic () {return containingSchematic; }
@@ -69,7 +69,8 @@ public:
   QList<Area *>     Ellips;
   QList<Port *>     Ports;
   QList<Text *>     Texts;
-  Q3PtrList<Property> Props;
+  mutable //bug: Q3PtrList does not support constness
+      Q3PtrList<Property> Props;
 
   #define COMP_IS_OPEN    0
   #define COMP_IS_ACTIVE  1
@@ -81,7 +82,7 @@ public:
   QString  Description;
 
 protected:
-  virtual QString netlist();
+  virtual QString netlist() const;
   virtual QString vhdlCode(int);
   virtual QString verilogCode(int);
 
@@ -112,7 +113,7 @@ protected:
 class GateComponent : public MultiViewComponent {
 public:
   GateComponent();
-  QString netlist();
+  QString netlist() const;
   QString vhdlCode(int);
   QString verilogCode(int);
 

--- a/qucs/qucs/components/digi_source.cpp
+++ b/qucs/qucs/components/digi_source.cpp
@@ -80,7 +80,7 @@ Element* Digi_Source::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString Digi_Source::netlist()
+QString Digi_Source::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/digi_source.h
+++ b/qucs/qucs/components/digi_source.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   QString vhdlCode(int);
   QString verilogCode(int);
 };

--- a/qucs/qucs/components/ecvs.cpp
+++ b/qucs/qucs/components/ecvs.cpp
@@ -90,7 +90,7 @@ Element* ecvs::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 
 // -------------------------------------------------------
-QString ecvs::netlist()
+QString ecvs::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/ecvs.h
+++ b/qucs/qucs/components/ecvs.h
@@ -38,7 +38,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/eqndefined.cpp
+++ b/qucs/qucs/components/eqndefined.cpp
@@ -69,7 +69,7 @@ Element* EqnDefined::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString EqnDefined::netlist()
+QString EqnDefined::netlist() const
 {
   QString s = Model+":"+Name;
   QString e = "\n";

--- a/qucs/qucs/components/eqndefined.h
+++ b/qucs/qucs/components/eqndefined.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 };
 

--- a/qucs/qucs/components/ground.cpp
+++ b/qucs/qucs/components/ground.cpp
@@ -60,7 +60,7 @@ Element* Ground::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString Ground::netlist()
+QString Ground::netlist() const
 {
   return QString("");
 }

--- a/qucs/qucs/components/ground.h
+++ b/qucs/qucs/components/ground.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/hic0_full.cpp
+++ b/qucs/qucs/components/hic0_full.cpp
@@ -341,7 +341,7 @@ void hic0_full::createSymbol()
   x2 =  30; y2 =  30;
 }
 
-QString hic0_full::netlist()
+QString hic0_full::netlist() const
 {
   QString s = "hic0_full:"+Name;
 

--- a/qucs/qucs/components/hic0_full.h
+++ b/qucs/qucs/components/hic0_full.h
@@ -23,7 +23,7 @@ class hic0_full : public MultiViewComponent
     static Element* info_pnp(QString&, char* &, bool getNewOne=false);
   protected:
     void createSymbol();
-    QString netlist();
+    QString netlist() const;
 };
 
 #endif /* hic0_full_H */

--- a/qucs/qucs/components/hicumL0V1p2.cpp
+++ b/qucs/qucs/components/hicumL0V1p2.cpp
@@ -359,7 +359,7 @@ void hicumL0V1p2::createSymbol()
   x2 =  30; y2 =  30;
 }
 
-QString hicumL0V1p2::netlist()
+QString hicumL0V1p2::netlist() const
 {
   QString s = "hicumL0V1p2:"+Name;
 

--- a/qucs/qucs/components/hicumL0V1p2.h
+++ b/qucs/qucs/components/hicumL0V1p2.h
@@ -23,7 +23,7 @@ class hicumL0V1p2 : public MultiViewComponent
     static Element* info_pnp(QString&, char* &, bool getNewOne=false);
   protected:
     void createSymbol();
-    QString netlist();
+    QString netlist() const;
 };
 
 #endif /* hicumL0V1p2_H */

--- a/qucs/qucs/components/hicumL0V1p2g.cpp
+++ b/qucs/qucs/components/hicumL0V1p2g.cpp
@@ -370,7 +370,7 @@ void hicumL0V1p2g::createSymbol()
   x2 =  30; y2 =  30;
 }
 
-QString hicumL0V1p2g::netlist()
+QString hicumL0V1p2g::netlist() const
 {
   QString s = "hicumL0V1p2g:"+Name;
 

--- a/qucs/qucs/components/hicumL0V1p2g.h
+++ b/qucs/qucs/components/hicumL0V1p2g.h
@@ -23,7 +23,7 @@ class hicumL0V1p2g : public MultiViewComponent
     static Element* info_pnp(QString&, char* &, bool getNewOne=false);
   protected:
     void createSymbol();
-    QString netlist();
+    QString netlist() const;
 };
 
 #endif /* hicumL0V1p2g_H */

--- a/qucs/qucs/components/hicumL0V1p3.cpp
+++ b/qucs/qucs/components/hicumL0V1p3.cpp
@@ -377,7 +377,7 @@ void hicumL0V1p3::createSymbol()
   x2 =  30; y2 =  30;
 }
 
-QString hicumL0V1p3::netlist()
+QString hicumL0V1p3::netlist() const
 {
   QString s = "hicumL0V1p3:"+Name;
 

--- a/qucs/qucs/components/hicumL0V1p3.h
+++ b/qucs/qucs/components/hicumL0V1p3.h
@@ -23,7 +23,7 @@ class hicumL0V1p3 : public MultiViewComponent
     static Element* info_pnp(QString&, char* &, bool getNewOne=false);
   protected:
     void createSymbol();
-    QString netlist();
+    QString netlist() const;
 };
 
 #endif /* hicumL0V1p3_H */

--- a/qucs/qucs/components/ifile.cpp
+++ b/qucs/qucs/components/ifile.cpp
@@ -80,7 +80,7 @@ Element* iFile::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString iFile::getSubcircuitFile()
+QString iFile::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;
@@ -88,7 +88,7 @@ QString iFile::getSubcircuitFile()
 }
 
 // -------------------------------------------------------
-QString iFile::netlist()
+QString iFile::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/ifile.h
+++ b/qucs/qucs/components/ifile.h
@@ -28,10 +28,10 @@ public:
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/libcomp.cpp
+++ b/qucs/qucs/components/libcomp.cpp
@@ -210,7 +210,7 @@ int LibComp::loadSymbol()
 }
 
 // -------------------------------------------------------
-QString LibComp::getSubcircuitFile()
+QString LibComp::getSubcircuitFile() const
 {
   QDir Directory(QucsSettings.LibDir);
   QString FileName = Directory.absFilePath(Props.first()->Value);
@@ -259,14 +259,14 @@ bool LibComp::createSubNetlist(QTextStream *stream, QStringList &FileList,
 }
 
 // -------------------------------------------------------
-QString LibComp::createType()
+QString LibComp::createType() const
 {
   QString Type = misc::properFileName(Props.first()->Value);
   return misc::properName(Type + "_" + Props.next()->Value);
 }
 
 // -------------------------------------------------------
-QString LibComp::netlist()
+QString LibComp::netlist() const
 {
   QString s = "Sub:"+Name;   // output as subcircuit
 

--- a/qucs/qucs/components/libcomp.h
+++ b/qucs/qucs/components/libcomp.h
@@ -31,10 +31,10 @@ public:
   Component* newOne();
 
   bool createSubNetlist(QTextStream *, QStringList&, int type=1);
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
-  QString netlist();
+  QString netlist() const;
   QString vhdlCode(int);
   QString verilogCode(int);
   void createSymbol();
@@ -42,7 +42,7 @@ protected:
 private:
   int  loadSymbol();
   int  loadSection(const QString&, QString&, QStringList* i=0);
-  QString createType();
+  QString createType() const;
 };
 
 #endif

--- a/qucs/qucs/components/mosfet.cpp
+++ b/qucs/qucs/components/mosfet.cpp
@@ -120,7 +120,7 @@ void MOSFET::createSymbol()
 }
 
 // -------------------------------------------------------
-QString MOSFET::netlist()
+QString MOSFET::netlist() const
 {
   QString s = "MOSFET:"+Name;
 

--- a/qucs/qucs/components/mosfet.h
+++ b/qucs/qucs/components/mosfet.h
@@ -32,7 +32,7 @@ public:
 
 protected:
   void createSymbol();
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/msvia.cpp
+++ b/qucs/qucs/components/msvia.cpp
@@ -70,7 +70,7 @@ Element* MSvia::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString MSvia::netlist()
+QString MSvia::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/msvia.h
+++ b/qucs/qucs/components/msvia.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/mutualx.cpp
+++ b/qucs/qucs/components/mutualx.cpp
@@ -72,7 +72,7 @@ Component* MutualX::newOne()
     return p;
 }
 
-QString MutualX::netlist()
+QString MutualX::netlist() const
 {
     QString s = Model + ":" + Name;
 

--- a/qucs/qucs/components/mutualx.h
+++ b/qucs/qucs/components/mutualx.h
@@ -33,7 +33,7 @@ public:
 
 protected:
   void createSymbol();
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/opt_sim.cpp
+++ b/qucs/qucs/components/opt_sim.cpp
@@ -62,7 +62,7 @@ Element* Optimize_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString Optimize_Sim::netlist()
+QString Optimize_Sim::netlist() const
 {
   QString s = "#\n";
   if (createASCOFiles()) {
@@ -76,7 +76,7 @@ QString Optimize_Sim::netlist()
 
  
 // -----------------------------------------------------------
-bool Optimize_Sim::createASCOFiles()
+bool Optimize_Sim::createASCOFiles() const
 {
   Property* pp;
   QFile afile(QucsSettings.QucsHomeDir.filePath("asco_netlist.cfg"));

--- a/qucs/qucs/components/opt_sim.h
+++ b/qucs/qucs/components/opt_sim.h
@@ -27,12 +27,12 @@ public:
  ~Optimize_Sim();
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  bool createASCOFiles();
+  bool createASCOFiles() const;
   bool createASCOnetlist();
   bool loadASCOout();
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/rfedd.cpp
+++ b/qucs/qucs/components/rfedd.cpp
@@ -77,7 +77,7 @@ Element* RFedd::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString RFedd::netlist()
+QString RFedd::netlist() const
 {
   QString s = Model+":"+Name;
   QString e = "\n";

--- a/qucs/qucs/components/rfedd.h
+++ b/qucs/qucs/components/rfedd.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 };
 

--- a/qucs/qucs/components/rfedd2p.cpp
+++ b/qucs/qucs/components/rfedd2p.cpp
@@ -74,7 +74,7 @@ Element* RFedd2P::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString RFedd2P::netlist()
+QString RFedd2P::netlist() const
 {
   QString s = "RFEDD:"+Name;
   QString e = "\n";

--- a/qucs/qucs/components/rfedd2p.h
+++ b/qucs/qucs/components/rfedd2p.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 };
 

--- a/qucs/qucs/components/sparamfile.cpp
+++ b/qucs/qucs/components/sparamfile.cpp
@@ -99,7 +99,7 @@ Element* SParamFile::info2(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString SParamFile::getSubcircuitFile()
+QString SParamFile::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;
@@ -107,7 +107,7 @@ QString SParamFile::getSubcircuitFile()
 }
 
 // -------------------------------------------------------
-QString SParamFile::netlist()
+QString SParamFile::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/sparamfile.h
+++ b/qucs/qucs/components/sparamfile.h
@@ -30,10 +30,10 @@ public:
   static Element* info1(QString&, char* &, bool getNewOne=false);
   static Element* info2(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 };
 

--- a/qucs/qucs/components/spicefile.cpp
+++ b/qucs/qucs/components/spicefile.cpp
@@ -148,7 +148,7 @@ void SpiceFile::createSymbol()
 }
 
 // ---------------------------------------------------
-QString SpiceFile::netlist()
+QString SpiceFile::netlist() const
 {
   if(Props.at(1)->Value.isEmpty())
     return QString("");  // no ports, no subcircuit instance
@@ -163,7 +163,7 @@ QString SpiceFile::netlist()
 }
 
 // -------------------------------------------------------
-QString SpiceFile::getSubcircuitFile()
+QString SpiceFile::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;

--- a/qucs/qucs/components/spicefile.h
+++ b/qucs/qucs/components/spicefile.h
@@ -37,7 +37,7 @@ public:
   bool withSim;
   bool createSubNetlist(QTextStream *);
   QString getErrorText() { return ErrText; }
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 private:
   bool makeSubcircuit;
@@ -50,7 +50,7 @@ private:
   bool recreateSubNetlist(QString *, QString *);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 
 private slots:

--- a/qucs/qucs/components/subcircuit.cpp
+++ b/qucs/qucs/components/subcircuit.cpp
@@ -198,7 +198,7 @@ int Subcircuit::loadSymbol(const QString& DocName)
 }
 
 // -------------------------------------------------------
-QString Subcircuit::netlist()
+QString Subcircuit::netlist() const
 {
   QString s = Model+":"+Name;
 
@@ -279,7 +279,7 @@ QString Subcircuit::verilogCode(int)
 }
 
 // -------------------------------------------------------
-QString Subcircuit::getSubcircuitFile()
+QString Subcircuit::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;

--- a/qucs/qucs/components/subcircuit.h
+++ b/qucs/qucs/components/subcircuit.h
@@ -28,10 +28,10 @@ public:
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
-  QString netlist();
+  QString netlist() const;
   QString vhdlCode(int);
   QString verilogCode(int);
   void createSymbol();

--- a/qucs/qucs/components/subcirport.cpp
+++ b/qucs/qucs/components/subcirport.cpp
@@ -98,7 +98,7 @@ Element* SubCirPort::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString SubCirPort::netlist()
+QString SubCirPort::netlist() const
 {
   return QString("");
 }

--- a/qucs/qucs/components/subcirport.h
+++ b/qucs/qucs/components/subcirport.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   QString vhdlCode(int);
   QString verilogCode(int);
   void createSymbol();

--- a/qucs/qucs/components/switch.cpp
+++ b/qucs/qucs/components/switch.cpp
@@ -65,7 +65,7 @@ Element* Switch::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString Switch::netlist()
+QString Switch::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/switch.h
+++ b/qucs/qucs/components/switch.h
@@ -29,7 +29,7 @@ public:
   static Element* info(QString&, char* &, bool getNewOne=false);
 
 protected:
-  QString netlist();
+  QString netlist() const;
   void createSymbol();
 };
 

--- a/qucs/qucs/components/verilogfile.cpp
+++ b/qucs/qucs/components/verilogfile.cpp
@@ -160,7 +160,7 @@ void Verilog_File::createSymbol()
 }
 
 // -------------------------------------------------------
-QString Verilog_File::getSubcircuitFile()
+QString Verilog_File::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;

--- a/qucs/qucs/components/verilogfile.h
+++ b/qucs/qucs/components/verilogfile.h
@@ -33,7 +33,7 @@ public:
 
   bool createSubNetlist(QTextStream *);
   QString getErrorText() { return ErrText; }
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
   QString verilogCode(int);

--- a/qucs/qucs/components/vfile.cpp
+++ b/qucs/qucs/components/vfile.cpp
@@ -82,7 +82,7 @@ Element* vFile::info(QString& Name, char* &BitmapFile, bool getNewOne)
 }
 
 // -------------------------------------------------------
-QString vFile::getSubcircuitFile()
+QString vFile::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;
@@ -90,7 +90,7 @@ QString vFile::getSubcircuitFile()
 }
 
 // -------------------------------------------------------
-QString vFile::netlist()
+QString vFile::netlist() const
 {
   QString s = Model+":"+Name;
 

--- a/qucs/qucs/components/vfile.h
+++ b/qucs/qucs/components/vfile.h
@@ -28,10 +28,10 @@ public:
   Component* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
 
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
-  QString netlist();
+  QString netlist() const;
 };
 
 #endif

--- a/qucs/qucs/components/vhdlfile.cpp
+++ b/qucs/qucs/components/vhdlfile.cpp
@@ -203,7 +203,7 @@ void VHDL_File::createSymbol()
 }
 
 // -------------------------------------------------------
-QString VHDL_File::getSubcircuitFile()
+QString VHDL_File::getSubcircuitFile() const
 {
   // construct full filename
   QString FileName = Props.getFirst()->Value;

--- a/qucs/qucs/components/vhdlfile.h
+++ b/qucs/qucs/components/vhdlfile.h
@@ -33,7 +33,7 @@ public:
 
   bool createSubNetlist(QTextStream *);
   QString getErrorText() { return ErrText; }
-  QString getSubcircuitFile();
+  QString getSubcircuitFile() const;
 
 protected:
   QString vhdlCode(int);

--- a/qucs/qucs/dialogs/simmessage.cpp
+++ b/qucs/qucs/dialogs/simmessage.cpp
@@ -456,7 +456,11 @@ void SimMessage::startSimulator()
     Stream << '\n';
 
     isVerilog = ((Schematic*)DocWidget)->isVerilog;
-    SimTime = ((Schematic*)DocWidget)->createNetlist(Stream, SimPorts);
+    auto sd = SimulatorDispatcher::get("qucsator");
+    assert(sd);
+    auto nl = sd->netLang();
+    assert(nl);
+    SimTime = ((Schematic*)DocWidget)->createNetlist(Stream, SimPorts, nl);
     if(SimTime.length()>0&&SimTime.at(0) == '\xA7') {
       NetlistFile.close();
       ErrText->insertPlainText(SimTime.mid(1));

--- a/qucs/qucs/dialogs/simmessage.cpp
+++ b/qucs/qucs/dialogs/simmessage.cpp
@@ -456,7 +456,7 @@ void SimMessage::startSimulator()
     Stream << '\n';
 
     isVerilog = ((Schematic*)DocWidget)->isVerilog;
-    auto sd = SimulatorDispatcher::get("qucsator");
+    auto sd = Dispatcher<Simulator>::get("qucsator");
     assert(sd);
     auto nl = sd->netLang();
     assert(nl);

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -259,7 +259,7 @@ Schematic *openSchematic(QString schematic)
   return sch;
 }
 
-int doNetlist(QString schematic, QString netlist)
+int doNetlist(QString schematic, QString netlist, NetLang const* lang)
 {
   Schematic *sch = openSchematic(schematic);
   if (sch == NULL) {
@@ -305,7 +305,7 @@ int doNetlist(QString schematic, QString netlist)
 
   Stream << '\n';
 
-  QString SimTime = sch->createNetlist(Stream, SimPorts);
+  QString SimTime = sch->createNetlist(Stream, SimPorts, lang);
   delete(sch);
 
   NetlistFile.close();
@@ -876,7 +876,11 @@ int main(int argc, char *argv[])
     }
     // create netlist from schematic
     if (netlist_flag) {
-      return doNetlist(inputfile, outputfile);
+      auto sd = SimulatorDispatcher::get("qucsator");
+      assert(sd);
+      auto nl = sd->netLang();
+      assert(nl);
+      return doNetlist(inputfile, outputfile, nl);
     } else if (print_flag) {
       return doPrint(inputfile, outputfile,
           page, dpi, color, orientation);
@@ -891,3 +895,5 @@ int main(int argc, char *argv[])
   //saveApplSettings(QucsMain);
   return result;
 }
+
+// vim:ts=8:sw=2:noet

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -876,7 +876,7 @@ int main(int argc, char *argv[])
     }
     // create netlist from schematic
     if (netlist_flag) {
-      auto sd = SimulatorDispatcher::get("qucsator");
+      auto sd = Dispatcher<Simulator>::get("qucsator");
       assert(sd);
       auto nl = sd->netLang();
       assert(nl);

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2799,3 +2799,5 @@ void QucsApp::slotSaveSchematicToGraphicsFile(bool diagram)
   }
   delete writer;
 }
+
+std::map<std::string, Simulator const*> SimulatorDispatcher::Simulators;

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2800,4 +2800,7 @@ void QucsApp::slotSaveSchematicToGraphicsFile(bool diagram)
   delete writer;
 }
 
-std::map<std::string, Simulator const*> SimulatorDispatcher::Simulators;
+template<>
+std::map<std::string, Simulator const*> Dispatcher<Simulator>::Stash{};
+template<>
+std::map<std::string, NetLang const*> Dispatcher<NetLang>::Stash{};

--- a/qucs/qucs/schematic.h
+++ b/qucs/qucs/schematic.h
@@ -34,6 +34,7 @@
 #include "diagrams/diagram.h"
 #include "paintings/painting.h"
 #include "components/component.h"
+#include "sim/sim.h"
 
 #include <Q3ScrollView>
 #include <Q3PtrList>
@@ -275,7 +276,7 @@ public:
   bool createSubNetlist(QTextStream *, int&, QStringList&, QPlainTextEdit*, int);
   void createSubNetlistPlain(QTextStream*, QPlainTextEdit*, int);
   int  prepareNetlist(QTextStream&, QStringList&, QPlainTextEdit*);
-  QString createNetlist(QTextStream&, int);
+  QString createNetlist(QTextStream&, int, NetLang const*);
   bool loadDocument();
   void highlightWireLabels (void);
 
@@ -304,8 +305,8 @@ private:
   void propagateNode(QStringList&, int&, Node*);
   void collectDigitalSignals(void);
   bool giveNodeNames(QTextStream *, int&, QStringList&, QPlainTextEdit*, int);
-  void beginNetlistDigital(QTextStream &);
-  void endNetlistDigital(QTextStream &);
+  void beginNetlistDigital(QTextStream &, NetLang const*);
+  void endNetlistDigital(QTextStream &, NetLang const*);
   bool throughAllComps(QTextStream *, int&, QStringList&, QPlainTextEdit *, int);
 
   DigMap Signals; // collecting node names for VHDL signal declarations

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -1902,7 +1902,7 @@ QString Schematic::createNetlist(QTextStream& stream, int NumPorts, NetLang cons
   QString s, Time;
   for(Component *pc = DocComps.first(); pc != 0; pc = DocComps.next()) {
     if(isAnalog) {
-      lang->printInstance(pc, stream);
+      lang->printItem(pc, stream);
     } else { // FIXME: use different lang to print things differently
       if(pc->Model == ".Digi" && pc->isActive) {  // simulation component ?
         if(NumPorts > 0) { // truth table simulation ?

--- a/qucs/qucs/sim/Makefile.am
+++ b/qucs/qucs/sim/Makefile.am
@@ -22,4 +22,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-EXTRA_DIST = qucsator.cpp
+noinst_LTLIBRARIES = qucsator.la
+AM_DEFAULT_SOURCE_EXT = .cpp
+
+qucsator_la_LDFLAGS = -module -avoid-version
+qucsator_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(abs_top_srcdir)/qucs
+# need Qt for TextStream.
+qucsator_la_CPPFLAGS += $(QT_INCLUDES)

--- a/qucs/qucs/sim/Makefile.am
+++ b/qucs/qucs/sim/Makefile.am
@@ -1,0 +1,25 @@
+## Process this file with automake to produce Makefile.in
+#
+# qucs/sim/Makefile.am
+#
+# Automake input file.
+#
+# Copyright (C) 2015 Felix Salfelder felix@salfelder.org
+#
+# This is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2, or (at your option)
+# any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this package; see the file COPYING.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street - Fifth Floor,
+# Boston, MA 02110-1301, USA.
+#
+
+EXTRA_DIST = qucsator.cpp

--- a/qucs/qucs/sim/qucsator.cpp
+++ b/qucs/qucs/sim/qucsator.cpp
@@ -1,0 +1,50 @@
+/***************************************************************************
+                             qucsator.cc
+                              ----------
+    begin                : yes
+    copyright            : (C) 2015 by Felix Salfelder
+    email                : felix@salfelder.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "sim.h"
+#include "../components/component.h"
+#include <QString>
+
+namespace {
+// qucslang language implementation
+class QucsLang : public NetLang
+{
+  virtual void printInstance(Component const*, QTextStream&) const;
+};
+
+/*!
+ * print Components in qucs language
+ */
+void QucsLang::printInstance(Component const* c, QTextStream& s) const
+{
+  // use callback hack (for now)
+  s << c->getNetlist();
+}
+
+static QucsLang qucslang;
+
+// qucsator simulator backend
+class Qucsator : public Simulator
+{
+  NetLang const* netLang() const{return &qucslang;}
+};
+
+static Qucsator Q;
+static SimulatorDispatcher p("qucsator", &Q);
+}
+
+// vim:ts=8:sw=2:noet

--- a/qucs/qucs/sim/qucsator.cpp
+++ b/qucs/qucs/sim/qucsator.cpp
@@ -78,7 +78,7 @@ class Qucsator : public Simulator
 };
 
 static Qucsator Q;
-static SimulatorDispatcher p("qucsator", &Q);
+static Dispatcher<Simulator> p("qucsator", &Q);
 }
 
 // vim:ts=8:sw=2:noet

--- a/qucs/qucs/sim/sim.h
+++ b/qucs/qucs/sim/sim.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+                                sim.h
+                              ----------
+    begin                : yes
+    copyright            : (C) 2015 by Felix Salfelder
+    email                : felix@salfelder.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QUCS_SIM_H__
+
+class NetLang;
+class Component;
+
+#include <assert.h>
+
+#include <QTextStream>
+#include <QDebug>
+#define stream_t QTextStream
+
+/*!
+ * class to provide simulator duties
+ */
+class Simulator{
+public:
+  virtual ~Simulator(){}
+
+  virtual NetLang const* netLang() const{return nullptr;}
+//  virtual SimOutputData const* results(){}
+};
+
+/*!
+ * class to provide language dependent functionality, such as netlisting
+ * FIXME (later): don't use Qt types here. has nothing to do with GUI
+ */
+class NetLang{
+public:
+  virtual ~NetLang(){}
+
+  virtual void printInstance(Component const*, stream_t&) const = 0;
+};
+
+/*!
+ * a dispatcher stub. hardly sophisticated, but functional
+ */
+class SimulatorDispatcher{
+public:
+  SimulatorDispatcher(std::string label, Simulator const* what)
+  {
+    qDebug() << "dispatcher install" << label.c_str();
+    assert(what);
+    Simulators[label] = what;
+  }
+  static Simulator const* get(std::string const& s)
+  {
+    qDebug() << "dispatcher get" << s.c_str();
+    return Simulators[s];
+  }
+private:
+  static std::map<std::string, Simulator const*> Simulators;
+};
+
+#define QUCS_SIM_H__
+#endif
+// vim:ts=8:sw=2:noet

--- a/qucs/qucs/sim/sim.h
+++ b/qucs/qucs/sim/sim.h
@@ -21,6 +21,8 @@ class NetLang;
 class Component;
 
 #include <assert.h>
+#include <components/component.h>
+#include <iostream>
 
 #include <QTextStream>
 #include <QDebug>
@@ -44,9 +46,29 @@ public:
 class NetLang{
 public:
   virtual ~NetLang(){}
-
+  void printItem(Element const*, stream_t&) const;
+private:
   virtual void printInstance(Component const*, stream_t&) const = 0;
 };
+
+/*!
+ * print an item
+ * boldly ripped from gnucap.
+ */
+inline void NetLang::printItem(Element const* c, stream_t& s) const
+{
+  assert(c);
+//  if (auto C=dynamic_cast<const Subcircuit*>(c)) {
+//    still using obsolete code
+//  }else
+//  ...
+  if (auto C=dynamic_cast<const Component*>(c)) {
+    printInstance(C, s);
+  }else{
+    std::cerr << "incomplete\n";
+  }
+}
+
 
 /*!
  * a dispatcher stub. hardly sophisticated, but functional

--- a/qucs/qucs/sim/sim.h
+++ b/qucs/qucs/sim/sim.h
@@ -73,21 +73,28 @@ inline void NetLang::printItem(Element const* c, stream_t& s) const
 /*!
  * a dispatcher stub. hardly sophisticated, but functional
  */
-class SimulatorDispatcher{
+template<class T>
+class Dispatcher{
 public:
-  SimulatorDispatcher(std::string label, Simulator const* what)
+  Dispatcher(std::string label, T const* what)
   {
     qDebug() << "dispatcher install" << label.c_str();
     assert(what);
-    Simulators[label] = what;
+    Stash[label] = what;
   }
-  static Simulator const* get(std::string const& s)
+  static T const* get(std::string const& s)
   {
     qDebug() << "dispatcher get" << s.c_str();
-    return Simulators[s];
+    return Stash[s];
+  }
+  static T const* get(QString const& s){
+    return get(std::string(s));
+  }
+  static T const* get(char const* s){
+    return get(std::string(s));
   }
 private:
-  static std::map<std::string, Simulator const*> Simulators;
+  static std::map<std::string, T const*> Stash;
 };
 
 #define QUCS_SIM_H__


### PR DESCRIPTION
as mentioned in #275, we need a basis for supporting different/several simulators and netlist languages. these commits introduce some basic infrastructure and a first stub (for qucsator) taking care of some netlisting.

the simulators modules are meant to be dynamically loaded using dlopen. this is not complete and might cause some linking or even run time headache. the cmake build is incomplete, please help...

EDIT: now also works with cmake (preliminary solution -- same as automake)
