### PR TITLE
Update Perl modules installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,10 @@ For ADMS
     sudo apt-get install zlib1g zlib1g-dev
     sudo apt-get install libgd2-xpm-dev
 
-Install Perl modules for ADMS. Configure cpan, no waiting for user input.
+Install Perl modules for ADMS:
 
-    (echo y;echo o conf prerequisites_policy follow;echo o conf commit)| sudo cpan
-    sudo cpan -i XML::LibXML
-    sudo cpan -f GD
+    sudo apt-get install libxml-libxml-perl
+    sudo apt-get install libgd-perl
 
 Compile qucs:
 


### PR DESCRIPTION
For Debian/Ubuntu, a preferred way to install these Perl modules is to use ones from the package repository. (in my case CPAN installed modules are not detected during configure on Ubuntu 15.04).