### PR TITLE
Fix devices translation (issue 487)

### DIFF
--- a/qucs-core/src/converter/check_spice.cpp
+++ b/qucs-core/src/converter/check_spice.cpp
@@ -641,7 +641,11 @@ static void spice_adjust_device (struct definition_t * def,
       def->pairs = netlist_append_pairs (def->pairs, p);
       // adjust type of device
       free (def->type);
-
+      def->type = strdup (tran->trans_type);
+      // append "Type" property
+      if (tran->trans_type_prop != NULL) {
+        spice_set_property_string (def, "Type", tran->trans_type_prop);
+      }
       break;
     }
   }
@@ -752,6 +756,15 @@ node_translations[] = {
     { 1, 2, -1 }
   },
   { "Iac", 0,
+    { 2, 1, -1 },
+    { 1, 2, -1 }
+  },
+  { "Idc", 0,
+    { 2, 1, -1 },
+    { 1, 2, -1 }
+  },
+  { "VCCS", 0,
+    { 3, 1, 2, 4, -1 },
     { 1, 2, 3, 4, -1 }
   },
   { "VCVS", 0,


### PR DESCRIPTION
This seems to fix #487.

Apparently a compound statement was [erroneously removed] (https://github.com/Qucs/qucs/commit/bfc7200fa443df3685a5b1c2a79b47144f26c2d6#diff-c725caf01acb3b690302160a1e02ac34L700) while removing the HICUM stuff.

Then, there were other lines in the `node_translations` array which were also [erroneously removed] (https://github.com/Qucs/qucs/commit/bfc7200fa443df3685a5b1c2a79b47144f26c2d6#diff-c725caf01acb3b690302160a1e02ac34L817) but I do not see why, as I think these are not directly related to the HICUM models.

The LM358 test circuit works again now, please do further checks :grin: