### PR TITLE
Match dialog fixes

### DIFF
--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -97,8 +97,8 @@ MatchDialog::MatchDialog(QWidget *parent)
   h1->addWidget(FormatLabel);
   FormatCombo = new QComboBox();
   h1->addWidget(FormatCombo);
-  FormatCombo->insertItem(tr("real/imag"));
-  FormatCombo->insertItem(tr("mag/deg"));
+  FormatCombo->insertItem(0, tr("real/imag"));
+  FormatCombo->insertItem(1, tr("mag/deg"));
   connect(FormatCombo, SIGNAL(activated(int)), SLOT(slotChangeMode(int)));
   h1->addStretch(5);
   SParLayout->addLayout(h1);
@@ -203,10 +203,10 @@ MatchDialog::MatchDialog(QWidget *parent)
   h2->addWidget(FrequencyLabel);
   h2->addWidget(FrequencyEdit);
   UnitCombo = new QComboBox();
-  UnitCombo->insertItem("Hz");
-  UnitCombo->insertItem("kHz");
-  UnitCombo->insertItem("MHz");
-  UnitCombo->insertItem("GHz");
+  UnitCombo->insertItem(0, "Hz");
+  UnitCombo->insertItem(1, "kHz");
+  UnitCombo->insertItem(2, "MHz");
+  UnitCombo->insertItem(3, "GHz");
   h2->addWidget(UnitCombo);
   h2->addStretch(5);
   SParLayout->addLayout(h2);
@@ -240,7 +240,7 @@ void MatchDialog::setFrequency(double Freq_)
   int Expo = int(log10(Freq_) / 3.0);
   if(Expo < 0) Expo = 0;
   else if(Expo > 3) Expo = 3;
-  UnitCombo->setCurrentItem(Expo);
+  UnitCombo->setCurrentIndex(Expo);
   Freq_ /= pow(10.0, double(3*Expo));
   FrequencyEdit->setText(QString::number(Freq_));
 }
@@ -405,7 +405,7 @@ void MatchDialog::slotImpedanceChanged(const QString&)
   double Real = S21magEdit->text().toDouble();
   double Imag = S21degEdit->text().toDouble();
 
-  if(FormatCombo->currentItem()) {  // entries in polar format
+  if(FormatCombo->currentIndex()) {  // entries in polar format
     p2c(Real, Imag);
     z2r(Real, Imag, Z0);
     c2p(Real, Imag);
@@ -432,7 +432,7 @@ void MatchDialog::slotReflexionChanged(const QString&)
   double Real = S11magEdit->text().toDouble();
   double Imag = S11degEdit->text().toDouble();
 
-  if(FormatCombo->currentItem()) {  // entries in polar format
+  if(FormatCombo->currentIndex()) {  // entries in polar format
     p2c(Real, Imag);
     r2z(Real, Imag, Z0);
     c2p(Real, Imag);
@@ -455,7 +455,7 @@ void MatchDialog::slotButtCreate()
   double Z1   = Ref1Edit->text().toDouble();
   double Z2   = Ref2Edit->text().toDouble();
   double Freq = FrequencyEdit->text().toDouble() *
-                pow(10.0, 3.0*double(UnitCombo->currentItem()));
+                pow(10.0, 3.0*double(UnitCombo->currentIndex()));
 
   double S11real = S11magEdit->text().toDouble();
   double S11imag = S11degEdit->text().toDouble();
@@ -465,7 +465,7 @@ void MatchDialog::slotButtCreate()
   double S21imag = S21degEdit->text().toDouble();
   double S22real = S22magEdit->text().toDouble();
   double S22imag = S22degEdit->text().toDouble();
-  if(FormatCombo->currentItem()) {  // are they polar ?
+  if(FormatCombo->currentIndex()) {  // are they polar ?
     p2c(S11real, S11imag);
     p2c(S12real, S12imag);
     p2c(S21real, S21imag);

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -239,21 +239,21 @@ void MatchDialog::slotSetTwoPort(bool on)
   if(on) { // two-port matching ?
     S11Label->setText(tr("S11"));
     S21Label->setText(tr("S21"));
-    S12magEdit->setEnabled(true);
-    S22magEdit->setEnabled(true);
-    S12degEdit->setEnabled(true);
-    S22degEdit->setEnabled(true);
-    S12Label->setEnabled(true);
-    S22Label->setEnabled(true);
-    S12sLabel->setEnabled(true);
-    S22sLabel->setEnabled(true);
-    S12degEdit->setEnabled(true);
-    S22degEdit->setEnabled(true);
-    S12uLabel->setEnabled(true);
-    S22uLabel->setEnabled(true);
-    Port2Label->setEnabled(true);
-    Ref2Edit->setEnabled(true);
-    Ohm2Label->setEnabled(true);
+    S12magEdit->setVisible(true);
+    S22magEdit->setVisible(true);
+    S12degEdit->setVisible(true);
+    S22degEdit->setVisible(true);
+    S12Label->setVisible(true);
+    S22Label->setVisible(true);
+    S12sLabel->setVisible(true);
+    S22sLabel->setVisible(true);
+    S12degEdit->setVisible(true);
+    S22degEdit->setVisible(true);
+    S12uLabel->setVisible(true);
+    S22uLabel->setVisible(true);
+    Port2Label->setVisible(true);
+    Ref2Edit->setVisible(true);
+    Ohm2Label->setVisible(true);
     // restore the previous S21 values
     S21magEdit->blockSignals(true); // do not call slot for "textChanged"
     S21magEdit->setText(QString::number(tmpS21mag));
@@ -265,21 +265,21 @@ void MatchDialog::slotSetTwoPort(bool on)
   else {
     S11Label->setText(tr("Reflexion Coefficient"));
     S21Label->setText(tr("Impedance (ohms)"));
-    S12magEdit->setEnabled(false);
-    S22magEdit->setEnabled(false);
-    S12degEdit->setEnabled(false);
-    S22degEdit->setEnabled(false);
-    S12Label->setEnabled(false);
-    S22Label->setEnabled(false);
-    S12sLabel->setEnabled(false);
-    S22sLabel->setEnabled(false);
-    S12degEdit->setEnabled(false);
-    S22degEdit->setEnabled(false);
-    S12uLabel->setEnabled(false);
-    S22uLabel->setEnabled(false);
-    Port2Label->setEnabled(false);
-    Ref2Edit->setEnabled(false);
-    Ohm2Label->setEnabled(false);
+    S12magEdit->setVisible(false);
+    S22magEdit->setVisible(false);
+    S12degEdit->setVisible(false);
+    S22degEdit->setVisible(false);
+    S12Label->setVisible(false);
+    S22Label->setVisible(false);
+    S12sLabel->setVisible(false);
+    S22sLabel->setVisible(false);
+    S12degEdit->setVisible(false);
+    S22degEdit->setVisible(false);
+    S12uLabel->setVisible(false);
+    S22uLabel->setVisible(false);
+    Port2Label->setVisible(false);
+    Ref2Edit->setVisible(false);
+    Ohm2Label->setVisible(false);
     // save S21 values, as these will be overwritten with the impedance value
     tmpS21mag = S21magEdit->text().toDouble();
     tmpS21deg = S21degEdit->text().toDouble();

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -4,6 +4,7 @@
     begin                : Fri Jul 22 2005
     copyright            : (C) 2005 by Michael Margraf
     email                : michael.margraf@alumni.tu-berlin.de
+    copyright            : (C) 2012, 2013, 2016 by Qucs Team (see AUTHORS file)
  ***************************************************************************/
 
 /***************************************************************************
@@ -292,8 +293,12 @@ void MatchDialog::slotChangeMode(int Index)
     double Real = S11magEdit->text().toDouble();
     double Imag = S11degEdit->text().toDouble();
     c2p(Real, Imag);
+    S11magEdit->blockSignals(true); // do not call slot for "textChanged"
     S11magEdit->setText(QString::number(Real));
+    S11magEdit->blockSignals(false);
+    S11degEdit->blockSignals(true); // do not call slot for "textChanged"
     S11degEdit->setText(QString::number(Imag));
+    S11degEdit->blockSignals(false);
 
     Real = S12magEdit->text().toDouble();
     Imag = S12degEdit->text().toDouble();
@@ -304,8 +309,12 @@ void MatchDialog::slotChangeMode(int Index)
     Real = S21magEdit->text().toDouble();
     Imag = S21degEdit->text().toDouble();
     c2p(Real, Imag);
+    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
     S21magEdit->setText(QString::number(Real));
+    S21magEdit->blockSignals(false);
+    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
     S21degEdit->setText(QString::number(Imag));
+    S21degEdit->blockSignals(false);
 
     Real = S22magEdit->text().toDouble();
     Imag = S22degEdit->text().toDouble();
@@ -326,8 +335,12 @@ void MatchDialog::slotChangeMode(int Index)
     double Mag   = S11magEdit->text().toDouble();
     double Phase = S11degEdit->text().toDouble();
     p2c(Mag, Phase);
+    S11magEdit->blockSignals(true); // do not call slot for "textChanged"
     S11magEdit->setText(QString::number(Mag));
+    S11magEdit->blockSignals(false);
+    S11degEdit->blockSignals(true); // do not call slot for "textChanged"
     S11degEdit->setText(QString::number(Phase));
+    S11degEdit->blockSignals(false);
 
     Mag   = S12magEdit->text().toDouble();
     Phase = S12degEdit->text().toDouble();
@@ -338,8 +351,12 @@ void MatchDialog::slotChangeMode(int Index)
     Mag   = S21magEdit->text().toDouble();
     Phase = S21degEdit->text().toDouble();
     p2c(Mag, Phase);
+    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
     S21magEdit->setText(QString::number(Mag));
+    S21magEdit->blockSignals(false);
+    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
     S21degEdit->setText(QString::number(Phase));
+    S21degEdit->blockSignals(false);
 
     Mag   = S22magEdit->text().toDouble();
     Phase = S22degEdit->text().toDouble();

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -245,6 +245,25 @@ void MatchDialog::setFrequency(double Freq_)
   FrequencyEdit->setText(QString::number(Freq_));
 }
 
+// Set visibility of LineEdits and Labels associated with two-port matching
+void MatchDialog::set2PortWidgetsVisible(bool visible)
+{
+    S12magEdit->setVisible(visible);
+    S22magEdit->setVisible(visible);
+    S12degEdit->setVisible(visible);
+    S22degEdit->setVisible(visible);
+    S12Label->setVisible(visible);
+    S22Label->setVisible(visible);
+    S12sLabel->setVisible(visible);
+    S22sLabel->setVisible(visible);
+    S12degEdit->setVisible(visible);
+    S22degEdit->setVisible(visible);
+    S12uLabel->setVisible(visible);
+    S22uLabel->setVisible(visible);
+    Port2Label->setVisible(visible);
+    Ref2Edit->setVisible(visible);
+    Ohm2Label->setVisible(visible);
+}
 // -----------------------------------------------------------------------
 // Is called when the checkbox for two-port matching changes.
 void MatchDialog::slotSetTwoPort(bool on)
@@ -252,21 +271,6 @@ void MatchDialog::slotSetTwoPort(bool on)
   if(on) { // two-port matching ?
     S11Label->setText(tr("S11"));
     S21Label->setText(tr("S21"));
-    S12magEdit->setVisible(true);
-    S22magEdit->setVisible(true);
-    S12degEdit->setVisible(true);
-    S22degEdit->setVisible(true);
-    S12Label->setVisible(true);
-    S22Label->setVisible(true);
-    S12sLabel->setVisible(true);
-    S22sLabel->setVisible(true);
-    S12degEdit->setVisible(true);
-    S22degEdit->setVisible(true);
-    S12uLabel->setVisible(true);
-    S22uLabel->setVisible(true);
-    Port2Label->setVisible(true);
-    Ref2Edit->setVisible(true);
-    Ohm2Label->setVisible(true);
     // restore the previous S21 values
     S21magEdit->blockSignals(true); // do not call slot for "textChanged"
     S21magEdit->setText(QString::number(tmpS21mag));
@@ -274,25 +278,12 @@ void MatchDialog::slotSetTwoPort(bool on)
     S21degEdit->blockSignals(true); // do not call slot for "textChanged"
     S21degEdit->setText(QString::number(tmpS21deg));
     S21degEdit->blockSignals(false);
+    set2PortWidgetsVisible(true);
   }
   else {
     S11Label->setText(tr("Reflexion Coefficient"));
     S21Label->setText(tr("Impedance (ohms)"));
-    S12magEdit->setVisible(false);
-    S22magEdit->setVisible(false);
-    S12degEdit->setVisible(false);
-    S22degEdit->setVisible(false);
-    S12Label->setVisible(false);
-    S22Label->setVisible(false);
-    S12sLabel->setVisible(false);
-    S22sLabel->setVisible(false);
-    S12degEdit->setVisible(false);
-    S22degEdit->setVisible(false);
-    S12uLabel->setVisible(false);
-    S22uLabel->setVisible(false);
-    Port2Label->setVisible(false);
-    Ref2Edit->setVisible(false);
-    Ohm2Label->setVisible(false);
+    set2PortWidgetsVisible(false);
     // save S21 values, as these will be overwritten with the impedance value
     tmpS21mag = S21magEdit->text().toDouble();
     tmpS21deg = S21degEdit->text().toDouble();

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -64,18 +64,21 @@ MatchDialog::MatchDialog(QWidget *parent)
   QHBoxLayout *ImpLayout = new QHBoxLayout();
   Port1Label = new QLabel(tr("Port 1"));
   Ref1Edit = new QLineEdit("50");
+  Ref1Edit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   Ref1Edit->setValidator(DoubleVal);
   Ohm1Label = new QLabel(tr("ohms"));
   connect(Ref1Edit, SIGNAL(textChanged(const QString&)),
 	  SLOT(slotImpedanceChanged(const QString&)));
   Port2Label = new QLabel(tr("Port 2"));
   Ref2Edit = new QLineEdit("50");
+  Ref2Edit->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   Ref2Edit->setValidator(DoubleVal);
   Ohm2Label = new QLabel(tr("ohms"));
   ImpLayout->addWidget(Port1Label);
   ImpLayout->addWidget(Ref1Edit);
   ImpLayout->addWidget(Ohm1Label);
   ImpLayout->addSpacing(50);
+  ImpLayout->addStretch();
   ImpLayout->addWidget(Port2Label);
   ImpLayout->addWidget(Ref2Edit);
   ImpLayout->addWidget(Ohm2Label);
@@ -85,6 +88,7 @@ MatchDialog::MatchDialog(QWidget *parent)
   QGroupBox *SParBox = new QGroupBox(tr("S Parameter"));
   all->addWidget(SParBox);
   QVBoxLayout *SParLayout = new QVBoxLayout();
+  SParLayout->setSpacing(10);
   SParBox->setLayout(SParLayout);
 
   QHBoxLayout *h1 = new QHBoxLayout();

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -272,12 +272,7 @@ void MatchDialog::slotSetTwoPort(bool on)
     S11Label->setText(tr("S11"));
     S21Label->setText(tr("S21"));
     // restore the previous S21 values
-    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21magEdit->setText(QString::number(tmpS21mag));
-    S21magEdit->blockSignals(false);
-    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21degEdit->setText(QString::number(tmpS21deg));
-    S21degEdit->blockSignals(false);
+    setS21LineEdits(tmpS21mag, tmpS21deg);
     set2PortWidgetsVisible(true);
   }
   else {
@@ -308,36 +303,24 @@ void MatchDialog::slotChangeMode(int Index)
     double Real = S11magEdit->text().toDouble();
     double Imag = S11degEdit->text().toDouble();
     c2p(Real, Imag);
-    S11magEdit->blockSignals(true); // do not call slot for "textChanged"
-    S11magEdit->setText(QString::number(Real));
-    S11magEdit->blockSignals(false);
-    S11degEdit->blockSignals(true); // do not call slot for "textChanged"
-    S11degEdit->setText(QString::number(Imag));
-    S11degEdit->blockSignals(false);
+    setS11LineEdits(Real, Imag);
 
     Real = S12magEdit->text().toDouble();
     Imag = S12degEdit->text().toDouble();
     c2p(Real, Imag);
-    S12magEdit->setText(QString::number(Real));
-    S12degEdit->setText(QString::number(Imag));
+    setS12LineEdits(Real, Imag);
 
     Real = S21magEdit->text().toDouble();
     Imag = S21degEdit->text().toDouble();
     c2p(Real, Imag);
-    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21magEdit->setText(QString::number(Real));
-    S21magEdit->blockSignals(false);
-    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21degEdit->setText(QString::number(Imag));
-    S21degEdit->blockSignals(false);
+    setS21LineEdits(Real, Imag);
     // convert also temp entries for future use
     c2p(tmpS21mag, tmpS21deg);
 
     Real = S22magEdit->text().toDouble();
     Imag = S22degEdit->text().toDouble();
     c2p(Real, Imag);
-    S22magEdit->setText(QString::number(Real));
-    S22degEdit->setText(QString::number(Imag));
+    setS22LineEdits(Real, Imag);
   }
   else {  // cartesian
     S11sLabel->setText("+j");
@@ -352,36 +335,24 @@ void MatchDialog::slotChangeMode(int Index)
     double Mag   = S11magEdit->text().toDouble();
     double Phase = S11degEdit->text().toDouble();
     p2c(Mag, Phase);
-    S11magEdit->blockSignals(true); // do not call slot for "textChanged"
-    S11magEdit->setText(QString::number(Mag));
-    S11magEdit->blockSignals(false);
-    S11degEdit->blockSignals(true); // do not call slot for "textChanged"
-    S11degEdit->setText(QString::number(Phase));
-    S11degEdit->blockSignals(false);
+    setS11LineEdits(Mag, Phase);
 
     Mag   = S12magEdit->text().toDouble();
     Phase = S12degEdit->text().toDouble();
     p2c(Mag, Phase);
-    S12magEdit->setText(QString::number(Mag));
-    S12degEdit->setText(QString::number(Phase));
+    setS12LineEdits(Mag, Phase);
 
     Mag   = S21magEdit->text().toDouble();
     Phase = S21degEdit->text().toDouble();
     p2c(Mag, Phase);
-    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21magEdit->setText(QString::number(Mag));
-    S21magEdit->blockSignals(false);
-    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
-    S21degEdit->setText(QString::number(Phase));
-    S21degEdit->blockSignals(false);
+    setS21LineEdits(Mag, Phase);
     // convert also temp entries for future use
     p2c(tmpS21mag, tmpS21deg);
 
     Mag   = S22magEdit->text().toDouble();
     Phase = S22degEdit->text().toDouble();
     p2c(Mag, Phase);
-    S22magEdit->setText(QString::number(Mag));
-    S22degEdit->setText(QString::number(Phase));
+    setS22LineEdits(Mag, Phase);
   }
 }
 
@@ -404,12 +375,7 @@ void MatchDialog::slotImpedanceChanged(const QString&)
     z2r(Real, Imag, Z0);
   }
 
-  S11magEdit->blockSignals(true); // do not call "changed-slot"
-  S11magEdit->setText(QString::number(Real));
-  S11magEdit->blockSignals(false);
-  S11degEdit->blockSignals(true); // do not call "changed-slot"
-  S11degEdit->setText(QString::number(Imag));
-  S11degEdit->blockSignals(false);
+  setS11LineEdits(Real, Imag);
 }
 
 // -----------------------------------------------------------------------
@@ -430,13 +396,39 @@ void MatchDialog::slotReflexionChanged(const QString&)
   } else {
     r2z(Real, Imag, Z0);
   }
+  setS21LineEdits(Real, Imag);
+}
 
-  S21magEdit->blockSignals(true); // do not call "changed-slot"
+void MatchDialog::setS11LineEdits(double Real, double Imag)
+{
+  S11magEdit->blockSignals(true); // do not call slot for "textChanged"
+  S11magEdit->setText(QString::number(Real));
+  S11magEdit->blockSignals(false);
+  S11degEdit->blockSignals(true); // do not call slot for "textChanged"
+  S11degEdit->setText(QString::number(Imag));
+  S11degEdit->blockSignals(false);
+}
+
+void MatchDialog::setS12LineEdits(double Real, double Imag)
+{
+  S12magEdit->setText(QString::number(Real));
+  S12degEdit->setText(QString::number(Imag));
+}
+
+void MatchDialog::setS21LineEdits(double Real, double Imag)
+{
+  S21magEdit->blockSignals(true); // do not call slot for "textChanged"
   S21magEdit->setText(QString::number(Real));
   S21magEdit->blockSignals(false);
-  S21degEdit->blockSignals(true); // do not call "changed-slot"
+  S21degEdit->blockSignals(true); // do not call slot for "textChanged"
   S21degEdit->setText(QString::number(Imag));
   S21degEdit->blockSignals(false);
+}
+
+void MatchDialog::setS22LineEdits(double Real, double Imag)
+{
+  S22magEdit->setText(QString::number(Real));
+  S22degEdit->setText(QString::number(Imag));
 }
 
 // -----------------------------------------------------------------------

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -391,7 +391,15 @@ void MatchDialog::slotImpedanceChanged(const QString&)
   double Z0   = Ref1Edit->text().toDouble();
   double Real = S21magEdit->text().toDouble();
   double Imag = S21degEdit->text().toDouble();
-  z2r(Real, Imag, Z0);
+
+  if(FormatCombo->currentItem()) {  // entries in polar format
+    p2c(Real, Imag);
+    z2r(Real, Imag, Z0);
+    c2p(Real, Imag);
+  } else {
+    z2r(Real, Imag, Z0);
+  }
+
   S11magEdit->blockSignals(true); // do not call "changed-slot"
   S11magEdit->setText(QString::number(Real));
   S11magEdit->blockSignals(false);
@@ -410,7 +418,15 @@ void MatchDialog::slotReflexionChanged(const QString&)
   double Z0   = Ref1Edit->text().toDouble();
   double Real = S11magEdit->text().toDouble();
   double Imag = S11degEdit->text().toDouble();
-  r2z(Real, Imag, Z0);
+
+  if(FormatCombo->currentItem()) {  // entries in polar format
+    p2c(Real, Imag);
+    r2z(Real, Imag, Z0);
+    c2p(Real, Imag);
+  } else {
+    r2z(Real, Imag, Z0);
+  }
+
   S21magEdit->blockSignals(true); // do not call "changed-slot"
   S21magEdit->setText(QString::number(Real));
   S21magEdit->blockSignals(false);

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -254,6 +254,13 @@ void MatchDialog::slotSetTwoPort(bool on)
     Port2Label->setEnabled(true);
     Ref2Edit->setEnabled(true);
     Ohm2Label->setEnabled(true);
+    // restore the previous S21 values
+    S21magEdit->blockSignals(true); // do not call slot for "textChanged"
+    S21magEdit->setText(QString::number(tmpS21mag));
+    S21magEdit->blockSignals(false);
+    S21degEdit->blockSignals(true); // do not call slot for "textChanged"
+    S21degEdit->setText(QString::number(tmpS21deg));
+    S21degEdit->blockSignals(false);
   }
   else {
     S11Label->setText(tr("Reflexion Coefficient"));
@@ -273,6 +280,10 @@ void MatchDialog::slotSetTwoPort(bool on)
     Port2Label->setEnabled(false);
     Ref2Edit->setEnabled(false);
     Ohm2Label->setEnabled(false);
+    // save S21 values, as these will be overwritten with the impedance value
+    tmpS21mag = S21magEdit->text().toDouble();
+    tmpS21deg = S21degEdit->text().toDouble();
+    slotReflexionChanged(""); // calculate impedance
   }
 }
 
@@ -315,6 +326,8 @@ void MatchDialog::slotChangeMode(int Index)
     S21degEdit->blockSignals(true); // do not call slot for "textChanged"
     S21degEdit->setText(QString::number(Imag));
     S21degEdit->blockSignals(false);
+    // convert also temp entries for future use
+    c2p(tmpS21mag, tmpS21deg);
 
     Real = S22magEdit->text().toDouble();
     Imag = S22degEdit->text().toDouble();
@@ -357,6 +370,8 @@ void MatchDialog::slotChangeMode(int Index)
     S21degEdit->blockSignals(true); // do not call slot for "textChanged"
     S21degEdit->setText(QString::number(Phase));
     S21degEdit->blockSignals(false);
+    // convert also temp entries for future use
+    p2c(tmpS21mag, tmpS21deg);
 
     Mag   = S22magEdit->text().toDouble();
     Phase = S22degEdit->text().toDouble();

--- a/qucs/qucs/dialogs/matchdialog.cpp
+++ b/qucs/qucs/dialogs/matchdialog.cpp
@@ -176,6 +176,15 @@ MatchDialog::MatchDialog(QWidget *parent)
     VBox0->addWidget(S22uLabel);
   SParLayout->addLayout(h3);
 
+  // set tab order to a more natural mode
+  setTabOrder(S11magEdit, S11degEdit);
+  setTabOrder(S11degEdit, S12magEdit);
+  setTabOrder(S12magEdit, S12degEdit);
+  setTabOrder(S12degEdit, S21magEdit);
+  setTabOrder(S21magEdit, S21degEdit);
+  setTabOrder(S21degEdit, S22magEdit);
+  setTabOrder(S22magEdit, S22degEdit);
+
   connect(S21magEdit, SIGNAL(textChanged(const QString&)),
 	  SLOT(slotImpedanceChanged(const QString&)));
   connect(S21degEdit, SIGNAL(textChanged(const QString&)),

--- a/qucs/qucs/dialogs/matchdialog.h
+++ b/qucs/qucs/dialogs/matchdialog.h
@@ -21,12 +21,12 @@
 #include <QDialog>
 #include <QVBoxLayout>
 #include <QLabel>
+#include <QCheckBox>
 
 class Element;
 class QLabel;
 class QLineEdit;
 class QComboBox;
-class QCheckBox;
 class QVBoxLayout;
 class QDoubleValidator;
 
@@ -48,11 +48,7 @@ public:
   static bool calc2PortMatch(double, double, double, double, double, double,
                              double, double, double);
   void setFrequency(double);
-
-  QLineEdit *Ref1Edit, *Ref2Edit, *FrequencyEdit,
-            *S11magEdit,*S11degEdit, *S21magEdit,*S21degEdit,
-            *S12magEdit,*S12degEdit, *S22magEdit,*S22degEdit;
-  QCheckBox *TwoCheck;
+  void setTwoPortMatch(bool on) { TwoCheck->setChecked(on); TwoCheck->setEnabled(false); }
 
 public slots:
   void slotButtCreate();
@@ -60,6 +56,10 @@ public slots:
   void slotReflexionChanged(const QString&);
   void slotSetTwoPort(bool);
   void slotChangeMode(int);
+  void setS11LineEdits(double, double);
+  void setS12LineEdits(double, double);
+  void setS21LineEdits(double, double);
+  void setS22LineEdits(double, double);
 
 private:
   QVBoxLayout *all;   // the mother of all widgets
@@ -71,6 +71,12 @@ private:
               *S12Label, *S12sLabel, *S12uLabel,
               *S22Label, *S22sLabel, *S22uLabel;
   QComboBox   *FormatCombo, *UnitCombo;
+
+  QLineEdit *Ref1Edit, *Ref2Edit, *FrequencyEdit,
+            *S11magEdit,*S11degEdit, *S21magEdit,*S21degEdit,
+            *S12magEdit,*S12degEdit, *S22magEdit,*S22degEdit;
+
+  QCheckBox *TwoCheck;
 
   double tmpS21mag, tmpS21deg;
 

--- a/qucs/qucs/dialogs/matchdialog.h
+++ b/qucs/qucs/dialogs/matchdialog.h
@@ -73,6 +73,8 @@ private:
   QComboBox   *FormatCombo, *UnitCombo;
 
   double tmpS21mag, tmpS21deg;
+
+  void set2PortWidgetsVisible(bool);
 };
 
 #endif

--- a/qucs/qucs/dialogs/matchdialog.h
+++ b/qucs/qucs/dialogs/matchdialog.h
@@ -71,6 +71,8 @@ private:
               *S12Label, *S12sLabel, *S12uLabel,
               *S22Label, *S22sLabel, *S22uLabel;
   QComboBox   *FormatCombo, *UnitCombo;
+
+  double tmpS21mag, tmpS21deg;
 };
 
 #endif

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2551,12 +2551,10 @@ void QucsApp::slotPowerMatching()
     Imag *= -1.0;
 
   MatchDialog *Dia = new MatchDialog(this);
-  Dia->TwoCheck->setChecked(false);
-  Dia->TwoCheck->setEnabled(false);
 //  Dia->Ref1Edit->setText(QString::number(Z0));
-  Dia->S11magEdit->setText(QString::number(pm->powReal()));
-  Dia->S11degEdit->setText(QString::number(Imag));
+  Dia->setS11LineEdits(pm->powReal(), Imag);
   Dia->setFrequency(pm->powFreq());
+  Dia->setTwoPortMatch(false); // will also cause the corresponding impedance LineEdit to be updated
 
   slotToPage();
   if(Dia->exec() != QDialog::Accepted)
@@ -2634,16 +2632,12 @@ void QucsApp::slot2PortMatching()
   delete Diag;
 
   MatchDialog *Dia = new MatchDialog(this);
-  Dia->TwoCheck->setEnabled(false);
+  Dia->setTwoPortMatch(true);
   Dia->setFrequency(Freq);
-  Dia->S11magEdit->setText(QString::number(S11real));
-  Dia->S11degEdit->setText(QString::number(S11imag));
-  Dia->S12magEdit->setText(QString::number(S12real));
-  Dia->S12degEdit->setText(QString::number(S12imag));
-  Dia->S21magEdit->setText(QString::number(S21real));
-  Dia->S21degEdit->setText(QString::number(S21imag));
-  Dia->S22magEdit->setText(QString::number(S22real));
-  Dia->S22degEdit->setText(QString::number(S22imag));
+  Dia->setS11LineEdits(S11real, S11imag);
+  Dia->setS12LineEdits(S12real, S12imag);
+  Dia->setS21LineEdits(S21real, S21imag);
+  Dia->setS22LineEdits(S22real, S22imag);
 
   slotToPage();
   if(Dia->exec() != QDialog::Accepted)


### PR DESCRIPTION
Small fixes for the Tools->Matching Circuit dialog:
- wrong results show for the polar/rectangular conversion:
  - to reproduce: open dialog, uncheck "calculate two-port matching", enter a non-zero imaginary part for the "Reflexion coefficient", change the Input Format from *real/imag* to *mag/deg* and then back again to *real/imag*. The result shown is not the same as the initial one.
- wrong conversion when polar format is used (similar to the previous one, but different root cause):
  - to reproduce: open dialog, uncheck "calculate two-port matching", change the Input Format to *mag/deg* and enter a non-zero angle part for the "Reflexion coefficient", e.g.10 degrees. The impedance will change even if the reflection coefficient magnitude is fixed at zero.

plus other small "cosmetic" fixes, see commits messages for details.