### PR TITLE
Fix for #467

### DIFF
--- a/qucs/qucs/mouseactions.cpp
+++ b/qucs/qucs/mouseactions.cpp
@@ -1935,6 +1935,8 @@ void MouseActions::editElement(Schematic *Doc, QMouseEvent *Event)
     case isHWireLabel:
     case isVWireLabel:
          editLabel(Doc, (WireLabel*)focusElement);
+         // update highlighting, labels may have changed
+         Doc->highlightWireLabels ();
          break;
 
     case isPainting:

--- a/qucs/qucs/schematic_element.cpp
+++ b/qucs/qucs/schematic_element.cpp
@@ -1343,7 +1343,7 @@ void Schematic::highlightWireLabels ()
                         // if only one wire has this label, do not highlight it
                         if (pltestinner != pltestouter)
                         {
-                            if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                            if (pltestouter->Name == pltestinner->Name)
                             {
                                 pltestinner->setHighlighted (true);
                                 hiLightOuter = true;
@@ -1360,7 +1360,7 @@ void Schematic::highlightWireLabels ()
                     pltestinner = pninner->Label; // test any label associated with the node
                     if (pltestinner)
                     {
-                        if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                        if (pltestouter->Name == pltestinner->Name)
                         {
                             // node label matches wire label
                             pltestinner->setHighlighted (true);
@@ -1397,7 +1397,7 @@ void Schematic::highlightWireLabels ()
                     pltestinner = pwinner->Label; // test any label associated with the wire
                     if (pltestinner)
                     {
-                        if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                        if (pltestouter->Name == pltestinner->Name)
                         {
                             // wire label matches node label
                             pltestinner->setHighlighted (true);
@@ -1418,7 +1418,7 @@ void Schematic::highlightWireLabels ()
                         // if only one node has this label, do not highlight it
                         if (pltestinner != pltestouter)
                         {
-                            if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                            if (pltestouter->Name == pltestinner->Name)
                             {
                                 pltestinner->setHighlighted (true);
                                 hiLightOuter = true;
@@ -1677,16 +1677,16 @@ void Schematic::newMovingWires(Q3PtrList<Element> *p, Node *pn, int pos)
         if(pw->Port1 != pn)
         {
             pw->Port1->State |= mask;
-            pw->Port1 = (Node*)mask;
+            pw->Port1 = (Node*)(uintptr_t)mask;
             pw->Port2->State |= invMask;
-            pw->Port2 = (Node*)invMask;  // move port 2 completely
+            pw->Port2 = (Node*)(uintptr_t)invMask;  // move port 2 completely
         }
         else
         {
             pw->Port1->State |= invMask;
-            pw->Port1 = (Node*)invMask;
+            pw->Port1 = (Node*)(uintptr_t)invMask;
             pw->Port2->State |= mask;
-            pw->Port2 = (Node*)mask;
+            pw->Port2 = (Node*)(uintptr_t)mask;
         }
 
         invMask ^= 3;
@@ -1694,12 +1694,12 @@ void Schematic::newMovingWires(Q3PtrList<Element> *p, Node *pn, int pos)
         // create new wire ?
         if(pw2 == 0)
         {
-            if(pw->Port1 != (Node*)mask)
+            if(pw->Port1 != (Node*)(uintptr_t)mask)
                 p->insert(pos,
-                          new Wire(pw->x2, pw->y2, pw->x2, pw->y2, (Node*)mask, (Node*)invMask));
+                          new Wire(pw->x2, pw->y2, pw->x2, pw->y2, (Node*)(uintptr_t)mask, (Node*)(uintptr_t)invMask));
             else
                 p->insert(pos,
-                          new Wire(pw->x1, pw->y1, pw->x1, pw->y1, (Node*)mask, (Node*)invMask));
+                          new Wire(pw->x1, pw->y1, pw->x1, pw->y1, (Node*)(uintptr_t)mask, (Node*)(uintptr_t)invMask));
             return;
         }
 
@@ -1717,12 +1717,12 @@ void Schematic::newMovingWires(Q3PtrList<Element> *p, Node *pn, int pos)
         {
             pw2->Port1 = (Node*)0;
             pw2->Port2->State |= mask;
-            pw2->Port2 = (Node*)mask;
+            pw2->Port2 = (Node*)(uintptr_t)mask;
         }
         else
         {
             pw2->Port1->State |= mask;
-            pw2->Port1 = (Node*)mask;
+            pw2->Port1 = (Node*)(uintptr_t)mask;
             pw2->Port2 = (Node*)0;
         }
         return;

--- a/qucs/qucs/schematic_element.cpp
+++ b/qucs/qucs/schematic_element.cpp
@@ -1322,6 +1322,7 @@ void Schematic::highlightWireLabels ()
         {
             if (pltestouter->isSelected)
             {
+                bool hiLightOuter = false;
                 // Search for matching labels
                 Q3PtrListIterator<Wire> itinner(*Wires);
                 Wire *pwinner;
@@ -1332,12 +1333,19 @@ void Schematic::highlightWireLabels ()
                     if (pltestinner)
                     {
                         // Highlight the label if it has the same name as the selected label
-                        if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                        // if only one wire has this label, do not highlight it
+                        if (pltestinner != pltestouter)
                         {
-                            pltestinner->setHighlighted (true);
+                            if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                            {
+                                pltestinner->setHighlighted (true);
+                                hiLightOuter = true;
+                            }
                         }
                     }
                 }
+                // two different wires with the same label found
+                pltestouter->setHighlighted (hiLightOuter);
             }
         }
     }

--- a/qucs/qucs/schematic_element.cpp
+++ b/qucs/qucs/schematic_element.cpp
@@ -1309,8 +1309,13 @@ void Schematic::highlightWireLabels ()
 
     // Then test every wire's label to see if we need to highlight it
     // and matching labels
-    for(Wire *pwouter = Wires->last(); pwouter != 0; pwouter = Wires->prev())
+    // maybe a bit inefficient, since the elements are checked n*n times;
+    // it could be done in n*(n+1)/2, but could not use Q3PtrListIterator...
+    Q3PtrListIterator<Wire> itouter(*Wires);
+    Wire *pwouter;
+    while ((pwouter = itouter.current()) !=0)
     {
+        ++itouter;
         // get any label associated with the wire
         pltestouter = pwouter->Label;
         if (pltestouter)
@@ -1318,8 +1323,11 @@ void Schematic::highlightWireLabels ()
             if (pltestouter->isSelected)
             {
                 // Search for matching labels
-                for(Wire *pwinner = Wires->last(); pwinner != 0; pwinner = Wires->prev())
+                Q3PtrListIterator<Wire> itinner(*Wires);
+                Wire *pwinner;
+                while ((pwinner = itinner.current()) !=0)
                 {
+                    ++itinner;
                     pltestinner = pwinner->Label; // test any label associated with the wire
                     if (pltestinner)
                     {

--- a/qucs/qucs/schematic_element.cpp
+++ b/qucs/qucs/schematic_element.cpp
@@ -1297,7 +1297,7 @@ void Schematic::highlightWireLabels ()
     WireLabel *pltestinner = 0;
     WireLabel *pltestouter = 0;
 
-    // First set highlighting for all wire labels to false
+    // First set highlighting for all wire and nodes labels to false
     for(Wire *pwouter = Wires->last(); pwouter != 0; pwouter = Wires->prev())
     {
         pltestouter = pwouter->Label; // test any label associated with the wire
@@ -1307,15 +1307,22 @@ void Schematic::highlightWireLabels ()
         }
     }
 
-    // Then test every wire's label to see if we need to highlight it
-    // and matching labels
-    // maybe a bit inefficient, since the elements are checked n*n times;
-    // it could be done in n*(n+1)/2, but could not use Q3PtrListIterator...
-    Q3PtrListIterator<Wire> itouter(*Wires);
-    Wire *pwouter;
-    while ((pwouter = itouter.current()) !=0)
+    for(Node *pnouter = Nodes->last(); pnouter != 0; pnouter = Nodes->prev())
     {
-        ++itouter;
+        pltestouter = pnouter->Label; // test any label associated with the node
+        if (pltestouter)
+        {
+            pltestouter->setHighlighted (false);
+        }
+    }
+	
+    // Then test every wire's label to see if we need to highlight it
+    // and matching labels on wires and nodes
+    Q3PtrListIterator<Wire> itwouter(*Wires);
+    Wire *pwouter;
+    while ((pwouter = itwouter.current()) != 0)
+    {
+        ++itwouter;
         // get any label associated with the wire
         pltestouter = pwouter->Label;
         if (pltestouter)
@@ -1323,12 +1330,12 @@ void Schematic::highlightWireLabels ()
             if (pltestouter->isSelected)
             {
                 bool hiLightOuter = false;
-                // Search for matching labels
-                Q3PtrListIterator<Wire> itinner(*Wires);
+                // Search for matching labels on wires
+                Q3PtrListIterator<Wire> itwinner(*Wires);
                 Wire *pwinner;
-                while ((pwinner = itinner.current()) !=0)
+                while ((pwinner = itwinner.current()) != 0)
                 {
-                    ++itinner;
+                    ++itwinner;
                     pltestinner = pwinner->Label; // test any label associated with the wire
                     if (pltestinner)
                     {
@@ -1344,7 +1351,82 @@ void Schematic::highlightWireLabels ()
                         }
                     }
                 }
-                // two different wires with the same label found
+                // Search for matching labels on nodes
+                Q3PtrListIterator<Node> itninner(*Nodes);
+                Node *pninner;
+                while ((pninner = itninner.current()) != 0)
+                {
+                    ++itninner;
+                    pltestinner = pninner->Label; // test any label associated with the node
+                    if (pltestinner)
+                    {
+                        if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                        {
+                            // node label matches wire label
+                            pltestinner->setHighlighted (true);
+                            hiLightOuter = true;
+                        }
+                    }
+                }
+                // highlight if at least two different wires/nodes with the same label found
+                pltestouter->setHighlighted (hiLightOuter);
+            }
+        }
+    }
+    // Same as above but for nodes labels:
+    // test every node label to see if we need to highlight it
+    // and matching labels on wires and nodes
+    Q3PtrListIterator<Node> itnouter(*Nodes);
+    Node *pnouter;
+    while ((pnouter = itnouter.current()) != 0)
+    {
+        ++itnouter;
+        // get any label associated with the node
+        pltestouter = pnouter->Label;
+        if (pltestouter)
+        {
+            if (pltestouter->isSelected)
+            {
+                bool hiLightOuter = false;
+                // Search for matching labels on wires
+                Q3PtrListIterator<Wire> itwinner(*Wires);
+                Wire *pwinner;
+                while ((pwinner = itwinner.current()) != 0)
+                {
+                    ++itwinner;
+                    pltestinner = pwinner->Label; // test any label associated with the wire
+                    if (pltestinner)
+                    {
+                        if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                        {
+                            // wire label matches node label
+                            pltestinner->setHighlighted (true);
+                            hiLightOuter = true;
+                        }
+                    }
+                }
+                // Search for matching labels on nodes
+                Q3PtrListIterator<Node> itninner(*Nodes);
+                Node *pninner;
+                while ((pninner = itninner.current()) != 0)
+                {
+                    ++itninner;
+                    pltestinner = pninner->Label; // test any label associated with the node
+                    if (pltestinner)
+                    {
+                        // Highlight the label if it has the same name as the selected label
+                        // if only one node has this label, do not highlight it
+                        if (pltestinner != pltestouter)
+                        {
+                            if (strcmp(pltestouter->Name, pltestinner->Name) == 0)
+                            {
+                                pltestinner->setHighlighted (true);
+                                hiLightOuter = true;
+                            }
+                        }
+                    }
+                }
+                // highlight if at least two different wires/nodes with the same label found
                 pltestouter->setHighlighted (hiLightOuter);
             }
         }

--- a/qucs/qucs/wirelabel.cpp
+++ b/qucs/qucs/wirelabel.cpp
@@ -115,7 +115,7 @@ void WireLabel::paint(ViewPainter *p)
 //    highlightfill.setAlpha(50);
 //    p->fillRect(x1-1, y1-1, x2, y2, highlightfill);
     p->Painter->setPen(QPen(Qt::darkBlue,3));
-    newFont.setWeight (QFont::DemiBold);
+    newFont.setWeight (QFont::Bold);
   }
   else
   {

--- a/qucs/qucs/wirelabel.cpp
+++ b/qucs/qucs/wirelabel.cpp
@@ -106,22 +106,25 @@ bool WireLabel::getSelected(int x, int y)
 // ----------------------------------------------------------------
 void WireLabel::paint(ViewPainter *p)
 {
-  QFont font = p->Painter->font();
+  QFont f = p->Painter->font(); // save current font
+  QFont newFont = f;
+
   if (isHighlighted)
   {
 //    QColor highlightfill (Qt::blue);
 //    highlightfill.setAlpha(50);
 //    p->fillRect(x1-1, y1-1, x2, y2, highlightfill);
     p->Painter->setPen(QPen(Qt::darkBlue,3));
-    font.setWeight (QFont::DemiBold);
+    newFont.setWeight (QFont::DemiBold);
   }
   else
   {
-    font.setWeight (QFont::Normal);
+    newFont.setWeight (QFont::Normal);
     p->Painter->setPen(QPen(Qt::black,1));
   }
-  p->Painter->setFont (font);
+  p->Painter->setFont (newFont);
   x2 = p->drawText(Name, x1, y1, &y2);
+  p->Painter->setFont(f); // restore old font
 
   int xpaint=0, ypaint=4, phi=0;
   switch(Type) {


### PR DESCRIPTION
#~~(Partial)~~ fix for the issues in #467 

Things corrected so far:
- [x] when selecting a wire label the text on some diagrams become boldfaced
- [x] selecting multiple different labels only highlights one group
- [x] labels on nodes are never highlighted
- [x] highlighting not updated when label is edited

I have also slightly modified the highlighting behavior: now a label is also highlighted (boldfaced) when selected only if the same label is used elsewhere. I think this gives a better feedback if a label is used multiple times, without need to search for boldface labels in the entire schematic to understand if a label is unique or not.

~~Feel free to merge already if you would like to see these things already fixed in 0.0.19 .~~
EDIT: should be ready to merge now