### PR TITLE
remove exclamation marks from error messages!

### DIFF
--- a/qucs/translations/qucs_ar.ts
+++ b/qucs/translations/qucs_ar.ts
@@ -5768,7 +5768,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12795,7 +12795,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation> خطأ : لا يمكن إنشاء دليل فرعي لمستخدم المكتبة !</translation>
     </message>
@@ -13315,28 +13315,28 @@ qucsedit [-r] file :إستعمال
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>كذلك طول متغير السطر!
+        <translation>كذلك طول متغير السطر
 
  </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>خطأ في معامل  الأمِر!
+        <translation>خطأ في معامل  الأمِر
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation> اسم الملف واحد فقط سمحت!
+        <translation> اسم الملف واحد فقط سمحت
 
 </translation>
     </message>
@@ -13886,9 +13886,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>وتتضمن هذه الوثيقة التغييرات غير المحفوظة!
+        <translation>وتتضمن هذه الوثيقة التغييرات غير المحفوظة
 </translation>
     </message>
     <message>
@@ -14195,9 +14195,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos;موجود بالفعل!
+        <translation>&apos;موجود بالفعل
 </translation>
     </message>
     <message>
@@ -16545,9 +16545,9 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>ويتضمن النص التغييرات غير المحفوظة!
+        <translation>ويتضمن النص التغييرات غير المحفوظة
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_ca.ts
+++ b/qucs/translations/qucs_ca.ts
@@ -5786,7 +5786,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12812,7 +12812,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13331,28 +13331,28 @@ Use:  qucsedit [-r] fitxer
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>¡Línea de comandos demasiado larga!
+        <translation>¡Línea de comandos demasiado larga
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>¡Línea de comandos equivocada!
+        <translation>¡Línea de comandos equivocada
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>¡Sólo está permitido el nombre de un fitxer!
+        <translation>¡Sólo está permitido el nombre de un fitxer
 
 </translation>
     </message>
@@ -13902,9 +13902,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>¡El document contiene cambios  no guardados!
+        <translation>¡El document contiene cambios  no guardados
 
 </translation>
     </message>
@@ -14212,9 +14212,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; ya existe!
+        <translation>&apos; ya existe
 </translation>
     </message>
     <message>
@@ -16547,9 +16547,9 @@ Editor de text muy simple para Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>¡El text contiene cambios  no guardados!
+        <translation>¡El text contiene cambios  no guardados
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_cs.ts
+++ b/qucs/translations/qucs_cs.ts
@@ -5770,7 +5770,7 @@ Neplatný začátek řádku!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12796,7 +12796,7 @@ Chybný řádkový formát &apos;component&apos; !</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13317,28 +13317,28 @@ Použití:  qucsedit [-r] soubor
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Příliš dlouhý argument v příkazovém řádku!
+        <translation>Příliš dlouhý argument v příkazovém řádku
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Chybný argument v příkazovém řádku!
+        <translation>Chybný argument v příkazovém řádku
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Je povolen jen jeden název souboru!
+        <translation>Je povolen jen jeden název souboru
 
 </translation>
     </message>
@@ -13888,9 +13888,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Dokument obsahuje neuložené změny!
+        <translation>Dokument obsahuje neuložené změny
 </translation>
     </message>
     <message>
@@ -14197,9 +14197,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; již existuje!
+        <translation>&apos; již existuje
 </translation>
     </message>
     <message>
@@ -16550,9 +16550,9 @@ Jednoduchý editor pro Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Text obsahuje neuložené změny!
+        <translation>Text obsahuje neuložené změny
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_de.ts
+++ b/qucs/translations/qucs_de.ts
@@ -5780,7 +5780,7 @@ Ungültiger Zeilenanfang!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12806,7 +12806,7 @@ Falsches &apos;component&apos; Zeilenformat!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13328,28 +13328,28 @@ Verwendung:  qucsedit [-r] Datei
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Kommandzeilenargument ist zu lang!
+        <translation>Kommandzeilenargument ist zu lang
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Falsches Kommandozeilenargument!
+        <translation>Falsches Kommandozeilenargument
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Es ist nur ein Dateiname erlaubt!
+        <translation>Es ist nur ein Dateiname erlaubt
 
 </translation>
     </message>
@@ -13899,7 +13899,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -14207,7 +14207,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>existiert bereits!</translation>
     </message>
@@ -14376,7 +14376,7 @@ Active Filter synthesis program
         <source>Cannot start text editor! 
 
 %1</source>
-        <translation>Kann den Text Editor nicht starten!
+        <translation>Kann den Text Editor nicht starten
 
 %1</translation>
     </message>
@@ -16306,7 +16306,7 @@ Einfacher Texteditor für Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>

--- a/qucs/translations/qucs_en.ts
+++ b/qucs/translations/qucs_en.ts
@@ -5765,7 +5765,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12790,7 +12790,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13288,21 +13288,21 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
         <translation type="unfinished"></translation>
@@ -13853,7 +13853,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -14161,7 +14161,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16243,7 +16243,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>

--- a/qucs/translations/qucs_es.ts
+++ b/qucs/translations/qucs_es.ts
@@ -5769,7 +5769,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12796,9 +12796,9 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>ERROR: No se pudo crear el subdirectorio de la biblioteca del usuario!
+        <translation>ERROR: No se pudo crear el subdirectorio de la biblioteca del usuario
 </translation>
     </message>
     <message>
@@ -13317,28 +13317,28 @@ Use:  qucsedit [-r] archivo
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>¡Línea de comandos demasiado larga!
+        <translation>¡Línea de comandos demasiado larga
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>¡Línea de comandos equivocada!
+        <translation>¡Línea de comandos equivocada
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>¡Sólo está permitido el nombre de un archivo!
+        <translation>¡Sólo está permitido el nombre de un archivo
 
 </translation>
     </message>
@@ -13888,9 +13888,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>¡El documento contiene cambios  no guardados!
+        <translation>¡El documento contiene cambios  no guardados
 
 </translation>
     </message>
@@ -14198,9 +14198,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; ya existe!
+        <translation>&apos; ya existe
 </translation>
     </message>
     <message>
@@ -16553,9 +16553,9 @@ Editor de texto muy simple para Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>¡El texto contiene cambios  no guardados!
+        <translation>¡El texto contiene cambios  no guardados
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_fr.ts
+++ b/qucs/translations/qucs_fr.ts
@@ -5775,7 +5775,7 @@ Début de ligne incorrect !</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12802,9 +12802,9 @@ Ligne « composant » incohérente !</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>ERREUR : impossible de créer un rayonnage personnalisé !
+        <translation>ERREUR : impossible de créer un rayonnage personnalisé
 </translation>
     </message>
     <message>
@@ -13325,7 +13325,7 @@ Invocation :  qucsedit [-r] fichier
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation>Ligne de commande trop longue ! 
@@ -13334,19 +13334,19 @@ Invocation :  qucsedit [-r] fichier
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Ligne de commande incorrecte !
+        <translation>Ligne de commande incorrecte
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Un seul nom de fichier possible !
+        <translation>Un seul nom de fichier possible
 
 </translation>
     </message>
@@ -13896,9 +13896,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Certaines modifications sont non sauvegardées !
+        <translation>Certaines modifications sont non sauvegardées
 </translation>
     </message>
     <message>
@@ -14205,9 +14205,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation> » existe déjà !
+        <translation> » existe déjà
 </translation>
     </message>
     <message>
@@ -16556,9 +16556,9 @@ Un petit éditeur sans prétention pour Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Le texte contient des modifications non sauvegardées !
+        <translation>Le texte contient des modifications non sauvegardées
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_he.ts
+++ b/qucs/translations/qucs_he.ts
@@ -5767,7 +5767,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12793,7 +12793,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13311,27 +13311,27 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Too long command line argument!
+        <translation>Too long command line argument
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Wrong command line argument!
+        <translation>Wrong command line argument
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Only one filename allowed!
+        <translation>Only one filename allowed
 
 </translation>
     </message>
@@ -13881,7 +13881,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation>המסמך מכיל שינויים שלא נשמרו!</translation>
     </message>
@@ -14189,7 +14189,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>&apos; כבר קיים!</translation>
     </message>
@@ -16282,7 +16282,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation>הטקסט מכיל שינויים שלא נשמרו!</translation>
     </message>

--- a/qucs/translations/qucs_hu.ts
+++ b/qucs/translations/qucs_hu.ts
@@ -1950,7 +1950,7 @@ fizikai tulajdonságait számítja ki.</translation>
     <message>
         <location line="+1"/>
         <source>Output file already exists!</source>
-        <translation>A kimeneti fájl már létezik!
+        <translation>A kimeneti fájl már létezik
 </translation>
     </message>
     <message>
@@ -3109,7 +3109,7 @@ Resistor color code computation program
     <message>
         <location line="-50"/>
         <source>Output file already exists!</source>
-        <translation>A kimeneti fájl már létezik!
+        <translation>A kimeneti fájl már létezik
 </translation>
     </message>
     <message>
@@ -5775,7 +5775,7 @@ Helytelen sor kezdés!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12803,7 +12803,7 @@ Digitális szimuláció</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13324,28 +13324,28 @@ Használat:  qucsedit [-r] fájl
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Túl hosszú parancssori argomentum!
+        <translation>Túl hosszú parancssori argomentum
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Helytelen parancssori argomentum!
+        <translation>Helytelen parancssori argomentum
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Csak egy fájlnév megengedett!
+        <translation>Csak egy fájlnév megengedett
 
 </translation>
     </message>
@@ -13895,9 +13895,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>A dokumentum tartalmaz mentetlen változásokat!
+        <translation>A dokumentum tartalmaz mentetlen változásokat
 
 </translation>
     </message>
@@ -14206,9 +14206,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; fájl már létezik!
+        <translation>&apos; fájl már létezik
 </translation>
     </message>
     <message>
@@ -14460,7 +14460,7 @@ Felülírjam?</translation>
     <message>
         <location line="+13"/>
         <source>Output file already exists!</source>
-        <translation>A kimeneti fájl már létezik!
+        <translation>A kimeneti fájl már létezik
 </translation>
     </message>
     <message>
@@ -16560,9 +16560,9 @@ Egyszerü szövegszerkesztő a Qucs-hoz
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>A szöveg tartalmaz mentetlen változásokat!
+        <translation>A szöveg tartalmaz mentetlen változásokat
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_it.ts
+++ b/qucs/translations/qucs_it.ts
@@ -5774,7 +5774,7 @@ Inizio linea errato!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12801,9 +12801,9 @@ Formato della linea &apos;component&apos; errato!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>ERRORE: Impossibile creare la sottodirectory per la libreria utente!
+        <translation>ERRORE: Impossibile creare la sottodirectory per la libreria utente
 </translation>
     </message>
     <message>
@@ -13322,28 +13322,28 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Parametro linea di comando troppo lungo!
+        <translation>Parametro linea di comando troppo lungo
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Parametro linea di comando errato!
+        <translation>Parametro linea di comando errato
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Ammesso un solo nome di file!
+        <translation>Ammesso un solo nome di file
 
 </translation>
     </message>
@@ -13894,9 +13894,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Il documento contiene modifiche non salvate!
+        <translation>Il documento contiene modifiche non salvate
 </translation>
     </message>
     <message>
@@ -14203,7 +14203,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>&apos; esiste gi�
 </translation>
@@ -16557,9 +16557,9 @@ Editor di testo minimale per Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Il testo contiene cambiamenti non salvati!
+        <translation>Il testo contiene cambiamenti non salvati
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_ja.ts
+++ b/qucs/translations/qucs_ja.ts
@@ -5767,7 +5767,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12793,7 +12793,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation>エラー;　ユーザライブラリサブディレクトリを作成できません!</translation>
     </message>
@@ -13307,21 +13307,21 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation>コマンドラインの引数が長すぎます!</translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation>コマンドラインの引数が不正です!</translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
         <translation>一つのファイルネームのみ許可されています!</translation>
@@ -13872,7 +13872,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation>ドキュメントに保存されていない変更があります!</translation>
     </message>
@@ -14180,7 +14180,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>&apos; は既に存在しています!</translation>
     </message>
@@ -16441,7 +16441,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation>セーブされていないテキストが含まれています!</translation>
     </message>

--- a/qucs/translations/qucs_kk.ts
+++ b/qucs/translations/qucs_kk.ts
@@ -5767,7 +5767,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12793,7 +12793,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation>ҚАТЕ:Тұтынушыға арналған папка құрылған жоқ!</translation>
     </message>
@@ -13310,28 +13310,28 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Басқару жолының аргументі өте ұзын!
+        <translation>Басқару жолының аргументі өте ұзын
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Басқару жолының аргументі дұрыс емес!
+        <translation>Басқару жолының аргументі дұрыс емес
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Тек қана бір файлдың аты рұқсат етіледі!
+        <translation>Тек қана бір файлдың аты рұқсат етіледі
 
 </translation>
     </message>
@@ -13881,9 +13881,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Құжатта сақталмаған өзгертулер бар!
+        <translation>Құжатта сақталмаған өзгертулер бар
 </translation>
     </message>
     <message>
@@ -14190,9 +14190,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; әлбетте бар !
+        <translation>&apos; әлбетте бар
 </translation>
     </message>
     <message>
@@ -16550,7 +16550,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation>Мәтін құрамында сақталмаған өзгерістер бар!</translation>
     </message>

--- a/qucs/translations/qucs_pl.ts
+++ b/qucs/translations/qucs_pl.ts
@@ -1650,7 +1650,7 @@ Program syntezy filtrów
     <message>
         <location filename="../qucs-filter/helpdialog.cpp" line="-29"/>
         <source>QucsFilter is a filter synthesis program. To create a filter, simply enter all parameters and press the big button at the bottom of the main window. Immediatly, the schematic of the filter is calculated and put into the clipboard. Now go to Qucs, open an empty schematic and press CTRL-V (paste from clipboard). The filter schematic can now be inserted and  simulated. Have lots of fun!</source>
-        <translation>QucsFilter jest programem służącym do syntezy filtrów. Aby zaprojektować filtr, wprowadź po prostu wszystkie parametry i wciśnij duży przycisk znajdujący na dole głównego okienka. Schemat filtra zostanie wtedy wygenerowany i zapamiętany w schowku. Następnie otwórz pusty plik schematu w programie Qucs i wciśnij CTRL-V (wklej ze schowka). Schemat filtra zostanie w ten sposób wstawiony i   może być zasymulowany. Miłej zabawy!
+        <translation>QucsFilter jest programem służącym do syntezy filtrów. Aby zaprojektować filtr, wprowadź po prostu wszystkie parametry i wciśnij duży przycisk znajdujący na dole głównego okienka. Schemat filtra zostanie wtedy wygenerowany i zapamiętany w schowku. Następnie otwórz pusty plik schematu w programie Qucs i wciśnij CTRL-V (wklej ze schowka). Schemat filtra zostanie w ten sposób wstawiony i   może być zasymulowany. Miłej zabawy
  </translation>
     </message>
     <message>
@@ -5771,7 +5771,7 @@ Błędny początek linii!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12799,9 +12799,9 @@ Błędny format lini &apos;component&apos;!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>BŁĄD: Nie można stworzyć podkatalogu z biblioteką użytkownika!
+        <translation>BŁĄD: Nie można stworzyć podkatalogu z biblioteką użytkownika
 </translation>
     </message>
     <message>
@@ -13322,28 +13322,28 @@ Stosowanie:  qucsedit [-r] plik
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Za długi argument komendy!
+        <translation>Za długi argument komendy
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Zły argument komendy!
+        <translation>Zły argument komendy
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Tylko jedna naywa pliku dozwolona!
+        <translation>Tylko jedna naywa pliku dozwolona
 
 </translation>
     </message>
@@ -13893,9 +13893,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Dokument zawiera niezapisane zmiany!
+        <translation>Dokument zawiera niezapisane zmiany
 </translation>
     </message>
     <message>
@@ -14202,9 +14202,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; już istnieje!
+        <translation>&apos; już istnieje
 </translation>
     </message>
     <message>
@@ -16558,9 +16558,9 @@ Bardzo prosty edytor tekstowy programu Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Tekst zawiera niezapisane zmiany!
+        <translation>Tekst zawiera niezapisane zmiany
 
 </translation>
     </message>

--- a/qucs/translations/qucs_pt_BR.ts
+++ b/qucs/translations/qucs_pt_BR.ts
@@ -5782,12 +5782,12 @@ Linha inicial errada!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
         <translation>Erro de formato: 
-Componente desconhecido!
+Componente desconhecido
 %1 
 Você utiliza componentes carregáveis dinamicamente?</translation>
     </message>
@@ -12811,7 +12811,7 @@ Formato da linha &apos;componente&apos; errado!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation>ERRO: Não é possivel criar o subdiretório para biblioteca do usuário!</translation>
     </message>
@@ -13164,7 +13164,7 @@ Campo &apos;diagrama&apos; não está fechado!</translation>
         <source>Format Error:
 Wrong &apos;painting&apos; line delimiter!</source>
         <translation>Erro de formato:
-Delimitador linha &apos;descrição&apos; errado!
+Delimitador linha &apos;descrição&apos; errado
 </translation>
     </message>
     <message>
@@ -13331,21 +13331,21 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
         <translation type="unfinished"></translation>
@@ -13898,7 +13898,7 @@ Programa de síntese de filtro ativo
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation>Este documento contém modificações a salvar!</translation>
     </message>
@@ -14206,9 +14206,9 @@ Programa de síntese de filtro ativo
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; já existe!
+        <translation>&apos; já existe
 </translation>
     </message>
     <message>
@@ -14414,7 +14414,7 @@ Programa de síntese de filtro ativo
         <location line="+1"/>
         <source>File &quot;%1&quot; already exists.
 Overwrite ?</source>
-        <translation>Arquivo &quot;%1&quot; já existe!
+        <translation>Arquivo &quot;%1&quot; já existe
 Sobrescrever?</translation>
     </message>
     <message>
@@ -16580,7 +16580,7 @@ Editor muito simples para Qucs</translation>
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation>O texto contém modificações a salvar!</translation>
     </message>

--- a/qucs/translations/qucs_pt_PT.ts
+++ b/qucs/translations/qucs_pt_PT.ts
@@ -5777,7 +5777,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12803,7 +12803,7 @@ Externo</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13317,21 +13317,21 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
         <translation type="unfinished"></translation>
@@ -13883,7 +13883,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation>O documento contém alterações por guardar!</translation>
     </message>
@@ -14191,7 +14191,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>&apos; já existe!</translation>
     </message>
@@ -16458,7 +16458,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>

--- a/qucs/translations/qucs_ro.ts
+++ b/qucs/translations/qucs_ro.ts
@@ -5766,7 +5766,7 @@ Linie de start greşită!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12792,7 +12792,7 @@ Fals format de linie a &apos;component&apos;!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13312,28 +13312,28 @@ Folosire:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Argument de linie prea lung!
+        <translation>Argument de linie prea lung
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Argument greşit de linie de comandă!
+        <translation>Argument greşit de linie de comandă
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Doar un nume de fişier acceptat!
+        <translation>Doar un nume de fişier acceptat
 
 </translation>
     </message>
@@ -13883,9 +13883,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Documentul conţine modificări nesalvate!
+        <translation>Documentul conţine modificări nesalvate
 </translation>
     </message>
     <message>
@@ -14192,9 +14192,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; exisă deja!
+        <translation>&apos; exisă deja
 </translation>
     </message>
     <message>
@@ -16287,9 +16287,9 @@ Editor de text foarte simplu pentur Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Documentul conţine modificări nesalvate!
+        <translation>Documentul conţine modificări nesalvate
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_ru.ts
+++ b/qucs/translations/qucs_ru.ts
@@ -5787,12 +5787,12 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
         <translation>Ошибка формата:
-Неизвестный компонент!
+Неизвестный компонент
 %1
 
 Вы пытаетесь использовать загружаемые компоненты?</translation>
@@ -12818,9 +12818,9 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>ОШИБКА: Не удаётся создать подкаталог для библиотек пользователя!
+        <translation>ОШИБКА: Не удаётся создать подкаталог для библиотек пользователя
 </translation>
     </message>
     <message>
@@ -13345,7 +13345,7 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation>Слишком много аргументов в командной строке
@@ -13354,19 +13354,19 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Неверный аргумент командной строки!
+        <translation>Неверный аргумент командной строки
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Разрешается только одно имя файла!
+        <translation>Разрешается только одно имя файла
 
 </translation>
     </message>
@@ -13922,9 +13922,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>В документе есть несохранённые изменения!
+        <translation>В документе есть несохранённые изменения
 </translation>
     </message>
     <message>
@@ -14231,9 +14231,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; уже существует!
+        <translation>&apos; уже существует
 </translation>
     </message>
     <message>
@@ -16641,9 +16641,9 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>В тексте есть несохранённые изменения!
+        <translation>В тексте есть несохранённые изменения
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_sv.ts
+++ b/qucs/translations/qucs_sv.ts
@@ -5774,7 +5774,7 @@ Felaktig början på rad!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12801,7 +12801,7 @@ Felaktigt komponentsradsformat!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13320,26 +13320,26 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>För långt argument på kommandoraden!
+        <translation>För långt argument på kommandoraden
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation>Felaktigt kommandoradsargument!</translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Enast ett filnamn tillåtet!
+        <translation>Enast ett filnamn tillåtet
 </translation>
     </message>
     <message>
@@ -13888,9 +13888,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Dokumentet innehåller osparade ändringr!
+        <translation>Dokumentet innehåller osparade ändringr
 </translation>
     </message>
     <message>
@@ -14197,9 +14197,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; finns redan!
+        <translation>&apos; finns redan
 </translation>
     </message>
     <message>
@@ -16509,9 +16509,9 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Texten innehåller osparade ändringar!
+        <translation>Texten innehåller osparade ändringar
 
 </translation>
     </message>

--- a/qucs/translations/qucs_tr.ts
+++ b/qucs/translations/qucs_tr.ts
@@ -5770,7 +5770,7 @@ Yanlış satır başlangıcı!</translation>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12798,9 +12798,9 @@ Yanlış &quot;bileşen-component&quot; satır biçimi!</translation>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>HATA: Kullanıcı kütüphanesi alt-dizini oluşturulamıyor !
+        <translation>HATA: Kullanıcı kütüphanesi alt-dizini oluşturulamıyor
 </translation>
     </message>
     <message>
@@ -13321,28 +13321,28 @@ Kullanım:  qucsedit [-r] kütük
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>Komut satırı çok uzun!
+        <translation>Komut satırı çok uzun
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Yanlış komut satırı anahtarı!
+        <translation>Yanlış komut satırı anahtarı
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Sadece bir kütük ismi izinli!
+        <translation>Sadece bir kütük ismi izinli
 
 </translation>
     </message>
@@ -13892,9 +13892,9 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
-        <translation>Belge kaydedilmemiş değişiklikler içeriyor!
+        <translation>Belge kaydedilmemiş değişiklikler içeriyor
 </translation>
     </message>
     <message>
@@ -14201,9 +14201,9 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
-        <translation>&apos; zaten mevcut!
+        <translation>&apos; zaten mevcut
 </translation>
     </message>
     <message>
@@ -16557,9 +16557,9 @@ Qucs için çok basit bit metin düzenleyici
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
-        <translation>Metin, kaydedilmemiş değişiklikler içeriyor!
+        <translation>Metin, kaydedilmemiş değişiklikler içeriyor
 </translation>
     </message>
     <message>

--- a/qucs/translations/qucs_uk.ts
+++ b/qucs/translations/qucs_uk.ts
@@ -5770,7 +5770,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12797,9 +12797,9 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
-        <translation>ПОМИЛКА: Неможливо створити папку для користувацьких бібліотек !
+        <translation>ПОМИЛКА: Неможливо створити папку для користувацьких бібліотек
 </translation>
     </message>
     <message>
@@ -13320,28 +13320,28 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
-        <translation>За довгий аргумент командного рядку!
+        <translation>За довгий аргумент командного рядку
 
 </translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
-        <translation>Невірний аргумент командного рядку!
+        <translation>Невірний аргумент командного рядку
 
 </translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
-        <translation>Можна тільки одну назву файлу!
+        <translation>Можна тільки одну назву файлу
 
 </translation>
     </message>
@@ -13891,7 +13891,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation>У документі є незбережені зміни! 
 </translation>
@@ -14200,7 +14200,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation>&apos; вже існує! 
 </translation>
@@ -16556,7 +16556,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation>У тексті є незбережені зміни! 
 </translation>

--- a/qucs/translations/qucs_zh_CN.ts
+++ b/qucs/translations/qucs_zh_CN.ts
@@ -5776,7 +5776,7 @@ Wrong line start!</source>
     <message>
         <location line="+20"/>
         <source>Format Error:
-Unknown component!
+Unknown component
 %1
 
 Do you make use of loadable components?</source>
@@ -12801,7 +12801,7 @@ Wrong &apos;component&apos; line format!</source>
     </message>
     <message>
         <location line="+13"/>
-        <source>ERROR: Cannot create user library subdirectory !
+        <source>ERROR: Cannot create user library subdirectory
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -13299,21 +13299,21 @@ Usage:  qucsedit [-r] file
     </message>
     <message>
         <location line="+48"/>
-        <source>Too long command line argument!
+        <source>Too long command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+10"/>
-        <source>Wrong command line argument!
+        <source>Wrong command line argument
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+7"/>
-        <source>Only one filename allowed!
+        <source>Only one filename allowed
 
 </source>
         <translation type="unfinished"></translation>
@@ -13864,7 +13864,7 @@ Active Filter synthesis program
     <message>
         <location line="+1"/>
         <location line="+676"/>
-        <source>The document contains unsaved changes!
+        <source>The document contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -14172,7 +14172,7 @@ Active Filter synthesis program
     </message>
     <message>
         <location line="+0"/>
-        <source>&apos; already exists!
+        <source>&apos; already exists
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16262,7 +16262,7 @@ Very simple text editor for Qucs
     </message>
     <message>
         <location line="+1"/>
-        <source>The text contains unsaved changes!
+        <source>The text contains unsaved changes
 </source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
scanning through https://en.wikipedia.org/wiki/Exclamation_mark, i cannot find a compelling reason why to remove exclamation marks. but there's some evidence. make up your own opinion...

this commit was a quick `sed -i`, but it looks correct at first glance. note that it removes the punctuation independent of the language.
