### PR TITLE
Re-add .moc.cpp to SUFFIXES to correct dependency

### DIFF
--- a/qucs/qucs/Makefile.am
+++ b/qucs/qucs/Makefile.am
@@ -94,6 +94,7 @@ EXTRA_DIST = \
 	$(hicolorsc_DATA) $(desktop_DATA)
 
 
+SUFFIXES = .moc.cpp
 .h.moc.cpp:
 	$(MOC) -o $@ $<
 


### PR DESCRIPTION
While moving back and forth between branches and recompiling, I got some strange errors on `qucs.moc.cpp`. Digging a little bit, I saw that `make` did not recognize that `qucs.h` changed and so did not regenerate the corresponding `qucs.moc.cpp`.
Apparently this is due to the fact that the line
```
SUFFIXES = .moc.cpp
```
was erroneously removed from `qucs/Makefile.am` in commit cb288ebc8f7c35586ca9ed72685e61fe711d6af5 so that the dependency
on the `.h` file was not honored.

Not sure why the rule worked when `qucs.moc.cpp` was not present but not when `qucs.h` was modified...

