### PR TITLE
Fix for Issue 311

### DIFF
--- a/qucs/qucs/dialogs/newprojdialog.cpp
+++ b/qucs/qucs/dialogs/newprojdialog.cpp
@@ -3,6 +3,7 @@
                              -------------------
     begin                : Sun Aug 24 2003
     copyright            : (C) 2003 by Michael Margraf
+                           (C) 2016 Qucs Team
     email                : michael.margraf@alumni.tu-berlin.de
  ***************************************************************************/
 
@@ -35,6 +36,7 @@ NewProjDialog::NewProjDialog(QWidget *parent, const char *name)
 
   ProjName = new QLineEdit(this);
   ProjName->setMinimumWidth(250);
+  connect(ProjName, SIGNAL(textChanged(const QString&)), SLOT(slotTextChanged(const QString&)));
   gbox->addMultiCellWidget(ProjName,0,0,1,2);
   OpenProj = new QCheckBox(tr("open new project"));
   OpenProj->setChecked(true);
@@ -42,6 +44,7 @@ NewProjDialog::NewProjDialog(QWidget *parent, const char *name)
 
   ButtonOk = new QPushButton(tr("Create"));
   gbox->addWidget(ButtonOk,2,1);
+  ButtonOk->setEnabled(false);
   ButtonCancel = new QPushButton(tr("Cancel"));
   gbox->addWidget(ButtonCancel,2,2);
 
@@ -50,6 +53,15 @@ NewProjDialog::NewProjDialog(QWidget *parent, const char *name)
 
   ButtonOk->setDefault(true);
   setFocusProxy(ProjName);
+}
+
+void NewProjDialog::slotTextChanged(const QString &text){
+  /* avoid creating project with empty name */
+  if (text.isEmpty()) {
+    ButtonOk->setEnabled(false);
+  } else {
+    ButtonOk->setEnabled(true);
+  }
 }
 
 NewProjDialog::~NewProjDialog()

--- a/qucs/qucs/dialogs/newprojdialog.cpp
+++ b/qucs/qucs/dialogs/newprojdialog.cpp
@@ -25,8 +25,8 @@
 #include <QGridLayout>
 
 
-NewProjDialog::NewProjDialog(QWidget *parent, const char *name)
-                             : QDialog(parent, name, true)
+NewProjDialog::NewProjDialog(QWidget *parent)
+  : QDialog(parent)
 {
   setWindowTitle(tr("Create new project"));
 
@@ -37,10 +37,10 @@ NewProjDialog::NewProjDialog(QWidget *parent, const char *name)
   ProjName = new QLineEdit(this);
   ProjName->setMinimumWidth(250);
   connect(ProjName, SIGNAL(textChanged(const QString&)), SLOT(slotTextChanged(const QString&)));
-  gbox->addMultiCellWidget(ProjName,0,0,1,2);
+  gbox->addWidget(ProjName, 0, 1, 1, 2);
   OpenProj = new QCheckBox(tr("open new project"));
   OpenProj->setChecked(true);
-  gbox->addMultiCellWidget(OpenProj,1,1,1,2);
+  gbox->addWidget(OpenProj, 1, 1, 1, 2);
 
   ButtonOk = new QPushButton(tr("Create"));
   gbox->addWidget(ButtonOk,2,1);

--- a/qucs/qucs/dialogs/newprojdialog.h
+++ b/qucs/qucs/dialogs/newprojdialog.h
@@ -39,6 +39,9 @@ public:
   QLineEdit   *ProjName;
   QCheckBox   *OpenProj;
 
+private slots:
+  void slotTextChanged(const QString &);
+
 private:
   QPushButton *ButtonOk, *ButtonCancel;
   QGridLayout *gbox;

--- a/qucs/qucs/dialogs/newprojdialog.h
+++ b/qucs/qucs/dialogs/newprojdialog.h
@@ -33,7 +33,7 @@ class QGridLayout;
 class NewProjDialog : public QDialog  {
   Q_OBJECT
 public:
-	NewProjDialog(QWidget *parent=0, const char *name=0);
+	NewProjDialog(QWidget *parent=0);
 	~NewProjDialog();
 
   QLineEdit   *ProjName;


### PR DESCRIPTION
This fixes #311 .
The "Create" button of the "New Project" dialog is now disabled if the name is empty.