### PR TITLE
Fixed not uppdating of the recent files list when SaveAs is invoked

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1560,13 +1560,13 @@ bool QucsApp::saveAs()
   Doc->setName(s);
   DocumentTab->setTabText(DocumentTab->indexOf(w), misc::properFileName(s));
   lastDirOpenSave = Info.absolutePath();  // remember last directory and file
-  updateRecentFilesList(s);
 
   n = Doc->save();   // SAVE
   if(n < 0)  return false;
 
   updatePortNumber(Doc, n);
   slotUpdateTreeview();
+  updateRecentFilesList(s);
   return true;
 }
 


### PR DESCRIPTION
This fixes the following bug. Steps to reproduce:

1. Open schematic file
2. Click SaveAs, select new file name, click Save.
3. Look Open recent files menu. There is no saved file in it.