### PR TITLE
[core] Fix warnings about integer comparison.

### DIFF
--- a/qucs-core/src/check_mdl.cpp
+++ b/qucs-core/src/check_mdl.cpp
@@ -418,9 +418,9 @@ static void mdl_find_varlink (struct mdl_link_t * link, char * name,
 // Sorts a dependency list according to their sweep order.
 static strlist * mdl_sort_deps (valuelist<int> * d) {
   strlist * deps = new strlist ();
-  for (int i = 0; i < d->size(); i++) {
+  for (unsigned i = 0; i < d->size(); i++) {
     for (auto &val: *d) {
-      if (val.second == i + 1) {
+      if ((unsigned) val.second == i + 1) {
 	deps->append (val.first.c_str());
       }
     }

--- a/qucs-core/src/circuit.cpp
+++ b/qucs-core/src/circuit.cpp
@@ -129,7 +129,7 @@ circuit::circuit (const circuit & c) : object (c), integrator (c) {
   if (size > 0) {
     // copy each node and set its circuit to the current circuit object
     nodes = new node[size];
-    for (int i = 0; i < size; i++) {
+    for (unsigned i = 0; i < size; i++) {
       nodes[i] = node (c.nodes[i]);;
       nodes[i].setCircuit (this);
     }
@@ -197,7 +197,7 @@ circuit::~circuit () {
    completely lost except the current size equals the given size. */
 void circuit::setSize (int s) {
   // nothing to do here
-  if (size == s) return;
+  if (size == (unsigned) s) return;
   assert (s >= 0);
 
   if (size > 0) {
@@ -642,8 +642,8 @@ void circuit::setInternalNode (int node, const std::string &suffix) {
 /* This function copies the matrix elements inside the given matrix to
    the internal S-parameter matrix of the circuit. */
 void circuit::setMatrixS (matrix s) {
-  int r = s.getRows ();
-  int c = s.getCols ();
+  unsigned r = s.getRows ();
+  unsigned c = s.getCols ();
   // copy matrix elements
   if (r > 0 && c > 0 && r * c == size * size) {
     memcpy (MatrixS, s.getData (), sizeof (nr_complex_t) * r * c);
@@ -663,8 +663,8 @@ matrix circuit::getMatrixS (void) {
 /* This function copies the matrix elements inside the given matrix to
    the internal noise correlation matrix of the circuit. */
 void circuit::setMatrixN (matrix n) {
-  int r = n.getRows ();
-  int c = n.getCols ();
+  unsigned r = n.getRows ();
+  unsigned c = n.getCols ();
   // copy matrix elements
   if (r > 0 && c > 0 && r * c == size * size) {
     memcpy (MatrixN, n.getData (), sizeof (nr_complex_t) * r * c);
@@ -684,8 +684,8 @@ matrix circuit::getMatrixN (void) {
 /* This function copies the matrix elements inside the given matrix to
    the internal G-MNA matrix of the circuit. */
 void circuit::setMatrixY (matrix y) {
-  int r = y.getRows ();
-  int c = y.getCols ();
+  unsigned r = y.getRows ();
+  unsigned c = y.getCols ();
   // copy matrix elements
   if (r > 0 && c > 0 && r * c == size * size) {
     memcpy (MatrixY, y.getData (), sizeof (nr_complex_t) * r * c);

--- a/qucs-core/src/circuit.h
+++ b/qucs-core/src/circuit.h
@@ -337,7 +337,7 @@ class circuit : public object, public integrator
   int pol;
 
  private:
-  int size;
+  unsigned int size;
   int pacport;
   int vsource;
   int vsources;

--- a/qucs-core/src/hbsolver.cpp
+++ b/qucs-core/src/hbsolver.cpp
@@ -415,7 +415,7 @@ void hbsolver::collectFrequencies (void) {
 
   // build frequency dimension lengths
   ndfreqs = new int[dfreqs.size ()];
-  for (i = 0; i < dfreqs.size (); i++) {
+  for (unsigned int i = 0; i < dfreqs.size (); i++) {
     ndfreqs[i] = (n + 1) * 2;
   }
 
@@ -428,7 +428,7 @@ void hbsolver::collectFrequencies (void) {
 #endif /* HB_DEBUG */
 
   // build list of positive frequencies including DC
-  for (n = 0; n < negfreqs.size (); n++) {
+  for (unsigned n = 0; n < negfreqs.size (); n++) {
     if ((f = negfreqs[n]) < 0.0) continue;
     rfreqs.push_back (f);
   }
@@ -576,7 +576,7 @@ void hbsolver::createMatrixLinearA (void) {
   A = new tmatrix<nr_complex_t> ((N + M) * lnfreqs);
 
   // through each frequency
-  for (int i = 0; i < rfreqs.size (); i++) {
+  for (unsigned i = 0; i < rfreqs.size (); i++) {
     freq = rfreqs[i];
     // calculate components' MNA matrix for the given frequency
     for (auto *lc : lincircuits)
@@ -882,7 +882,7 @@ void hbsolver::calcConstantCurrent (void) {
     circuit * vs = *it;
     vs->initHB ();
     vs->setVoltageSource (0);
-    for (int f = 0; f < rfreqs.size (); f++) { // for each frequency
+    for (unsigned f = 0; f < rfreqs.size (); f++) { // for each frequency
       nr_double_t freq = rfreqs[f];
       vs->calcHB (freq);
       VC (vsrc * lnfreqs + f) = vs->getE (VSRC_1);

--- a/qucs-core/src/interface/e_trsolver.cpp
+++ b/qucs-core/src/interface/e_trsolver.cpp
@@ -371,7 +371,7 @@ void e_trsolver::printx()
 {
     char buf [1024];
 
-    for (int r = 0; r < x->size(); r++) {
+    for (unsigned int r = 0; r < x->size(); r++) {
         buf[0] = '\0';
         //sprintf (buf, "%+.2e%+.2ei", (double) real (x->get (r)), (double) imag (x->get (r)));
 
@@ -825,12 +825,12 @@ void e_trsolver::rejectstep_async(void)
 /* Makes a copy of a set of solution vectors */
 void e_trsolver::copySolution (tvector<nr_double_t> * src[8], tvector<nr_double_t> * dest[8])
 {
-    for (int i = 0; i < 8; i++)
+    for (unsigned int i = 0; i < 8; i++)
     {
         // check sizes are the same
         assert (src[i]->size () == dest[i]->size ());
         // copy over the data values
-        for (int j = 0; j < src[i]->size (); j++)
+        for (unsigned int j = 0; j < src[i]->size (); j++)
         {
             dest[i]->set (j, src[i]->get (j));
         }

--- a/qucs-core/src/module.cpp
+++ b/qucs-core/src/module.cpp
@@ -456,7 +456,7 @@ void module::registerDynamicModules (char *proj, std::list<std::string> modlist)
 */
 
   fprintf(stdout,"project location: %s\n", proj);
-  fprintf(stdout,"modules to load: %lu\n", modlist.size());
+  fprintf(stdout,"modules to load: %u\n", modlist.size());
 
   std::list<std::string>::iterator it;
   for (it=modlist.begin(); it!=modlist.end(); ++it) {

--- a/qucs-core/src/nasolver.cpp
+++ b/qucs-core/src/nasolver.cpp
@@ -248,7 +248,7 @@ void nasolver<nr_type_t>::applyNodeset (bool nokeep)
     if (x == NULL || nlist == NULL) return;
 
     // set each solution to zero
-    if (nokeep) for (int i = 0; i < x->size (); i++) x->set (i, 0);
+    if (nokeep) for (unsigned int i = 0; i < x->size (); i++) x->set (i, 0);
 
     // then apply the nodeset itself
     for (nodeset * n = subnet->getNodeset (); n; n = n->getNext ())

--- a/qucs-core/src/spline.cpp
+++ b/qucs-core/src/spline.cpp
@@ -94,8 +94,8 @@ spline::spline (tvector<nr_double_t> y, tvector<nr_double_t> t) {
 
 // Pass interpolation datapoints as vectors.
 void spline::vectors (qucs::vector y, qucs::vector t) {
-  int i = t.getSize ();
-  assert (y.getSize () == i && i >= 3);
+  unsigned int i = t.getSize ();
+  assert ((unsigned int) y.getSize () == i && i >= 3);
 
   // create local copy of f(x)
   realloc (i);
@@ -106,8 +106,8 @@ void spline::vectors (qucs::vector y, qucs::vector t) {
 
 // Pass interpolation datapoints as tvectors.
 void spline::vectors (::std::vector<nr_double_t> y, ::std::vector<nr_double_t> t) {
-  int i = (int)t.size ();
-  assert ((int)y.size () == i && i >= 3);
+  unsigned int i = t.size ();
+  assert (y.size () == i && i >= 3);
 
   // create local copy of f(x)
   realloc (i);
@@ -118,7 +118,7 @@ void spline::vectors (::std::vector<nr_double_t> y, ::std::vector<nr_double_t> t
 
 // Pass interpolation datapoints as tvectors.
 void spline::vectors (tvector<nr_double_t> y, tvector<nr_double_t> t) {
-  int i = t.size ();
+  unsigned int i = t.size ();
   assert (y.size () == i && i >= 3);
 
   // create local copy of f(x)
@@ -130,7 +130,7 @@ void spline::vectors (tvector<nr_double_t> y, tvector<nr_double_t> t) {
 
 // Pass interpolation datapoints as pointers.
 void spline::vectors (nr_double_t * y, nr_double_t * t, int len) {
-  int i = len;
+  unsigned int i = len;
   assert (i >= 3);
 
   // create local copy of f(x)
@@ -141,7 +141,7 @@ void spline::vectors (nr_double_t * y, nr_double_t * t, int len) {
 }
 
 // Reallocate vector data if necessary.
-void spline::realloc (int size) {
+void spline::realloc (unsigned int size) {
   if (n != size - 1) {
     n = size - 1;
     delete[] f0;
@@ -158,7 +158,7 @@ void spline::realloc (int size) {
 void spline::construct (void) {
 
   // calculate first derivative h = f'(x)
-  int i;
+  unsigned int i;
   nr_double_t * h  = new nr_double_t[n+1];
   for (i = 0; i < n; i++) {
     h[i] = x[i+1] - x[i];

--- a/qucs-core/src/spline.h
+++ b/qucs-core/src/spline.h
@@ -62,7 +62,7 @@ class spline
 
  private:
   nr_double_t * upper_bound (nr_double_t *, nr_double_t *, nr_double_t);
-  void realloc (int);
+  void realloc (unsigned int);
 
  private:
   nr_double_t * x;
@@ -71,7 +71,7 @@ class spline
   nr_double_t * f2;
   nr_double_t * f3;
   nr_double_t d0, dn;
-  int n;
+  unsigned int n;
   int boundary;
 };
 

--- a/qucs-core/src/tmatrix.cpp
+++ b/qucs-core/src/tmatrix.cpp
@@ -289,7 +289,7 @@ tmatrix<nr_type_t> operator * (tmatrix<nr_type_t> a, tmatrix<nr_type_t> b) {
 // Multiplication of matrix and vector.
 template <class nr_type_t>
 tvector<nr_type_t> operator * (tmatrix<nr_type_t> a, tvector<nr_type_t> b) {
-  assert (a.getCols () == b.size ());
+  assert ((unsigned int) a.getCols () == b.size ());
   int r, c, n = a.getCols ();
   nr_type_t z;
   tvector<nr_type_t> res (n);
@@ -304,7 +304,7 @@ tvector<nr_type_t> operator * (tmatrix<nr_type_t> a, tvector<nr_type_t> b) {
 // Multiplication of vector (transposed) and matrix.
 template <class nr_type_t>
 tvector<nr_type_t> operator * (tvector<nr_type_t> a, tmatrix<nr_type_t> b) {
-  assert (a.size () == b.getRows ());
+  assert (a.size () == (unsigned) b.getRows ());
   int r, c, n = b.getRows ();
   nr_type_t z;
   tvector<nr_type_t> res (n);

--- a/qucs-core/src/tvector.cpp
+++ b/qucs-core/src/tvector.cpp
@@ -180,7 +180,7 @@ template <class nr_type_t>
 nr_type_t scalar (tvector<nr_type_t> a, tvector<nr_type_t> b) {
   assert (a.size () == b.size ());
   nr_type_t n = 0;
-  for (int i = 0; i < a.size (); i++) n += a.get (i) * b.get (i);
+  for (unsigned int i = 0; i < a.size (); i++) n += a.get (i) * b.get (i);
   return n;
 }
 
@@ -195,16 +195,16 @@ tvector<nr_type_t> tvector<nr_type_t>::operator = (const nr_type_t val) {
 template <class nr_type_t>
 nr_type_t sum (tvector<nr_type_t> a) {
   nr_type_t res = 0;
-  for (int i = 0; i < a.size (); i++) res += a.get (i);
+  for (unsigned int i = 0; i < a.size (); i++) res += a.get (i);
   return res;
 }
 
 // Vector negation.
 template <class nr_type_t>
 tvector<nr_type_t> operator - (tvector<nr_type_t> a) {
-  int n = a.size ();
+  unsigned int n = a.size ();
   tvector<nr_type_t> res (n);
-  for (int i = 0; i < n; i++) res.set (i, -a.get (i));
+  for (unsigned int i = 0; i < n; i++) res.set (i, -a.get (i));
   return res;
 }
 
@@ -249,7 +249,7 @@ nr_double_t norm (tvector<nr_type_t> a) {
   return n;
 #else
   nr_double_t scale = 0, n = 1, x, ax;
-  for (int i = 0; i < a.size (); i++) {
+  for (unsigned int i = 0; i < a.size (); i++) {
     if ((x = real (a (i))) != 0) {
       ax = fabs (x);
       if (scale < ax) {
@@ -283,7 +283,7 @@ nr_double_t norm (tvector<nr_type_t> a) {
 template <class nr_type_t>
 nr_double_t maxnorm (tvector<nr_type_t> a) {
   nr_double_t nMax = 0, n;
-  for (int i = 0; i < a.size (); i++) {
+  for (unsigned int i = 0; i < a.size (); i++) {
     n = norm (a.get (i));
     if (n > nMax) nMax = n;
   }
@@ -293,16 +293,16 @@ nr_double_t maxnorm (tvector<nr_type_t> a) {
 // Conjugate vector.
 template <class nr_type_t>
 tvector<nr_type_t> conj (tvector<nr_type_t> a) {
-  int n = a.size ();
+  unsigned int n = a.size ();
   tvector<nr_type_t> res (n);
-  for (int i = 0; i < n; i++) res.set (i, conj (a.get (i)));
+  for (unsigned int i = 0; i < n; i++) res.set (i, conj (a.get (i)));
   return res;
 }
 
 // Checks validity of vector.
 template <class nr_type_t>
 int tvector<nr_type_t>::isFinite (void) {
-  for (int i = 0; i < (int)data.size (); i++)
+  for (unsigned int i = 0; i < (int)data.size (); i++)
     if (!std::isfinite (real ((*data)[i]))) return 0;
   return 1;
 }


### PR DESCRIPTION
warning: comparison between signed and unsigned integer

Why use `int` to cont from 0 and up?
We could write just `unsigned` instead of `unsigned int`.

Todo: replace by `unsigned` everywhere. Task for another day.