### PR TITLE
Several fixes concerning rectangular waveguides

### DIFF
--- a/qucs-core/src/components/rectline.cpp
+++ b/qucs-core/src/components/rectline.cpp
@@ -183,7 +183,7 @@ void rectline::calcPropagation (nr_double_t frequency) {
     // resistive
     rs = std::sqrt (pi * frequency * mur * MU0 * rho);
     ac = rs * (2.0 * b * sqr (pi) + cubic (a) * sqr (k0)) /
-      (cubic (a) * b * beta * k0 *  Z0);
+      (cubic (a) * b * beta * k0 *  Z0  * std::sqrt(mur/er));
     alpha = (ad + ac);
 
     // wave impedance

--- a/qucs-core/src/components/rectline.cpp
+++ b/qucs-core/src/components/rectline.cpp
@@ -187,14 +187,14 @@ void rectline::calcPropagation (nr_double_t frequency) {
     alpha = (ad + ac);
 
     // wave impedance
-    zl = (k0 * Z0) / beta;
+    zl = (k0 * Z0  * std::sqrt(mur/er)) / beta;
 
   } else {
     /* according to [2] eq 3.207 */
     beta = 0;
     alpha = -std::sqrt (- (sqr (k0) - sqr (kc)));
     // wave impedance
-    zl = (k0 * Z0) / nr_complex_t (0, -alpha) ;
+    zl = (k0 * Z0 * std::sqrt(mur/er)) / nr_complex_t (0, -alpha) ;
   }
 }
 

--- a/qucs/qucs-transcalc/rectwaveguide.cpp
+++ b/qucs/qucs-transcalc/rectwaveguide.cpp
@@ -223,7 +223,7 @@ void rectwaveguide::analyze ()
     beta = sqrt (pow (k, 2.0) - pow (kc (1,0), 2.0));
     lambda_g = 2.0 * pi / beta;
     /* Z0 = (k * ZF0) / beta; */
-    Z0 = k * ZF0 / beta;
+    Z0 = k * ZF0 * sqrt(mur/er) / beta;
 
     /* calculate electrical angle */
     lambda_g = 2.0 * pi / beta;


### PR DESCRIPTION
As suggested [here] (https://github.com/Qucs/qucs/issues/347), it seems that the equation for calculating the wave impedance was wrong. According to Pozar's book (Page113, Equation 3.86):
Z_{TE} = k * eta / beta
where k is the wave number, beta is the propagation constant and eta is
the intrinsic impedance of the waveguide. By definition, eta=sqrt(mu/e) (where 'mu' is the permeability and 'e' the permittivity). However, transcalc calculated eta as eta = sqrt(mu_0/ e_0), so it worked only for e_r = 1 and mu_r = 1

I think that the same issue occurs at qucs-core/src/components/rectline.cpp