### PR TITLE
Enabled loading of unknown components

### DIFF
--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -1571,16 +1571,24 @@ Component* getComponentFromName(QString& Line, Schematic* p)
 
   if(!c) {
     /// \todo enable user to load partial schematic, skip unknown components
-      QMessageBox* msg = new QMessageBox(QMessageBox::Warning,QObject::tr("Warning"),
-                                         QObject::tr("Format Error:\nUnknown component!\n"
-                                                     "%1\n\n"
-                                                     "Do you want to load schematic anyway?\n"
-                                                     "Unknown components will be replaced \n"
-                                                     "by dummy subcircuit placeholders.").arg(cstr),
-                                         QMessageBox::Yes|QMessageBox::No);
-      int r = msg->exec();
-      if (r == QMessageBox::Yes) c = new Subcircuit();
-      else return 0;
+      if (QucsMain!=0) {
+          QMessageBox* msg = new QMessageBox(QMessageBox::Warning,QObject::tr("Warning"),
+                                             QObject::tr("Format Error:\nUnknown component!\n"
+                                                         "%1\n\n"
+                                                         "Do you want to load schematic anyway?\n"
+                                                         "Unknown components will be replaced \n"
+                                                         "by dummy subcircuit placeholders.").arg(cstr),
+                                             QMessageBox::Yes|QMessageBox::No);
+          int r = msg->exec();
+          delete msg;
+          if (r == QMessageBox::Yes) c = new Subcircuit();
+          else return 0;
+      } else {
+          QString err_msg = QString("Schematic loading error! Unknown device %1").arg(cstr);
+          qCritical()<<err_msg;
+          return 0;
+      }
+
   }
 
   if(!c->load(Line)) {

--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -1581,8 +1581,13 @@ Component* getComponentFromName(QString& Line, Schematic* p)
                                              QMessageBox::Yes|QMessageBox::No);
           int r = msg->exec();
           delete msg;
-          if (r == QMessageBox::Yes) c = new Subcircuit();
-          else return 0;
+          if (r == QMessageBox::Yes) {
+              c = new Subcircuit();
+              // Hack: insert dummy File property before the first property
+              int pos1 = Line.indexOf('"');
+              QString filestr = QString("\"%1.sch\" 1 ").arg(cstr);
+              Line.insert(pos1,filestr);
+          } else return 0;
       } else {
           QString err_msg = QString("Schematic loading error! Unknown device %1").arg(cstr);
           qCritical()<<err_msg;

--- a/qucs/qucs/components/component.cpp
+++ b/qucs/qucs/components/component.cpp
@@ -1571,11 +1571,16 @@ Component* getComponentFromName(QString& Line, Schematic* p)
 
   if(!c) {
     /// \todo enable user to load partial schematic, skip unknown components
-    QMessageBox::critical(0, QObject::tr("Error"),
-	QObject::tr("Format Error:\nUnknown component!\n"
-                "%1\n\n"
-                "Do you make use of loadable components?").arg(cstr));
-    return 0;
+      QMessageBox* msg = new QMessageBox(QMessageBox::Warning,QObject::tr("Warning"),
+                                         QObject::tr("Format Error:\nUnknown component!\n"
+                                                     "%1\n\n"
+                                                     "Do you want to load schematic anyway?\n"
+                                                     "Unknown components will be replaced \n"
+                                                     "by dummy subcircuit placeholders.").arg(cstr),
+                                         QMessageBox::Yes|QMessageBox::No);
+      int r = msg->exec();
+      if (r == QMessageBox::Yes) c = new Subcircuit();
+      else return 0;
   }
 
   if(!c->load(Line)) {


### PR DESCRIPTION
This fixes #506. If Qucs find unknown component, a new dialog window with Yes/No buttons will be shown. User can press Yes and load schematic anyway, and press No and abort loading of schematic. Unknown components will be replaced by placeholders. I am using Subcircuits as placeholders. Maybe it's better to create some special placeholder device, which will be available for this purpose only? Should this PR will be for `release-0.0.19`?
