### PR TITLE
Fix Qucsconv handling of hicumL2v2p31

### DIFF
--- a/qucs-core/src/converter/check_spice.cpp
+++ b/qucs-core/src/converter/check_spice.cpp
@@ -126,7 +126,7 @@ struct define_t spice_definition_available[] =
   { "K", 4, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_LINEAR,
     spice_noprops, spice_noprops },
   /* BJT device */
-  { "Q", 4, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_NONLINEAR,
+  { "Q", 5, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_NONLINEAR,
     spice_noprops, spice_noprops },
   /* MOS device */
   { "M", 4, PROP_COMPONENT, PROP_NO_SUBSTRATE, PROP_NONLINEAR,

--- a/qucs-core/src/converter/check_spice.cpp
+++ b/qucs-core/src/converter/check_spice.cpp
@@ -681,10 +681,19 @@ static void spice_adjust_device (struct definition_t * def,
 	      def->type = strdup ("hicumL2V2p23");
 	      hic = true;
 	    }
-	    else if (level == 2 && version >= 2.24) {
+	    else if (level == 2 && version == 2.24) {
 	      def->type = strdup ("hicumL2V2p24");
 	      hic = true;
 	    }
+	    else if (level == 2 && (version == 2.31 || version == 2.31e-9) ) {
+	      def->type = strdup ("hicumL2V2p31n");
+	      hic = true;
+	    }
+      else {
+        fprintf (stderr, "spice error, no such BJT level `%1.0f' and "
+	        "version `%.2e' as referenced by %s\n", level, version, def->instance);
+        spice_errors++;
+      }
 	  }
 	}
       }

--- a/qucs-core/src/converter/parse_spice.ypp
+++ b/qucs-core/src/converter/parse_spice.ypp
@@ -395,6 +395,17 @@ DefinitionLine:
     spice_append_str_value ($$, $6, HINT_NAME);
     $$->values = netlist_append_values ($$->values, $7);
   }
+  | Bipolar_Device Node Node Node Node Node MODEL_Ident DEVICE_List_2 {
+    /* 5 node BJT */
+    $$ = spice_create_device ($1);
+    spice_append_str_value ($$, $2, HINT_NODE);
+    spice_append_str_value ($$, $3, HINT_NODE);
+    spice_append_str_value ($$, $4, HINT_NODE);
+    spice_append_str_value ($$, $5, HINT_NODE);
+    spice_append_str_value ($$, $6, HINT_NODE);
+    spice_append_str_value ($$, $7, HINT_NAME);
+    $$->values = netlist_append_values ($$->values, $8);
+  }
   | MOSFET_Device Node Node Node Node MODEL_Ident DEVICE_List_3 {
     /* MOS */
     $$ = spice_create_device ($1);

--- a/qucs-core/src/converter/qucs_producer.cpp
+++ b/qucs-core/src/converter/qucs_producer.cpp
@@ -269,7 +269,7 @@ struct device_t {
   const char * ltype;      // schematic type
   const char * stype;      // spice type
   int nodes;               // number of nodes
-  const char * props[128]; // list of properties in schematic order
+  const char * props[130]; // list of properties in schematic order
   const char * symbol;     // symbol text
   const char * coords;     // coordinates and other text
   const char * ports;      // subcircuit ports
@@ -437,6 +437,28 @@ qucs_devices[] = {
       "latb", "latl", "vgb", "alt0", "kt0", "zetaci", "alvs", "alces",
       "zetarbi", "zetarbx", "zetarcx", "zetare", "zetacx", "vge", "vgc",
       "vgs", "f1vg", "f2vg", "zetact", "zetabet", "alb", "flsh", "rth", "cth",
+      "flcomp", "tnom", "dt", "Temp", NULL },
+    NULL,
+    "1 0 0 8 -26 0 0",
+    NULL
+  },
+  /* hicum/l2 v2.31 bipolar transistor */
+  { "hicumL2V2p31n", "hicumL2V2p31n", "Q", 5,
+    { "c10", "qp0", "ich", "hf0", "hfe", "hfc", "hjei", "ahjei", "rhjei",
+      "hjci", "ibeis", "mbei", "ireis", "mrei", "ibeps", "mbep", "ireps",
+      "mrep", "mcf", "tbhrec", "ibcis", "mbci", "ibcxs", "mbcx", "ibets",
+      "abet", "tunode", "favl", "qavl", "alfav", "alqav", "rbi0", "rbx",
+      "fgeo", "fdqr0", "fcrbi", "fqi", "re", "rcx", "itss", "msf", "iscs",
+      "msc", "tsf", "rsu", "csu", "cjei0", "vdei", "zei", "ajei", "cjep0",
+      "vdep", "zep", "ajep", "cjci0", "vdci", "zci", "vptci", "cjcx0", "vdcx",
+      "zcx", "vptcx", "fbcpar", "fbepar", "cjs0", "vds", "zs", "vpts", "t0",
+      "dt0h", "tbvl", "tef0", "gtfe", "thcs", "ahc", "fthc", "rci0", "vlim",
+      "vces", "vpt", "tr", "vcbar", "icbar", "acbar", "delck", "cbepar",
+      "cbcpar", "alqf", "alit", "flnqs", "kf", "af", "cfbe", "flcono", "kfre",
+      "afre", "latb", "latl", "vgb", "alt0", "kt0", "zetaci", "alvs", "alces",
+      "zetarbi", "zetarbx", "zetarcx", "zetare", "zetacx", "vge", "vgc",
+      "vgs", "f1vg", "f2vg", "zetact", "zetabet", "alb", "dvgbe", "zetahjei",
+      "zetavgbe", "flsh", "rth", "zetarth", "alrth", "cth",
       "flcomp", "tnom", "dt", "Temp", NULL },
     NULL,
     "1 0 0 8 -26 0 0",


### PR DESCRIPTION
This is related to converting SPICE model cards and instances into qucsator and qucslib formats.

Can be tested with something like:

```
echo ".MODEL  HICUM  NPN (LEVEL = 2  VERSION = 2.31)" >> model.sp
echo "Q1 1 2 3 HICUM" >> model.sp
qucsconv -i model.sp -if spice -of qucs
qucsconv -i model.sp -if spice -of qucslib
```