### PR TITLE
qucslib: Searchboxes fix crash

### DIFF
--- a/qucs/qucs-lib/qucslib.cpp
+++ b/qucs/qucs-lib/qucslib.cpp
@@ -233,6 +233,7 @@ void QucsLib::slotQuit()
     tmp = y();		// ... set them correctly before closing the ...
     tmp = width();	// dialog !!!  Otherwise the frame of the window ...
     tmp = height();	// will not be recognized (a X11 problem).
+    Q_UNUSED(tmp);
 
     qApp->quit();
 }
@@ -245,6 +246,7 @@ void QucsLib::closeEvent(QCloseEvent *Event)
     tmp = y();		// ... set them correctly before closing the ...
     tmp = width();	// dialog !!!  Otherwise the frame of the window ...
     tmp = height();	// will not be recognized (a X11 problem).
+    Q_UNUSED(tmp);
 
     Event->accept();
 }

--- a/qucs/qucs-lib/qucslib.cpp
+++ b/qucs/qucs-lib/qucslib.cpp
@@ -61,11 +61,11 @@ QucsLib::QucsLib()
 
     QAction * manageLib =new QAction (tr("Manage User &Libraries..."), this);
     manageLib->setShortcut(Qt::CTRL+Qt::Key_M);
-    connect(manageLib, SIGNAL(activated()), SLOT(slotManageLib()));
+    connect(manageLib, SIGNAL(triggered()), SLOT(slotManageLib()));
 
     QAction * fileQuit = new QAction(tr("&Quit"), this);
     fileQuit->setShortcut(Qt::CTRL+Qt::Key_Q);
-    connect(fileQuit, SIGNAL(activated()), SLOT(slotQuit()));
+    connect(fileQuit, SIGNAL(triggered()), SLOT(slotQuit()));
 
     fileMenu->addAction(manageLib);
     fileMenu->addSeparator();
@@ -78,11 +78,11 @@ QucsLib::QucsLib()
     QAction * helpHelp = new QAction(tr("&Help"), this);
     helpHelp->setShortcut(Qt::Key_F1);
     helpMenu->addAction(helpHelp);
-    connect(helpHelp, SIGNAL(activated()), SLOT(slotHelp()));
+    connect(helpHelp, SIGNAL(triggered()), SLOT(slotHelp()));
 
     QAction * helpAbout = new QAction(tr("About"), this);
     helpMenu->addAction(helpAbout);
-    connect(helpAbout, SIGNAL(activated()), SLOT(slotAbout()));
+    connect(helpAbout, SIGNAL(triggered()), SLOT(slotAbout()));
 
     // use Escape key to clear search
     QAction *escape = new QAction(this);

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -44,6 +44,12 @@ SymbolWidget::SymbolWidget(QWidget *parent) : QWidget(parent)
 {
 
   Text_x = Text_y = 0;
+  cx = 0;
+  cy = 0;
+  x1 = 0;
+  x2 = 0;
+  y1 = 0;
+  y2 = 0;
   PaintText = tr("Symbol:");
   QFontMetrics  metrics(QucsSettings.font, 0); // use the the screen-compatible metric
   TextWidth = metrics.width(PaintText) + 4;    // get size of text

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -105,6 +105,9 @@ void SymbolWidget::paintEvent(QPaintEvent*)
   QPainter Painter(this);
   Painter.drawText(2, 2, 0, 0, Qt::AlignLeft | Qt::TextDontClip, PaintText);
 
+  QFontMetrics metrics(QucsSettings.font, 0);
+  Painter.drawText(2, metrics.height(), 0, 0, Qt::AlignLeft | Qt::TextDontClip, Warning);
+
   int dx = (x2-x1)/2 + TextWidth - DragNDropWidth/2;
   if(dx < 2)  dx = 2;
   Painter.drawText(dx, y2-y1+2, 0, 0, Qt::AlignLeft | Qt::TextDontClip, DragNDropText);
@@ -167,6 +170,8 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
   Texts.clear();
   LibraryName = Lib_;
   ComponentName = Comp_;
+
+  Warning.clear();
 
   int PortNo = 0;
   QString Comp = ModelString.section(' ', 0,0);
@@ -383,6 +388,13 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
     PortNo = 0;
     x1 = -34; y1 =-44;
     x2 =  84; y2 = 20;
+  }
+  else {
+    // Warn in case a default component symbol is not
+    // mapped or implemented.
+    Warning = tr("Warning: Symbol '%1' missing in Qucs Library.\n"
+                 "Drag and Drop may still work.\n"
+                 "Please contact the developers.").arg(Comp);
   }
 
   x1 -= 4;   // enlarge component boundings a little

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -296,6 +296,7 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
   else if(Comp == "hicumL2V2p1" || Comp == "hic2_full" ||
 	  Comp == "hic0_full" || Comp == "hicumL0V1p2" ||
 	  Comp == "hicumL2V2p23" || Comp == "hicumL2V2p24" ||
+      Comp == "hicumL2V2p31n" ||
 	  Comp == "hicumL0V1p2g" || Comp == "hicumL0V1p3") {
     // normal bipolar
     Lines.append(new Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -64,7 +64,9 @@ private:
   bool getPen  (const QString&, QPen&, int);
   bool getBrush(const QString&, QBrush&, int);
 
-  QString PaintText, DragNDropText;
+  QString PaintText;
+  QString DragNDropText;
+  QString Warning;
   int TextWidth, DragNDropWidth, TextHeight;
   int cx, cy, x1, x2, y1, y2;
   QList<Line *> Lines;

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -38,43 +38,6 @@
 class QPaintEvent;
 class QSizePolicy;
 
-
-//struct Line {
-//  Line(int _x1, int _y1, int _x2, int _y2, QPen _style)
-//       : x1(_x1), y1(_y1), x2(_x2), y2(_y2), style(_style) {};
-//  int   x1, y1, x2, y2;
-//  QPen  style;
-//};
-//
-//struct Arc {
-//  Arc(int _x, int _y, int _w, int _h, int _angle, int _arclen, QPen _style)
-//      : x(_x), y(_y), w(_w), h(_h), angle(_angle),
-//	arclen(_arclen), style(_style) {};
-//  int   x, y, w, h, angle, arclen;
-//  QPen  style;
-//};
-//
-//struct Area {
-//  Area(int _x, int _y, int _w, int _h, QPen _Pen,
-//	QBrush _Brush = QBrush(Qt::NoBrush))
-//	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
-//  int    x, y, w, h;
-//  QPen   Pen;
-//  QBrush Brush;    // filling style/color
-//};
-//
-//struct Text {
-//  Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
-//	float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
-//	: x(_x), y(_y), s(_s), Color(_Color), Size(_Size) {};
-//  int     x, y;
-//  QString s;
-//  QColor  Color;
-//  float   Size;
-//};
-
-
-
 class SymbolWidget : public QWidget  {
    Q_OBJECT
 public:
@@ -101,8 +64,6 @@ private:
   bool getPen  (const QString&, QPen&, int);
   bool getBrush(const QString&, QBrush&, int);
 
-  //Q3DragObject *myDragObject;
-
   QString PaintText, DragNDropText;
   int TextWidth, DragNDropWidth, TextHeight;
   int cx, cy, x1, x2, y1, y2;
@@ -110,10 +71,6 @@ private:
   QList<Arc *> Arcs;
   QList<Area *> Rects, Ellips;
   QList<Text *>  Texts;
-  //Q3PtrList<Line>       Lines;
-  //Q3PtrList<struct Arc> Arcs;
-  //Q3PtrList<Area>       Rects, Ellips;
-  //Q3PtrList<Text>       Texts;
 };
 
 #endif // SYMBOLWIDGET_H


### PR DESCRIPTION
Fix Qucs-lib crash while testing #303.
Because the component (symbol for) `hicumL2V2p31n` was not found, variables ended up uninitialized.
The variables were used to reside the window according to he symbol size. When uninitialized it could could be resized to random values, eventually crashing the application (fail assert in Qt). 
This patch attempts to make it more robust and inform the user about missing default symbols.

TODO: registering each component again on qucs-lib (and copying the default symbol) seems redundant.