### PR TITLE
Fix for #372, hardcoded .qucs paths in Qucs Help and Qucs Transcalc

### DIFF
--- a/qucs/qucs-help/main.cpp
+++ b/qucs/qucs-help/main.cpp
@@ -31,6 +31,7 @@
 #include <QDir>
 #include <QFont>
 #include <QTextCodec>
+#include <QSettings>
 #include <QDebug>
 
 #include "qucshelp.h"
@@ -43,77 +44,38 @@ QDir QucsHelpDir; // directory to find helps files
 tQucsSettings QucsSettings; // application settings
 
 // #########################################################################
-// Loads the settings file and stores the settings.
+// Loads the application settings and stores them into QucsSettings.
+// TODO: should not return a bool. it has no meaning
+// FIXME: error handling is broken, due to Qt and/or -fno-exceptions
+//        (errors loading settings are not checked/reported)
 bool loadSettings()
 {
-  bool result = true;
-
-  QFile file(QDir::homePath()+QDir::convertSeparators ("/.qucs/helprc"));
-  if(!file.open(QIODevice::ReadOnly))
-    result = false; // settings file doesn't exist
-  else {
-    QTextStream stream(&file);
-    QString Line, Setting;
-    while(!stream.atEnd()) {
-      Line = stream.readLine();
-      Setting = Line.section('=',0,0);
-      Line = Line.section('=',1,1);
-      if(Setting == "HelpWindow") {
-	QucsSettings.x  = Line.section(",",0,0).toInt();
-	QucsSettings.y  = Line.section(",",1,1).toInt();
-	QucsSettings.dx = Line.section(",",2,2).toInt();
-	QucsSettings.dy = Line.section(",",3,3).toInt();
-	break; }
-    }
-    file.close();
-  }
-
-  file.setFileName(QDir::homePath()+QDir::convertSeparators ("/.qucs/qucsrc"));
-  if(!file.open(QIODevice::ReadOnly))
-    result = true; // qucs settings not necessary
-  else {
-    QTextStream stream(&file);
-    QString Line, Setting;
-    while(!stream.atEnd()) {
-      Line = stream.readLine();
-      Setting = Line.section('=',0,0);
-      Line = Line.section('=',1,1).trimmed();
-      if(Setting == "Font")
-	QucsSettings.font.fromString(Line);
-      else if(Setting == "Language")
-	QucsSettings.Language = Line;
-    }
-    file.close();
-  }
-  return result;
+  QSettings settings("qucs","qucs");
+  settings.beginGroup("QucsHelp");
+  if(settings.contains("x"))QucsSettings.x=settings.value("x").toInt();
+  if(settings.contains("y"))QucsSettings.y=settings.value("y").toInt();
+  if(settings.contains("dx"))QucsSettings.dx=settings.value("dx").toInt();
+  if(settings.contains("dy"))QucsSettings.dy=settings.value("dy").toInt();
+  settings.endGroup();
+  if(settings.contains("font"))QucsSettings.font.fromString(settings.value("font").toString());
+  if(settings.contains("Language"))QucsSettings.Language=settings.value("Language").toString();
+  return true;
 }
 
 // #########################################################################
-// Saves the settings in the settings file.
+// Saves the application settings.
+// TODO: should not return a bool. it has no meaning
+// FIXME: error handling is broken, due to Qt and/or -fno-exceptions
+//        (errors saving settings are not checked/reported)
 bool saveApplSettings(QucsHelp *qucs)
 {
-  if(qucs->x() == QucsSettings.x)
-    if(qucs->y() == QucsSettings.y)
-      if(qucs->width() == QucsSettings.dx)
-	if(qucs->height() == QucsSettings.dy)
-	  return true;   // nothing has changed
-
-
-  QFile file(QDir::homePath()+QDir::convertSeparators ("/.qucs/helprc"));
-  if(!file.open(QIODevice::WriteOnly)) {
-    QMessageBox::warning(0, QObject::tr("Warning"),
-			QObject::tr("Cannot save settings !"));
-    return false;
-  }
-
-  QString Line;
-  QTextStream stream(&file);
-
-  stream << "Settings file, Qucs Help System " PACKAGE_VERSION "\n"
-	 << "HelpWindow=" << qucs->x() << ',' << qucs->y() << ','
-	 << qucs->width() << ',' << qucs->height() << '\n';
-
-  file.close();
+  QSettings settings ("qucs","qucs");
+  settings.beginGroup("QucsHelp");
+  settings.setValue("x", qucs->x());
+  settings.setValue("y", qucs->y());
+  settings.setValue("dx", qucs->width());
+  settings.setValue("dy", qucs->height());
+  settings.endGroup();
   return true;
 }
 

--- a/qucs/qucs-transcalc/main.cpp
+++ b/qucs/qucs-transcalc/main.cpp
@@ -58,6 +58,11 @@ bool loadSettings()
     settings.endGroup();
     if(settings.contains("font"))QucsSettings.font.fromString(settings.value("font").toString());
     if(settings.contains("Language"))QucsSettings.Language=settings.value("Language").toString();
+    if(settings.contains("QucsHomeDir"))
+      if(settings.value("QucsHomeDir").toString() != "")
+	QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
+
+    QucsSettings.QucsWorkDir = QucsSettings.QucsHomeDir;
 
   return true;
 }
@@ -79,8 +84,8 @@ bool saveApplSettings(QucsTranscalc *qucs)
     settings.setValue("ResUnit", TransUnits[2].units[QucsSettings.res_unit]);
     settings.setValue("AngUnit", TransUnits[3].units[QucsSettings.ang_unit]);
     settings.endGroup();
-  return true;
 
+    return true;
 }
 
 
@@ -102,6 +107,7 @@ int main(int argc, char *argv[])
   QucsSettings.res_unit = 0;
   QucsSettings.ang_unit = 0;
   QucsSettings.freq_unit = 0;
+  QucsSettings.QucsHomeDir.setPath(QDir::homePath() + "/.qucs");
 
   // is application relocated?
   char * var = getenv ("QUCSDIR");
@@ -113,7 +119,6 @@ int main(int argc, char *argv[])
   } else {
     QucsSettings.LangDir = LANGUAGEDIR;
   }
-  QucsSettings.QucsWorkDir.setPath (QDir::homePath()+QDir::convertSeparators ("/.qucs"));
   loadSettings();
 
   QApplication a(argc, argv);
@@ -132,7 +137,8 @@ int main(int argc, char *argv[])
   qucs->move(QucsSettings.x, QucsSettings.y);     // ... before "show" !!!
   qucs->show();
 
-  qucs->loadFile(QDir::homePath()+"/.qucs/transrc");
+  // load file with all the GUI input values from the Qucs Home
+  qucs->loadFile(QucsSettings.QucsHomeDir.filePath("transrc"));
   qucs->setMode(QucsSettings.Mode);
 
   // optional file argument
@@ -144,6 +150,8 @@ int main(int argc, char *argv[])
 
   int result = a.exec();
   saveApplSettings(qucs);
+  // save file with all the GUI input values in the Qucs Home
+  qucs->saveModes(QucsSettings.QucsHomeDir.filePath("transrc"));
   delete qucs;
   return result;
 }

--- a/qucs/qucs-transcalc/qucstrans.cpp
+++ b/qucs/qucs-transcalc/qucstrans.cpp
@@ -1079,14 +1079,28 @@ void QucsTranscalc::saveMode(QTextStream& stream) {
   stream << "</" << t->description << ">\n";
 }
 
-// Writes the transmission line values for all modes into the given stream.
-void QucsTranscalc::saveModes(QTextStream& stream) {
+// Writes the transmission line values for all modes into the given file.
+bool QucsTranscalc::saveModes(QString fname) {
   int oldmode = mode;
+
+  QFile file(fname);
+  if(!file.open(QIODevice::WriteOnly)) {
+    QMessageBox::warning(this, QObject::tr("Warning"),
+			 QObject::tr("Cannot save GUI settings in\n") + fname);
+    return false;
+  }
+  
+  QTextStream stream(&file);
+  stream << "QucsTranscalc " PACKAGE_VERSION " GUI Settings File\n";
   for (int i = 0; i < MAX_TRANS_TYPES; i++) {
     mode = TransLineTypes[i].type;
     saveMode (stream);
   }
+  file.close();
+
   mode = oldmode;
+
+  return true;
 }
 
 // Saves the GUI values into internal data structures.

--- a/qucs/qucs-transcalc/qucstrans.h
+++ b/qucs/qucs-transcalc/qucstrans.h
@@ -148,7 +148,7 @@ public:
   bool    isSelected (QString);
 
   void    saveMode (QTextStream&);
-  void    saveModes (QTextStream&);
+  bool    saveModes (QString);
   bool    loadFile (QString, int * _mode = 0);
   QString getMode (void);
   void    setMode (QString);


### PR DESCRIPTION
This fixes #372. 
Now Qucs Help uses the standard QucsSetting to store/retrieve its settings and the main GUI settings (language and font).
Qucs Transcalc now stores the last used GUI input values in QucsHome instead of `~/.qucs` 