### PR TITLE
Fixed bug on applying on nonexistant property in ID_Dialog

### DIFF
--- a/qucs/qucs/paintings/id_dialog.cpp
+++ b/qucs/qucs/paintings/id_dialog.cpp
@@ -312,6 +312,8 @@ void ID_Dialog::slotOk()
 void ID_Dialog::slotApply()
 {
   int selectedrow = ParamTable->currentRow();
+  if (selectedrow<0) return; // Nothing selected
+
   QTableWidgetItem *item;
   item = ParamTable->item(selectedrow, 0);
   item->setText(showCheck->isChecked() ? tr("yes") : tr("no"));


### PR DESCRIPTION
This commit fixes the following bug that presents in `master`. Steps to reproduce are:

1. Create a subcircuit;
2. Switch to symbol editing mode (F9)
3. Double click on subcircuit propertes
4. Enter in the `Name` field a nonexistent parameter, that is not presented in `Parameters` list.
5. Press Apply
6. Qucs crashes!
