### PR TITLE
make distcheck work in qucs-core.

### DIFF
--- a/qucs-core/Makefile.am
+++ b/qucs-core/Makefile.am
@@ -28,21 +28,9 @@ CODE_COVERAGE_LCOV_OPTIONS ?= --no-external --rc lcov_branch_coverage=1 $(CODE_C
 CODE_COVERAGE_GENHTML_OPTIONS ?= --rc lcov_branch_coverage=1
 @CODE_COVERAGE_RULES@
 
-## if maintainer mode we may build adms
-if MAINTAINER_MODE
-## Test if an internal adms has been requested
-if USE_INTERNAL_ADMS
-SUBDIRS = deps/adms
-else
-SUBDIRS =
-endif
-else
-SUBDIRS =
-endif
-
 ## Add the subdirectories, including a '.' which forces adms
 ## to be build first, followed by src, then doc
-SUBDIRS += src doc .
+SUBDIRS = $(ADMS_SUBDIR) src doc
 
 # include subdirs to build gtest and run unit tests
 if USE_GTEST
@@ -53,7 +41,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 nodist_pkginclude_HEADERS = qucs_typedefs.h
 
-EXTRA_DIST = BUGS bootstrap.sh depcomp RELEASE
+EXTRA_DIST = BUGS bootstrap.sh RELEASE
 
 pkginclude_HEADERS = config.h
 
@@ -75,7 +63,7 @@ MOSTLYCLEANFILES = \
 # https://github.com/Qucs/qucs-test.
 TEST_EXTENSIONS = .net .txt
 NET_LOG_COMPILER = $(top_srcdir)/tests/runqucsator.sh
-AM_NET_LOG_FLAGS = $(abs_top_srcdir)/src/qucsator
+AM_NET_LOG_FLAGS = $(abs_top_builddir)/src/qucsator
 
 TESTS =
 
@@ -111,3 +99,8 @@ if USE_QUCS_TEST
               tests/qucs-test/testsuite/DC_SW_diff1_prj/netlist.txt \
               tests/qucs-test/testsuite/DC_TR_SW_spice_BFR520_prj/netlist.txt
 endif
+
+# this is a VILE HACK
+# (but better than nothing, for now)
+dist-hook:
+	cp -r $(top_srcdir)/tests/basic $(distdir)/tests

--- a/qucs-core/configure.ac
+++ b/qucs-core/configure.ac
@@ -623,7 +623,12 @@ AM_CONDITIONAL([USE_INTERNAL_ADMS],
 dnl if we are using internal adms we need to add it to the
 dnl subdirectories autoconf will recurse into as it has its
 dnl own configure.ac and Makefile.am
-AM_COND_IF([USE_INTERNAL_ADMS], [AC_CONFIG_SUBDIRS([deps/adms/])])
+adms_subdir=
+AM_COND_IF([USE_INTERNAL_ADMS],
+	   [AC_CONFIG_SUBDIRS([deps/adms/])
+	    adms_subdir=deps/adms
+	   ])
+AC_SUBST(ADMS_SUBDIR, $adms_subdir)
 
 dnl Checks for libraries.
 AC_CHECK_LIB(m, sin)

--- a/qucs-core/src/Makefile.am
+++ b/qucs-core/src/Makefile.am
@@ -57,17 +57,17 @@ noinst_HEADERS = $(noinst_TEMPLATES)            \
 	tokens_netlist.h tokens_dataset.h check_dataset.h tokens_touchstone.h       \
 	check_touchstone.h  spsolver.h dcsolver.h variable.h       \
 	parasweep.h sweep.h libqucsator.h evaluate.h matvec.h acsolver.h   \
-	transient.h netdefs.h qucsdefs.h hbsolver.h poly.h     \
+	transient.h netdefs.h hbsolver.h poly.h     \
 	spline.h tridiag.h fourier.h hash.h applications.h     \
 	range.h history.h devstates.h tokens_citi.h check_citi.h check_zvr.h  \
 	tokens_zvr.h check_mdl.h tokens_mdl.h differentiate.h tokens_csv.h  \
-	check_csv.h analyses.h receiver.h interpolator.h
+	check_csv.h analyses.h receiver.h interpolator.h \
 	logging.h net.h input.h dataset.h equation.h tvector.h tmatrix.h \
 	environment.h exceptionstack.h check_netlist.h module.h nasolver.h \
 	states.h analysis.h trsolver.h nasolution.h eqnsys.h compat.h \
 	exception.h object.h node.h circuit.h constants.h vector.h \
 	nodeset.h nodelist.h strlist.h operatingpoint.h  consts.h  \
-	integrator.h valuelist.h
+	integrator.h valuelist.h gperfappgen.h
 
 libqucs_la_SOURCES = dataset.cpp check_dataset.cpp parse_dataset.cpp      \
 	scan_dataset.cpp check_touchstone.cpp vector.cpp object.cpp          \
@@ -92,6 +92,9 @@ qucsator_LDADD = libqucs.la
 qucsator_LDFLAGS = -Wl,-rpath,$(libdir)
 
 qucsator_SOURCES = ucs.cpp
+
+all-am: qucsdefs.h
+
 
 if MAINTAINER_MODE
 ## Here we create the various input parsing code files using
@@ -158,6 +161,8 @@ endif
 ## is #included in the body of equation.cpp
 equation.cpp: gperfapphash.cpp
 
+BUILT_SOURCES = equation.cpp
+
 if MAINTAINER_MODE
 ## Here we generate gperfapphash.cpp for equation.cpp.
 ##
@@ -174,8 +179,6 @@ gperfapphash.gph: gperfappgen$(EXEEXT)
 gperfapphash.cpp: gperfapphash.gph
 	$(GPERF) -I -m 8 $< | sed -e 's/{""},/{"",0},/g' > $@
 
-gperfappgen.cpp: gperfappgen.h
-
 gperfappgen.h: applications.h
 	sed -e 's/evaluate::[a-zA-Z0-9_]*/NULL/g' < $< > $@
 
@@ -189,4 +192,4 @@ endif
 
 CLEANFILES = *~ *.orig *.rej *.output
 MAINTAINERCLEANFILES = Makefile.in $(generated_FILES) $(gperf_FILES)
-DISTCLEANFILES = $(generated_FILES)
+DISTCLEANFILES = $(generated_FILES) $(gperf_FILES)

--- a/qucs-core/src/components/microstrip/Makefile.am
+++ b/qucs-core/src/components/microstrip/Makefile.am
@@ -32,7 +32,7 @@ libmicrostrip_la_SOURCES = substrate.cpp msline.cpp mscorner.cpp msmbend.cpp   \
 	bondwire.cpp msrstub.cpp
 
 noinst_HEADERS = substrate.h msline.h mscorner.h msmbend.h msstep.h msopen.h \
-	msgap.h mscoupled.h mslange.cpp mstee.h mscross.h msvia.h cpwline.h cpwopen.h    \
+	msgap.h mscoupled.h mslange.h mstee.h mscross.h msvia.h cpwline.h cpwopen.h    \
 	cpwshort.h cpwgap.h cpwstep.h bondwire.h msrstub.h
 
 AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/math \

--- a/qucs-core/src/converter/Makefile.am
+++ b/qucs-core/src/converter/Makefile.am
@@ -30,7 +30,9 @@ qucsconv_LDADD = ../libqucs.la ../math/libqucsmath.la
 
 qucsconv_LDFLAGS = -Wl,-rpath,$(libdir)
 
-AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/math
+AM_CPPFLAGS = -I$(top_builddir)/src \
+              -I$(top_srcdir)/src \
+              -I$(top_srcdir)/src/math
 
 qucsconv_SOURCES = qucsconv.cpp parse_spice.cpp scan_spice.cpp \
 	check_spice.cpp qucs_producer.cpp parse_vcd.cpp scan_vcd.cpp \

--- a/qucs-core/tests/Makefile.am
+++ b/qucs-core/tests/Makefile.am
@@ -51,3 +51,4 @@ libqucsUnitTest_SOURCES = testMain.cpp \
 
 libqucsUnitTest_CXXFLAGS = "-DGTEST_HAS_PTHREAD=0"
 
+EXTRA_DIST = runqucsator.sh

--- a/qucs-core/tests/runqucsator.sh
+++ b/qucs-core/tests/runqucsator.sh
@@ -1,4 +1,6 @@
-# run qucsator in directory dst on file 
+#!/bin/sh
+# run qucsator in directory dst on file
+
 qucsator="$1"
 dst="$2"
 simuldir=`


### PR DESCRIPTION
... almost work. still need
DISTCHECK_CONFIGURE_FLAGS=--enable-maintainer-mode\ --with-mkadms=admsXml

this fixes
- dont try to distribute nonexisting depcomp
- ADMS_SUBDIR (now taken care of by AC_SUBST)
- line continuation in *_HEADERS block
- some CPPFLAGS (add builddir where necessary)
- proper paths in test command
- complete CLEANFILES