### PR TITLE
Correct pin assignment in LM317 regulator

### DIFF
--- a/qucs/qucs-lib/library/Regulators.lib
+++ b/qucs/qucs-lib/library/Regulators.lib
@@ -554,7 +554,7 @@ Sub:X1 _net1 _net0 _net2 gnd Type="LM140_5_mod"
   </Description>
   <Model>
 .Def:lm317_cir _net1 _net2 _net3 _ref
-  .Def:XLM317 _ref _net1 _net2 _net3
+  .Def:XLM317 _ref _net1 _net3 _net2
   JFET:J1 _net3 _net1 _net4 Type="nfet" Beta="0.0001" Vt0="-7" Is="1e-014" N="1" Lambda="0" M="0.5" Pb="1" Fc="0.5" Cgs="0" Cgd="0"
   BJT:Q2 _net5 _net5 _net6 _ref Type="pnp" Area="0.1" Bf="40" Rb="20" Tf="0.6ns" Tr="10ns" Cje="1.5pF" Cjc="1pF" Vaf="50" Is="1e-016" Nf="1" Nr="1" Ikf="0" Ikr="0" Var="0" Ise="0" Ne="1.5" Isc="0" Nc="2" Br="1" Rbm="0" Irb="0" Vje="0.75" Mje="0.33" Vjc="0.75" Mjc="0.33" Xcjc="1" Cjs="0" Vjs="0.75" Mjs="0" Fc="0.5" Vtf="0" Xtf="0" Itf="0"
   BJT:Q3 _net8 _net5 _net9 _ref Type="npn" Area="0.2" Eg="1.22" Bf="80" Rb="100" Cjs="1.5pF" Tf="0.3ns" Tr="6ns" Cje="2pF" Cjc="1pF" Vaf="100" Is="1e-016" Nf="1" Nr="1" Ikf="0" Ikr="0" Var="0" Ise="0" Ne="1.5" Isc="0" Nc="2" Br="1" Rbm="0" Irb="0" Vje="0.75" Mje="0.33" Vjc="0.75" Mjc="0.33" Xcjc="1" Vjs="0.75" Mjs="0" Fc="0.5" Vtf="0" Xtf="0" Itf="0"


### PR DESCRIPTION
Fixes #367. The pins OUT and ADJ were swapped in the LM317 model. Note that the model has/causes some convergence issues. 
The two LM317 model in the library are very similar but not identical (a few BJT have different area and/or saturation current), so some results, like the exact output voltage or the maximum current are different.

Simulations results below, with the two LM317 models (and with the LM337 just to show it works well, with a negative voltage at input)

![test317_sch](https://cloud.githubusercontent.com/assets/9018179/9980829/dd13e130-5fa7-11e5-9943-38ef3bfbc8d2.png)

![test317_dpl](https://cloud.githubusercontent.com/assets/9018179/9980830/e4dea9f4-5fa7-11e5-9e63-d746dc8ebb62.png)
