### PR TITLE
Continuing fixing #320

### DIFF
--- a/qucs/qucs/imagewriter.cpp
+++ b/qucs/qucs/imagewriter.cpp
@@ -286,9 +286,11 @@ void ImageWriter::getSchWidthAndHeight(Schematic *sch, int &w, int &h, int &xmin
 
     int f_w, f_h;
     if (sch->sizeOfFrame(f_w,f_h)) {
-        xmin = 0;
-        ymin = 0;
-        w = f_w;
-        h = f_h;
+        xmin = std::min(0,xmin); // For components
+        ymin = std::min(0,ymin); // that fall out of frame
+        w = abs(std::max(f_w,sch->UsedX2) - xmin);
+        h = abs(std::max(f_h,sch->UsedY2) - ymin);
+        //w = std::max(w,f_w);
+        //h = std::max(h,f_h);
     }
 }


### PR DESCRIPTION
Enabled printing of components that fall out of the frame. 
![export](https://cloud.githubusercontent.com/assets/4920080/8857085/d7c2d00a-3177-11e5-9590-a1591ee601c0.png)
