### PR TITLE
Correct the Ideal OpAmp model

### DIFF
--- a/qucs/qucs-lib/library/Ideal.lib
+++ b/qucs/qucs-lib/library/Ideal.lib
@@ -168,16 +168,16 @@ Simple operational amplifier model
   </Description>
   <Model>
 .Def:Ideal_OpAmp _net0 _net2 _net6 GBP="1E6" AOLDC="106" RO="75" VLIMP="14" VLIMN="-14"
-VCVS:SRC1 _net0 _net1 gnd _net2 G="G" T="0"
-R:R1 _net1 _net3 R="1E3/sqrt(2*pi*fg)" Temp="26.85" Tc1="0.0" Tc2="0.0" Tnom="26.85"
-C:C1 gnd _net3 C="1E-3/sqrt(2*pi*fg)" V=""
+VCVS:SRC1 _net0 _net1 gnd _net2 G="OLG" T="0"
+R:R1 _net1 _net3 R="R1" Temp="26.85" Tc1="0.0" Tc2="0.0" Tnom="26.85"
+C:C1 gnd _net3 C="C1" V=""
 CCVS:SRC2 _net4 _net5 gnd gnd G="1 Ohm" T="0"
-Eqn:Eqn1 OLG="10^(AOLDC/20)" fg="GBP/OLG" Export="yes"
+Eqn:Eqn1 OLG="10^(AOLDC/20)" fg="GBP/OLG" C1="1E-3/sqrt(2*pi*fg)" R1="1E3/sqrt(2*pi*fg)" Export="yes"
 R:R2 _net5 _net6 R="RO" Temp="26.85" Tc1="0.0" Tc2="0.0" Tnom="26.85"
 EDD:D1 _net3 gnd gnd _net4 I1="D1.I1" Q1="D1.Q1" I2="D1.I2" Q2="D1.Q2"
   Eqn:EqnD1I1 D1.I1="0" Export="no"
   Eqn:EqnD1Q1 D1.Q1="0" Export="no"
-  Eqn:EqnD1I2 D1.I2="(V2<VLIMP)?((V2>VLIMN)?V2:VLIMN):VLIMP" Export="no"
+  Eqn:EqnD1I2 D1.I2="(V1<VLIMP)?((V1>VLIMN)?V1:VLIMN):VLIMP" Export="no"
   Eqn:EqnD1Q2 D1.Q2="0" Export="no"
 .Def:End
   </Model>


### PR DESCRIPTION
This fixes #140 . The OpAmp model in the Ideal library had several errors in its definition (strange but true...)

A Qucs Package with some test circuits can be found [here] (https://gist.github.com/in3otd/ee3b324524a1be277292/raw/986f5a91b86b25437c7e3e5fe79f4c254f944b28/IdealOpAmpTest.qucs)

Some sample simulations results:
![idealopamp_ac](https://cloud.githubusercontent.com/assets/9018179/9977131/60b20cc0-5efd-11e5-9ec6-ac98aaae040b.png)

![idealopamp_dc](https://cloud.githubusercontent.com/assets/9018179/9977135/78d87b4a-5efd-11e5-9562-e7150bfa3aed.png)
