### PR TITLE
qucs-rescodes update

### DIFF
--- a/qucs/qucs-rescodes/main.cpp
+++ b/qucs/qucs-rescodes/main.cpp
@@ -4,6 +4,8 @@
     begin                : Mar 2012
     copyright            : (C) 2012 by Sudhakar.M.K
     email                : sudhakar.m.kumar@gmail.com
+    copyright            : (C) 2016, Qucs team (see AUTHORS file)
+
  ***************************************************************************/
 
 /***************************************************************************
@@ -25,8 +27,6 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
-#ifndef QUCS_RESCODES_MAIN_CPP
-#define QUCS_RESCODES_MAIN_CPP
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QGridLayout>
@@ -44,19 +44,17 @@
 #include <string>
 //------------------------class member declarations for MyWidget---------------------------------//
 
-MyWidget::MyWidget( QWidget *parent, const char *name )
-: QWidget( parent/*, name */)
+/* setup the GUI */
+MyWidget::MyWidget()
 {
-  Q_UNUSED(name);
-
-	setWindowTitle("Color Codes");
+  setWindowTitle("Qucs Resistor Color Code " PACKAGE_VERSION);
 
   // icons are handled differently on OSX
 #ifndef __APPLE__
   setWindowIcon(QPixmap(":/bitmaps/big.qucs.xpm"));
 #endif
 
-	 // --------  create menubar  -------------------
+  // --------  create menubar  -------------------
   QAction *fileExit = new QAction(tr("E&xit"), this);
   fileExit->setShortcut(Qt::CTRL+Qt::Key_Q);
   connect(fileExit, SIGNAL(activated()), qApp, SLOT(quit()));
@@ -80,10 +78,9 @@ MyWidget::MyWidget( QWidget *parent, const char *name )
   helpMenu->addSeparator();
   helpMenu->addAction(aboutQt);
 
-  QMenuBar *menuBar = new QMenuBar(this);
-	menuBar->addMenu(fileMenu);
-	menuBar->addSeparator();
-	menuBar->addMenu(helpMenu);
+  menuBar()->addMenu(fileMenu);
+  menuBar()->addSeparator();
+  menuBar()->addMenu(helpMenu);
 
 	res= new QResistor();
 	//--------------------resistance displayin ui ---------------------------------//
@@ -119,20 +116,20 @@ MyWidget::MyWidget( QWidget *parent, const char *name )
   buttonBox->addWidget(quit);
 
 	//--------------------packing all of them together---------------------------------------//
-  QGridLayout *grid = new QGridLayout(this);
-  grid->setMargin(10);
 
-#ifndef __APPLE__
-    QWidget *Space = new QWidget(this);   // reserve space for menubar
-    Space->setFixedSize(1, menuBar->height());
-    grid->addWidget(Space, 0,0);
-#endif
+  // main box
+  QWidget *main = new QWidget(this);
+  setCentralWidget(main);
+  QGridLayout *grid = new QGridLayout();
+  main->setLayout(grid);
+  grid->setSpacing (10);
+  grid->setMargin (10);
 
-	grid->addWidget( resBox, 1, 0 );
-	grid->addLayout( buttonBox, 2, 0 );
-	grid->addWidget( colorBox, 3, 0 );
-
+  grid->addWidget( resBox, 1, 0 );
+  grid->addLayout( buttonBox, 2, 0 );
+  grid->addWidget( colorBox, 3, 0 );
 }
+
 void MyWidget :: setResistanceValue()
 {
 	res->QResistorModify(resBox->enteredValue(),resBox->enteredTolerance());
@@ -198,4 +195,3 @@ int main( int argc, char **argv )
 	w.show();
 	return a.exec();
 }
-#endif

--- a/qucs/qucs-rescodes/mywidget.h
+++ b/qucs/qucs-rescodes/mywidget.h
@@ -1,10 +1,14 @@
-#include <QWidget>
+
+#ifndef MYWIDGET_H
+#define MYWIDGET_H
+
+#include <QMainWindow>
 class MyResistanceBox;
 class MyColorBox;
 class QResistor;
 
 //---------------------------class declarations------------------------------------//
-class MyWidget: public QWidget
+class MyWidget: public QMainWindow
 {
 	Q_OBJECT
 	QResistor *res;
@@ -12,7 +16,7 @@ class MyWidget: public QWidget
 	MyColorBox *colorBox;
 
 	public:
-		MyWidget( QWidget *parent=0, const char *name=0 );
+		MyWidget();
 	public slots:
 
 		void setResistanceValue();
@@ -24,5 +28,4 @@ class MyWidget: public QWidget
 	signals:
 };
 
-
-
+#endif /* MYWIDGET_H */

--- a/qucs/qucs-rescodes/mywidget.h
+++ b/qucs/qucs-rescodes/mywidget.h
@@ -7,6 +7,14 @@ class MyResistanceBox;
 class MyColorBox;
 class QResistor;
 
+// Application settings.
+struct tQucsSettings {
+  int x, y, dx, dy;    // position and size of main window
+  QFont font;          // font
+  QString LangDir;     // translation directory
+  QString Language;
+};
+
 //---------------------------class declarations------------------------------------//
 class MyWidget: public QMainWindow
 {

--- a/qucs/qucs-rescodes/mywidget.h
+++ b/qucs/qucs-rescodes/mywidget.h
@@ -1,3 +1,21 @@
+/***************************************************************************
+                               mywidget.h
+                             ------------------
+    begin                : Mar 2012
+    copyright            : (C) 2012 by Sudhakar.M.K
+    email                : sudhakar.m.kumar@gmail.com
+    copyright            : (C) 2016, Qucs team (see AUTHORS file)
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
 
 #ifndef MYWIDGET_H
 #define MYWIDGET_H


### PR DESCRIPTION
Quick update for the `qucs-rescodes` tool to use a standard `QMainWindow` and menubar and the global Qucs font and language settings.
Fixes #445 .

Note that I have added a missing copyright/license header to a file, as it seems to me that it was simply forgotten by the original author.

(This little tool needs some refactoring/polishing, will be another PR, maybe)