### PR TITLE
A "What's new" window (WIP)

### DIFF
--- a/qucs/qucs-help/docs/en/Makefile.am
+++ b/qucs/qucs-help/docs/en/Makefile.am
@@ -24,7 +24,7 @@
 
 HTML = index.html short.html start.html mathfunc.html subcircuit.html       \
   programs.html internal.html characters.html matching.html start_digi.html \
-  start_opt.html octave.html
+  start_opt.html octave.html whatsnew.html
 PIC  = qucsmain.png paste.png wire.png select.png contab.png subcircuit.png \
   qucsdigi.png optimization1.png optimization2.png optimization3.png        \
   optimization4.png optimization5.png optimization6.png optimization7.png   \

--- a/qucs/qucs-help/docs/en/whatsnew.html
+++ b/qucs/qucs-help/docs/en/whatsnew.html
@@ -1,0 +1,107 @@
+<h1>Qucs 0.0.19 Release Notes</h1>
+
+<p>This release brings improvements on many parts of Qucs.
+The port from Qt3 to Qt4 is still ongoing and many bugs and usability issues have been fixed in the process.
+A few new features were added and others are in development.
+See below a short summary of the enhancements.</p>
+
+<h2>Qucs</h2>
+
+<ul>
+<li>Fix diagram color picker button (<a href="https://github.com/Qucs/qucs/issues/30">#30</a>)</li>
+<li>Fix zoom in a box (<a href="https://github.com/Qucs/qucs/issues/31">#31</a>)</li>
+<li>[NEW] Command line to save schematic as image (png, svg, pdf) (<a href="https://github.com/Qucs/qucs/issues/32">#32</a>)</li>
+<li>[NEW] Add component MutualX (<a href="https://github.com/Qucs/qucs/issues/54">#54</a>)</li>
+<li>[NEW] Enable anti-aliasing, provide it as option (<a href="https://github.com/Qucs/qucs/issues/73">#73</a>)</li>
+<li>[NEW] Add search file on component dock (<a href="https://github.com/Qucs/qucs/pull/86">PR#86</a>)</li>
+<li>Fix rendering of component text properties (<a href="https://github.com/Qucs/qucs/pull/87">PR#87</a>, <a href="https://github.com/Qucs/qucs/pull/98">PR#98</a>)</li>
+<li>[NEW] Add recently opened menu (<a href="https://github.com/Qucs/qucs/pull/95">PR#95</a>, <a href="https://github.com/Qucs/qucs/pull/207">PR#207</a>)</li>
+<li>Fix crash on loaiding timingdiagram (<a href="https://github.com/Qucs/qucs/issues/112">#112</a>)</li>
+<li>Refactor text search dialog (<a href="https://github.com/Qucs/qucs/pull/124">PR#124</a>)</li>
+<li>Correct simulator process exit check (<a href="https://github.com/Qucs/qucs/issues/132">#132</a>)</li>
+<li>Refactor project manager (<a href="https://github.com/Qucs/qucs/pull/153">PR#153</a>)</li>
+<li>Deprecated use of <code>HOME</code> environment variable (<a href="https://github.com/Qucs/qucs/issues/204">#204</a>)</li>
+<li>[NEW] Enable use of <code>QUCSATOR</code> environment variable to overide <code>qucsator</code> (<a href="https://github.com/Qucs/qucs/pull/209">PR#209</a>) </li>
+<li>Fix bug on deactivation (short-circuiting) a component (<a href="https://github.com/Qucs/qucs/issues/216">#216</a>)</li>
+<li>Various usability enhancements (<a href="https://github.com/Qucs/qucs/pull/232">PR#232</a>)
+<ul><li>Adjust various dialogs for a better table sizing</li>
+<li>Results of Optimization dialog can be copied to clipboard and pasted as an Equation </li>
+<li>Fix usage of font metrics in the schematic</li>
+<li>Fix handling of simulation messages in case a simulation is aborted</li>
+<li>Add <code>QT3_WARNINGS</code> to serve as a reminder of which Qt3 stuff still needs removal.</li></ul></li>
+<li>[NEW] Redesigned About dialog (<a href="https://github.com/Qucs/qucs/pull/252">PR#252</a>)</li>
+<li>Fix context menu texts when pressed over toolbar (<a href="https://github.com/Qucs/qucs/issues/253">#253</a>)</li>
+<li>Fix crash when using DC bias annotation with a simulation sweep (<a href="https://github.com/Qucs/qucs/issues/272">#272</a>)</li>
+</ul>
+
+<h2>Qucsator</h2>
+
+<ul>
+<li>Fix segmentation fault during noise enabled S-parameter simulaton (<a href="https://github.com/Qucs/qucs/issues/133">#133</a>)</li>
+<li>Fix regression on tswitch component (<a href="https://github.com/Qucs/qucs/issues/34">#34</a>, <a href="https://github.com/Qucs/qucs/pull/203">PR#203</a>)</li>
+<li>Fix coplanar waveguide formulae (<a href="https://sourceforge.net/p/qucs/bugs/183">SF#183</a>, <a href="https://github.com/Qucs/qucs/pull/306">PR#306</a>)</li>
+<li>Fix several segfaults during fuzzed input (<a href="https://github.com/Qucs/qucs/pull/274">PR#274</a>) </li>
+<li>Remove null and free checks (<a href="https://github.com/Qucs/qucs/pull/267">PR#267</a>)</li>
+<li>Adopt to standard library in several classes.</li>
+<li>Enable gcov for coverage</li>
+</ul>
+
+<h2>Qucs-transcalc</h2>
+
+<ul>
+<li>Fix issues with coupled microstrips (<a href="https://sourceforge.net/p/qucs/bugs/171">SF#171</a>,<a href="https://github.com/Qucs/qucs/pull/85">PR#85</a>)</li>
+<li>Fix coplanar waveguide formulae (<a href="https://sourceforge.net/p/qucs/bugs/183">SF#183</a>, <a href="https://github.com/Qucs/qucs/pull/306">PR#306</a>)</li>
+</ul>
+
+<h2>[New] Qucs-ActiveFilter</h2>
+
+<ul>
+<li>Merge new qucs-activefilter tool (<a href="https://github.com/Qucs/qucs/issues/43">#43</a>)</li>
+</ul>
+
+<h2>Qucs-Filter</h2>
+
+<ul>
+<li>Port QucsStudio Filter synthesis (<a href="https://github.com/Qucs/qucs/issues/15">#15</a>)</li>
+</ul>
+
+<h2>Qucs-lib</h2>
+
+<ul>
+<li>Fix issue that corrupt netlist for item dragged from the library dock (<a href="https://github.com/Qucs/qucs/issues/39">#39</a>)</li>
+<li>Fixed library paths for user library components (<a href="https://github.com/Qucs/qucs/pull/292">PR#292</a>)</li>
+</ul>
+
+<h2>Qucs-rescodes</h2>
+
+<ul>
+<li>Ported to Qt4 (<a href="https://github.com/Qucs/qucs/issues/38">#38</a>)</li>
+</ul>
+
+<h2>Qucsconv</h2>
+
+<ul>
+<li>Add further command line help documentation, <code>qucsconv -h</code> (<a href="https://github.com/Qucs/qucs/issues/57">#57</a>)</li>
+</ul>
+
+<h2>Documentation</h2>
+
+<ul>
+<li>Fix table of contents on Technical.pdf (<a href="https://github.com/Qucs/qucs/issues/55">#55</a>)</li>
+<li>Documentation for qucs-active filter (<a href="https://github.com/Qucs/qucs/pull/156">PR#156</a>)</li>
+</ul>
+
+<h2>Translations</h2>
+
+<ul>
+<li>Updated DE (<a href="https://github.com/Qucs/qucs/pull/128">PR#128</a>)</li>
+</ul>
+
+<h2>Miscelaneous</h2>
+
+<ul>
+<li>Move from math.h to cmath.h (<a href="https://github.com/Qucs/qucs/pull/168">PR#168</a>)</li>
+</ul>
+
+<!-- Cross reference generated with NEWS_crossref.py -->
+

--- a/qucs/qucs/components/libcomp.cpp
+++ b/qucs/qucs/components/libcomp.cpp
@@ -100,8 +100,9 @@ int LibComp::loadSection(const QString& Name, QString& Section,
 
   int Start, End = Section.indexOf(' ', 14);
   if(End < 15) return -3;
-  QString Line = Section.mid(14, End-14);
-  if(!misc::checkVersion(Line)) // wrong version number ?
+  QString Line = Section.mid(14, End-14); // extract version string
+  VersionTriplet LibVersion = VersionTriplet(Line);
+  if (LibVersion > QucsVersion) // wrong version number ?
     return -3;
 
   if(Name == "Symbol") {

--- a/qucs/qucs/components/subcircuit.cpp
+++ b/qucs/qucs/components/subcircuit.cpp
@@ -162,7 +162,8 @@ int Subcircuit::loadSymbol(const QString& DocName)
     return -3;
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) // wrong version number ?
+  VersionTriplet SymbolVersion = VersionTriplet(Line);
+  if (SymbolVersion > QucsVersion) // wrong version number ?
     return -4;
 
   // read content *************************

--- a/qucs/qucs/dialogs/CMakeLists.txt
+++ b/qucs/qucs/dialogs/CMakeLists.txt
@@ -25,6 +25,7 @@ settingsdialog.h
 simmessage.h
 sweepdialog.h
 vasettingsdialog.h
+whatsnewdialog.h
 )
 
 
@@ -36,7 +37,7 @@ importdialog.cpp		savedialog.cpp labeldialog.cpp
 searchdialog.cpp     librarydialog.cpp settingsdialog.cpp
 matchdialog.cpp			simmessage.cpp newprojdialog.cpp
 sweepdialog.cpp			exportdialog.cpp loaddialog.cpp
-aboutdialog.cpp
+aboutdialog.cpp			whatsnewdialog.cpp
 )
 
 SET(DIALOGS_MOC_HDRS
@@ -59,6 +60,7 @@ simmessage.h
 sweepdialog.h
 sweepdialog.h
 vasettingsdialog.h
+whatsnewdialog.h
 )
 
 SET(DIALOGS_UIC_HDRS

--- a/qucs/qucs/dialogs/Makefile.am
+++ b/qucs/qucs/dialogs/Makefile.am
@@ -28,7 +28,8 @@ MOCHEADERS = settingsdialog.h simmessage.h qucssettingsdialog.h      \
      labeldialog.h changedialog.h matchdialog.h digisettingsdialog.h \
      sweepdialog.h searchdialog.h librarydialog.h importdialog.h     \
      packagedialog.h savedialog.h vasettingsdialog.h                 \
-     exportdialog.h loaddialog.h newprojdialog.h aboutdialog.h
+     exportdialog.h loaddialog.h newprojdialog.h aboutdialog.h       \
+     whatsnewdialog.h
 
 MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 
@@ -41,7 +42,7 @@ libdialogs_a_SOURCES = settingsdialog.cpp newprojdialog.cpp \
      matchdialog.cpp sweepdialog.cpp digisettingsdialog.cpp searchdialog.cpp \
      librarydialog.cpp importdialog.cpp packagedialog.cpp \
      savedialog.cpp vasettingsdialog.cpp exportdialog.cpp loaddialog.cpp \
-     aboutdialog.cpp
+     aboutdialog.cpp whatsnewdialog.cpp
 
 nodist_libdialogs_a_SOURCES = $(MOCFILES)
 

--- a/qucs/qucs/dialogs/packagedialog.cpp
+++ b/qucs/qucs/dialogs/packagedialog.cpp
@@ -365,6 +365,7 @@ void PackageDialog::extractPackage()
 
   QDir currDir = QucsSettings.QucsHomeDir;
   QString Version;
+  VersionTriplet PackageVersion;
   Q_UINT16 Checksum;
   Q_UINT32 Code, Length;
 
@@ -376,7 +377,8 @@ void PackageDialog::extractPackage()
   }
 
   Version = QString(Content.data()+13);
-  if(!misc::checkVersion(Version)) {
+  PackageVersion = VersionTriplet(Version);
+  if (PackageVersion > QucsVersion) { // wrong version number ?
     MsgText->append(tr("ERROR: Wrong version number!"));
     goto ErrorEnd;
   }

--- a/qucs/qucs/dialogs/whatsnewdialog.cpp
+++ b/qucs/qucs/dialogs/whatsnewdialog.cpp
@@ -1,0 +1,127 @@
+/*
+ * whatsnewdialog.h - dialog showing textual info about the current release
+ *
+ * Copyright (C) 2015, Qucs team (see AUTHORS file)
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*!
+ * \file whatsnewdialog.cpp
+ * \brief Implementation of the What's new dialog
+ */
+
+#include <string>
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+#include "main.h"
+#include "whatsnewdialog.h"
+
+#include <QObject>
+#include <QApplication>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QTextBrowser>
+#include <QPushButton>
+#include <QCheckBox>
+#include <QDir>
+#include <QDebug>
+
+
+WhatsNewDialog::WhatsNewDialog(QWidget *parent)
+    : QDialog(parent)
+{
+  resize(600, 400);
+  setWindowTitle(tr("What's new"));
+
+  mainBrowser = new QTextBrowser;
+  // open external HTML links in the default browser
+  mainBrowser ->setOpenExternalLinks(true);
+  // the Ctrl-Wheel event we would like to filter is handled by the viewport
+  mainBrowser->viewport()->installEventFilter(this);
+
+  QString WhatsNewFile = "whatsnew.html";
+
+  // this is taken from qucs-help
+  QString locale = QucsSettings.Language;
+  if(locale.isEmpty())
+    locale = QString(QLocale::system().name());
+
+  QDir QucsHelpDir = QucsSettings.DocDir + locale;
+  if (!QucsHelpDir.exists(WhatsNewFile)) {
+    int p = locale.indexOf ('_');
+    if (p != -1) {
+      QucsHelpDir = QucsSettings.DocDir + locale.left(p);
+      if (!QucsHelpDir.exists(WhatsNewFile)) {
+	QucsHelpDir = QucsSettings.DocDir + "en";
+      }
+    } else {
+      QucsHelpDir = QucsSettings.DocDir + "en";
+    }
+  }
+  mainBrowser->setSearchPaths(QStringList() 
+			      << QucsHelpDir.absolutePath()
+			      << ":/bitmaps");
+
+  mainBrowser->setSource(QUrl::fromLocalFile(WhatsNewFile));
+
+  all = new QVBoxLayout(this);
+  all->addWidget(mainBrowser);
+
+  QWidget *hbChk = new QWidget();
+  QHBoxLayout *hlChk = new QHBoxLayout(hbChk);
+  //hlChk->setContentsMargins(0,0,0,0);
+  all->addWidget(hbChk);
+
+  dnsaChk = new QCheckBox(tr("don't show this again"), parent);
+  hlChk->addWidget(dnsaChk);
+  hlChk->addStretch();
+
+  QWidget *hbBtn = new QWidget();
+  QHBoxLayout *hlBtn = new QHBoxLayout(hbBtn);
+  hlBtn->setContentsMargins(0,0,0,0);
+  all->addWidget(hbBtn);
+
+  QPushButton *okButton = new QPushButton(tr("&OK"), parent);
+  okButton->setFocus();
+  connect(okButton, SIGNAL(clicked()), this, SLOT(close()));
+  hlBtn->addStretch();
+  hlBtn->addWidget(okButton);
+}
+
+bool WhatsNewDialog::getCheckBoxState() {
+  return dnsaChk->isChecked();
+}
+
+void WhatsNewDialog::setCheckBoxState(bool state) {
+  dnsaChk->setChecked(state);
+}
+
+// event filter to remove the Ctrl-Wheel (text zoom) event
+bool WhatsNewDialog::eventFilter(QObject *obj, QEvent *event) {
+  if ((event->type() == QEvent::Wheel) &&
+      (QApplication::keyboardModifiers() & Qt::ControlModifier )) {    
+    return true; // eat Ctrl-Wheel event
+  } else {
+    // pass the event on to the parent class
+    return QDialog::eventFilter(obj, event);
+  }
+}
+
+

--- a/qucs/qucs/dialogs/whatsnewdialog.h
+++ b/qucs/qucs/dialogs/whatsnewdialog.h
@@ -1,0 +1,51 @@
+/*
+ * whatsnewdialog.h - dialog showing textual info about the current release
+ *
+ * Copyright (C) 2015, Qucs team (see AUTHORS file)
+ *
+ * This file is part of Qucs
+ *
+ * Qucs is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Qucs.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef WHATSNEW_H
+#define WHATSNEW_H
+
+
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QCheckBox>
+
+class QString;
+class QTextBrowser;
+
+class WhatsNewDialog : public QDialog  {
+   Q_OBJECT
+
+public:
+  WhatsNewDialog(QWidget *parent = 0);
+  bool getCheckBoxState();
+  void setCheckBoxState(bool state);
+
+protected:
+  bool eventFilter(QObject *obj, QEvent *ev);
+
+private:
+  QVBoxLayout *all;
+  QTextBrowser *mainBrowser;
+  QCheckBox *dnsaChk;
+};
+
+#endif

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -45,6 +45,7 @@
 
 #include "schematic.h"
 #include "module.h"
+#include "misc.h"
 
 #include "components/components.h"
 
@@ -63,6 +64,7 @@ tQucsSettings QucsSettings;
 QucsApp *QucsMain = 0;  // the Qucs application itself
 QString lastDir;    // to remember last directory for several dialogs
 QStringList qucsPathList;
+VersionTriplet QucsVersion; // Qucs version string
 
 // #########################################################################
 // Loads the settings file and stores the settings.
@@ -632,6 +634,9 @@ void createListComponentEntry(){
 int main(int argc, char *argv[])
 {
   qInstallMsgHandler(qucsMessageOutput);
+  // set the Qucs version string
+  QucsVersion = VersionTriplet(PACKAGE_VERSION);
+
   // apply default settings
   QucsSettings.font = QFont("Helvetica", 12);
   QucsSettings.largeFontSize = 16.0;

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -120,6 +120,9 @@ bool loadSettings()
     if (settings.contains("TextAntiAliasing")) QucsSettings.TextAntiAliasing = settings.value("TextAntiAliasing").toBool();
     else QucsSettings.TextAntiAliasing = false;
 
+    if (settings.contains("WhatsNewVersion")) QucsSettings.WhatsNewVersion = settings.value("WhatsNewVersion").toString();
+    else QucsSettings.WhatsNewVersion = "";
+
     QucsSettings.RecentDocs = settings.value("RecentDocs").toString().split("*",QString::SkipEmptyParts);
     QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
 
@@ -184,6 +187,7 @@ bool saveApplSettings()
     settings.setValue("IgnoreVersion", QucsSettings.IgnoreFutureVersion);
     settings.setValue("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);
     settings.setValue("TextAntiAliasing", QucsSettings.TextAntiAliasing);
+    settings.setValue("WhatsNewVersion", QucsSettings.WhatsNewVersion);
 
     // Copy the list of directory paths in which Qucs should
     // search for subcircuit schematics from qucsPathList
@@ -906,10 +910,12 @@ int main(int argc, char *argv[])
   }
 
   QucsMain = new QucsApp();
-  a.setMainWidget(QucsMain);
+  a.setMainWidget(QucsMain); // FIXME Qt3 relic?
   
   QucsMain->show();
+
   int result = a.exec();
+
   //saveApplSettings(QucsMain);
   return result;
 }

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -33,6 +33,7 @@
 
 class QucsApp;
 class Component;
+class VersionTriplet;
 
 static const double pi = 3.1415926535897932384626433832795029;  /* pi   */
 
@@ -83,6 +84,7 @@ extern tQucsSettings QucsSettings;  // extern because nearly everywhere used
 extern QucsApp *QucsMain;  // the Qucs application itself
 extern QString lastDir;    // to remember last directory for several dialogs
 extern QStringList qucsPathList;
+extern VersionTriplet QucsVersion;
 
 bool loadSettings();
 bool saveApplSettings();

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -78,6 +78,7 @@ struct tQucsSettings {
   bool IgnoreFutureVersion;
   bool GraphAntiAliasing;
   bool TextAntiAliasing;
+  QString WhatsNewVersion;
 };
 
 extern tQucsSettings QucsSettings;  // extern because nearly everywhere used

--- a/qucs/qucs/misc.cpp
+++ b/qucs/qucs/misc.cpp
@@ -425,3 +425,81 @@ bool misc::checkVersion(QString& Line)
     return false;
   return true;
 }
+
+// a small class to handle the application version string
+//   loosely modeled after the standard Semantic Versioning...
+VersionTriplet::VersionTriplet(const QString& version) {
+  // TODO should be likely made more robust...
+  if (version.isEmpty()) {
+    major = minor = patch = 0;
+  } else {
+    QStringList vl = QStringList::split('.', version);
+    major = vl.at(0).toUInt();
+    minor = vl.at(1).toUInt();
+    patch = vl.at(2).toUInt();
+  }
+}
+
+VersionTriplet::VersionTriplet(){
+  major = minor = patch = 0;
+}
+
+bool VersionTriplet::operator==(const VersionTriplet& v2) {
+  if (this->major != v2.major)
+    return false;
+  if (this->minor != v2.minor)
+    return false;
+  if (this->patch != v2.patch)
+    return false;
+  return true;
+}
+
+bool VersionTriplet::operator>(const VersionTriplet& v2) {
+  if (this->major < v2.major)
+    return false;
+  if (this->major > v2.major)
+    return true;
+
+  if (this->minor < v2.minor)
+    return false;
+  if (this->minor > v2.minor)
+    return true;
+
+  if (this->patch < v2.patch)
+    return false;
+  if (this->patch > v2.patch)
+    return true;
+
+  return false;
+}
+
+bool VersionTriplet::operator<(const VersionTriplet& v2) {
+  if (this->major > v2.major)
+    return false;
+  if (this->major < v2.major)
+    return true;
+
+  if (this->minor > v2.minor)
+    return false;
+  if (this->minor < v2.minor)
+    return true;
+
+  if (this->patch > v2.patch)
+    return false;
+  if (this->patch < v2.patch)
+    return true;
+
+  return false;
+}
+
+bool VersionTriplet::operator>=(const VersionTriplet& v2) {
+  return !((*this) < v2);
+}
+
+bool VersionTriplet::operator<=(const VersionTriplet& v2) {
+  return !((*this) > v2);
+}
+
+QString VersionTriplet::toString() {
+  return QString("%1.%2.%3").arg(major).arg(minor).arg(patch);
+}

--- a/qucs/qucs/misc.h
+++ b/qucs/qucs/misc.h
@@ -41,3 +41,24 @@ namespace misc {
   QString Verilog_Param(const QString);
   bool    checkVersion(QString&);
 }
+
+/*! handle the application version string
+ *
+ *  loosely modeled after the standard Semantic Versioning
+ */
+class VersionTriplet {
+ public:
+  VersionTriplet();
+  VersionTriplet(const QString&);
+
+  bool operator==(const VersionTriplet& v2);
+  bool operator>(const VersionTriplet& v2);
+  bool operator<(const VersionTriplet& v2);
+  bool operator>=(const VersionTriplet& v2);
+  bool operator<=(const VersionTriplet& v2);
+
+  QString toString();
+
+ private:
+  int major, minor, patch;
+};

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -40,6 +40,7 @@
 #include <QFileSystemModel>
 #include <QUrl>
 #include <QSettings>
+#include <QTimer>
 #include <QDebug>
 
 #include "main.h"
@@ -177,6 +178,17 @@ QucsApp::QucsApp()
       arg = QucsSettings.QucsWorkDir.filePath(Info.fileName());
       gotoPage(arg);
     }
+  }
+
+  // show What's New dialog ?
+  VersionTriplet QucsVersion = VersionTriplet(PACKAGE_VERSION);
+  VersionTriplet WhatsNewVersion = VersionTriplet(QucsSettings.WhatsNewVersion);
+  if (WhatsNewVersion < QucsVersion) {
+    // hack to show the dialog after the main window is shown
+    QTimer *timer = new QTimer(this);
+    timer->setSingleShot(true);
+    connect(timer, SIGNAL(timeout()), this, SLOT(slotWhatsNew()));
+    timer->start(100); // hopefully 100 ms are enough to show the main window...
   }
 }
 

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -237,6 +237,7 @@ public slots:
   void printCursorPosition(int, int);
   void slotUpdateUndo(bool);  // update undo available state
   void slotUpdateRedo(bool);  // update redo available state
+  void slotWhatsNew();  // shows a What's new dialog
 
 private slots:
   void slotViewToolBar(bool toggle);    // toggle the toolbar
@@ -253,8 +254,8 @@ private:
   void initToolBar();    // creates the toolbars
   void initStatusBar();  // setup the statusbar
 
-  QAction *helpAboutApp, *helpAboutQt, *viewToolBar, *viewStatusBar,
-          *viewBrowseDock, *viewOctaveDock;
+  QAction *helpAboutApp, *helpAboutQt, *helpWhatsNew, *viewToolBar, 
+    *viewStatusBar, *viewBrowseDock, *viewOctaveDock;
 
   // menus contain the items of their menubar
   enum { MaxRecentFiles = 8 };

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -56,7 +56,12 @@
 #include "dialogs/importdialog.h"
 #include "dialogs/packagedialog.h"
 #include "dialogs/aboutdialog.h"
+#include "dialogs/whatsnewdialog.h"
 #include "module.h"
+#include "misc.h"
+
+// Qucs version string
+extern VersionTriplet QucsVersion;
 
 // for editing component name on schematic
 QRegExp  Expr_CompProp;
@@ -1551,6 +1556,24 @@ void QucsApp::slotHelpAbout()
 {
   AboutDialog *ad = new AboutDialog(this);
   ad->exec();
+}
+
+void QucsApp::slotWhatsNew()
+{
+  WhatsNewDialog *wd = new WhatsNewDialog(this);
+  VersionTriplet WhatsNewVersion = VersionTriplet(QucsSettings.WhatsNewVersion);
+
+  // tick checkbox "don't show again" ?
+  wd->setCheckBoxState(WhatsNewVersion >= QucsVersion);
+  wd->exec();
+
+  if (wd->getCheckBoxState()) { // don't want to see the dialog again at startup
+    // remember the version for which the dialog was shown
+    QucsSettings.WhatsNewVersion = QucsVersion.toString();
+  } else {
+    // remove version, so that dialog will be shown ar next startup
+    QucsSettings.WhatsNewVersion = "";
+  }
 }
 
 // vim:ts=8:sw=2:noet

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -649,6 +649,11 @@ void QucsApp::initActions()
 	tr("Getting Started\n\nShort introduction into Qucs"));
   connect(helpGetStart, SIGNAL(triggered()), SLOT(slotGettingStarted()));
 
+  helpWhatsNew = new QAction(tr("What's new..."), this);
+  helpWhatsNew->setStatusTip(tr("What's new in this Qucs release"));
+  helpWhatsNew->setWhatsThis(tr("What's new\n\nWhat's new in this Qucs release"));
+  connect(helpWhatsNew, SIGNAL(triggered()), SLOT(slotWhatsNew()));
+
   helpAboutApp = new QAction(tr("&About Qucs..."), this);
   helpAboutApp->setStatusTip(tr("About the application"));
   helpAboutApp->setWhatsThis(tr("About\n\nAbout the application"));
@@ -864,6 +869,7 @@ void QucsApp::initMenuBar()
   }
 
 
+  helpMenu->addAction(helpWhatsNew);
   helpMenu->insertSeparator();
   helpMenu->addAction(helpAboutApp);
   helpMenu->addAction(helpAboutQt);

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -865,7 +865,8 @@ bool Schematic::loadDocument()
   }
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) { // wrong version number ?
+  VersionTriplet DocVersion = VersionTriplet(Line);
+  if (DocVersion > QucsVersion) { // wrong version number ?
 
     QMessageBox::StandardButton result;
     result = QMessageBox::warning(0,
@@ -1103,7 +1104,8 @@ int Schematic::testFile(const QString& DocName)
   }
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) { // wrong version number ?
+  VersionTriplet DocVersion = VersionTriplet(Line);
+  if (DocVersion > QucsVersion) { // wrong version number ?
       if (!QucsSettings.IgnoreFutureVersion) {
           file.close();
           return -4;


### PR DESCRIPTION
here is a customary "What's new" window that might be useful to inform the (new) users about the most important changes.
As usual, the window is automatically shown at startup (if the current Qucs version is newer than the last version used) and the user can choose not to see the "What's new" window again. It remains available in the 'Help' menu anyway.
I label this as a Work In Progress since
- the actual text to show still needs to be written (not an easy task...)
- I think that the window appearance and design could be improved

![qucs_whatsnew](https://cloud.githubusercontent.com/assets/9018179/9280932/ff79422c-42c1-11e5-9f2a-9d38b2a28246.png)

and, as usual, while writing this I (had to) change other stuff; I added a `SemVer` class to handle the comparison between version strings, since there was nothing already that could tell "is version 0.0.18 earlier than 0.0.19 or not?".
The existing `misc::checkVersion()` handled only one kind of comparison ('greather than') and also did not handle major versions (important if we will ever release `Qucs 1.0.0`, one day :grin:)
