### PR TITLE
Help button on the Edit Component Properties dialog

### DIFF
--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -15,6 +15,10 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
 #include "componentdialog.h"
 #include "qucs.h"
 #include "schematic.h"
@@ -33,6 +37,8 @@
 #include <QComboBox>
 #include <QGroupBox>
 #include <QPushButton>
+#include <QUrl>
+#include <QDesktopServices>
 #include <QEvent>
 #include <QKeyEvent>
 #include <QDebug>
@@ -403,12 +409,17 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
   hbox2->setLayout(h2);
   h2->setSpacing(5);
   all->addWidget(hbox2);
+  QPushButton *help = new QPushButton(tr("Help"));
   QPushButton *ok = new QPushButton(tr("OK"));
   QPushButton *apply = new QPushButton(tr("Apply"));
   QPushButton *cancel = new QPushButton(tr("Cancel"));
-  h2->addWidget(ok);
-  h2->addWidget(apply);
-  h2->addWidget(cancel);
+  // set stretch factors to limit the space taken by the added stretch
+  h2->addWidget(help, 1);
+  h2->addStretch(1);
+  h2->addWidget(ok, 1);
+  h2->addWidget(apply, 1);
+  h2->addWidget(cancel, 1);
+  connect(help,   SIGNAL(clicked()), SLOT(slotButtHelp()));
   connect(ok,     SIGNAL(clicked()), SLOT(slotButtOK()));
   connect(apply,  SIGNAL(clicked()), SLOT(slotApplyInput()));
   connect(cancel, SIGNAL(clicked()), SLOT(slotButtCancel()));
@@ -1054,6 +1065,19 @@ void ComponentDialog::slotApplyInput()
     }
   }
 
+}
+
+// -------------------------------------------------------------------------
+// Is called if the "Help"-button is pressed.
+void ComponentDialog::slotButtHelp()
+{
+  QString linkName = QString(Comp->Model);
+
+  qDebug() << "HELP : model = " << linkName;
+  // for local testing use something like
+  // QDesktopServices::openUrl(QUrl::fromLocalFile("<base dir>/qucs-manual/build/html/component_reference.html").toString() + "#" + linkName.toLower());
+
+  QDesktopServices::openUrl(QUrl("http://qucs.github.io/qucs-manual/" PACKAGE_VERSION "/html-en/component_reference.html#" + linkName.toLower(), QUrl::TolerantMode));
 }
 
 // -------------------------------------------------------------------------

--- a/qucs/qucs/components/componentdialog.h
+++ b/qucs/qucs/components/componentdialog.h
@@ -47,6 +47,7 @@ public:
 private slots:
   void slotButtOK();
   void slotButtCancel();
+  void slotButtHelp();
   void slotSelectProperty(QTableWidgetItem *item);
   void slotApplyInput();
   void slotApplyState(int State);


### PR DESCRIPTION
A simple idea to allow opening the online [Qucs Reference Manual](http://qucs.github.io/qucs-manual/0.0.19/html-en/index.html) (QRM) directly on the component description, when the Edit Component Properties dialog is open.
As an example, when the properties of a DIAC are being edited and the Help button is pressed

![qucscompshelp](https://cloud.githubusercontent.com/assets/9018179/12859958/b975deb2-cc59-11e5-9737-1e7a816e5e41.png)

this will (try to) open the page http://qucs.github.io/qucs-manual/0.0.19/html-en/component_reference.html#compdiac

~At present this is **not working** since the web links are not right and some "details" need to be worked out:~
**Edit:** it works now, see latest comments.
- the current component links in the QRM are not directly linked to the component model or graphic, but are a simple counter of the component index
- at present the QRM contains a section for every component symbol, but we should probably have a section for every component model. E.g. we have a `resistor` and a `resistor_US`, which have different symbols but the same model. Same for `n-JFET` and `p-JFET` and several others.

Of course many improvements are possible, like
- linking the `F1` to the component help, even maybe when the component is just selected on the schematic
- point to the local copy of the QRM (which is not currently installed AFAIK)
- ...
