### PR TITLE
Last minute fixes

### DIFF
--- a/qucs-core/src/components/devices/bjt.cpp
+++ b/qucs-core/src/components/devices/bjt.cpp
@@ -460,19 +460,24 @@ void bjt::calcDC (void) {
   dQbdUbe = Q1 * (Qb * Var + gif * Ikf / Sqrt);
   dQbdUbc = Q1 * (Qb * Vaf + gir * Ikr / Sqrt);
 
+  // If and gif will be later used also for the capacitance/charge calculations
+  // Values computed from the excess phase routine should be used only
+  //   for computing the companion model current and conductance
+  nr_double_t Ifx = If;
+  nr_double_t gifx = gif;
   // during transient analysis only
   if (doTR) {
     // calculate excess phase influence
-    If /= Qb;
-    excessPhase (cexState, If, gif);
-    If *= Qb;
+    Ifx /= Qb;
+    excessPhase (cexState, Ifx, gifx);
+    Ifx *= Qb;
   }
 
   // compute transfer current
-  It = (If - Ir) / Qb;
+  It = (Ifx - Ir) / Qb;
 
   // compute forward and backward transconductance
-  gitf = (+gif - It * dQbdUbe) / Qb;
+  gitf = (+gifx - It * dQbdUbe) / Qb;
   gitr = (-gir - It * dQbdUbc) / Qb;
 
   // compute old SPICE values

--- a/qucs-core/src/components/devices/thyristor.cpp
+++ b/qucs-core/src/components/devices/thyristor.cpp
@@ -84,6 +84,9 @@ void thyristor::calcTheModel (bool last) {
   else
     isOn = Ud > Ud_bo;
 
+  nr_double_t Vak = real (getV (NODE_A1) - getV (NODE_A2));
+  isOn *= (Vak > 0.0);
+
   if (Ud >= 80.0) {
     Id *= std::exp (80.0) * (1.0 + Ud - 80.0) - 1.0;
     Ud  = 80.0;

--- a/qucs-core/src/eqnsys.cpp
+++ b/qucs-core/src/eqnsys.cpp
@@ -1245,7 +1245,7 @@ void eqnsys<nr_type_t>::chop_svd (void) {
   nr_double_t Max, Min;
   Max = 0.0;
   for (c = 0; c < N; c++) if (fabs (S_(c)) > Max) Max = fabs (S_(c));
-  Min = Max * std::numeric_limits<nr_double_t>::max();
+  Min = Max * std::numeric_limits<nr_double_t>::epsilon();
   for (c = 0; c < N; c++) if (fabs (S_(c)) < Min) S_(c) = 0.0;
 }
 


### PR DESCRIPTION
...nothing's like announcing a possible release candidate to motivate pushing some small fixes...

So here are
- ecaff9c0f77de8672df29e90713da597f2aff075 : an old acquaintance, seen already in #206 more than one year ago. Since it passes `qucs-test` (due to lack of a proper test...) it would be good to merge it
- b4ba51b4eb7cfb1cf03a18be8bcd6e37f77e67ba : a small bug/regression fix for the matrix SVD routine that was broken since Christmas 2014.
- ecaff9c0f77de8672df29e90713da597f2aff075 : a quick fix for the SCR reverse conduction bug mentioned recently on `qucs-help`. This also passes `qucs-test` since there is no test schematic with an SCR there.
BTW, I think the overall model needs some review/documentation, but this will be for later.