### PR TITLE
Qucs: add missing variable in assignment.

### DIFF
--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -686,7 +686,7 @@ int main(int argc, char *argv[])
   QucsSettings.QucsWorkDir.setPath(QucsSettings.QucsHomeDir.canonicalPath());
 
   /// \todo Make the setting up of all executables below more consistent
-  getenv("QUCSATOR");
+  var = getenv("QUCSATOR");
   if(var != NULL) {
       QucsSettings.Qucsator = QString(var);
   }


### PR DESCRIPTION
The variable 'var' is used on the condition below. It may be forever
empty or polluted with contents of a previous assignment.

Trivial fix, [skip ci]