### PR TITLE
Small GUI fix

### DIFF
--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -28,6 +28,7 @@
 #include <QStringList>
 #include <QDir>
 #include <QStandardItemModel>
+#include <QDebug>
 
 ProjectView::ProjectView(QWidget *parent)
   : QTreeView(parent)
@@ -57,7 +58,11 @@ ProjectView::setProjPath(const QString &path)
   if (m_valid) {
     m_projPath = path; // full path
     m_projName = QDir(m_projPath).dirName(); // only project directory name
-    m_projName.remove("_prj");
+    if (m_projName.endsWith("_prj")) {
+      m_projName.chop(4);// remove "_prj" from name
+    } else { // should not happen
+      qWarning() << "ProjectView::setProjPath() : path does not end in '_prj' (" << m_projName << ")";
+    }
   }
   refresh();
 }

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -94,7 +94,7 @@ ProjectView::refresh()
 
   // put all files into "Content"-ListView
   QDir workPath(m_projPath);
-  QStringList files = workPath.entryList("*", QDir::Files, QDir::Name);
+  QStringList files = workPath.entryList(QStringList() << "*", QDir::Files, QDir::Name);
   QStringList::iterator it;
   QString extName, fileName;
   QList<QStandardItem *> columnData;

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1294,18 +1294,19 @@ bool QucsApp::deleteProject(const QString& Path)
 {
   slotHideEdit();
 
-  QString Name = Path;
+  if(Path.isEmpty()) return false;
 
-  if(Name.isEmpty()) return false;
+  QString delProjName = QDir(Path).dirName(); // only project directory name
 
-  if (Name.endsWith(QDir::separator())) {
-    Name = Name.left(Name.length()-1);  // cut off trailing '/'
+  if (!delProjName.endsWith("_prj")) { // should not happen
+    QMessageBox::critical(this, tr("Error"),
+                          tr("Project directory name does not end in '_prj' (%1)").arg(delProjName));
+    return false;
   }
-  int i = Name.lastIndexOf(QDir::separator());
-  if(i > 0) Name = Name.mid(i+1);  // cut out the last subdirectory
-  Name.chop(4); // remove "_prj" from name
 
-  if(Name == ProjName) {
+  delProjName.chop(4); // remove "_prj" from name
+
+  if(delProjName == ProjName) {
     QMessageBox::information(this, tr("Info"),
         tr("Cannot delete an open project !"));
     return false;


### PR DESCRIPTION
Looking around the `ProjecView()` code I saw a couple of small things that were not fully correct.
- when creating a project with a name *containing* `_prj`, this part of the string will be removed from the project name used internally. I.e. when asking to create `my_prj_EE101` the project name shown will be `my_EE101`. This is due to the usage of `QString::remove()`[here] (https://github.com/Qucs/qucs/blob/release-0.0.19/qucs/qucs/qucs.cpp#L1168)
This has an interesting side-effect: if you now try to remove this project while it's still open, Qucs will happily do that, since the currently open project name is different from the expected project directory name.

While at it, I have also added a couple of checks to make sure the project path ends in `_prj`when opening or deleting a project. 
Also, the order of operations while trying to open a new project is slightly changed: now the current project is not closed automatically before checking if the new project can be opened.
