### PR TITLE
Instantiate QApplication sooner so applicationDirPath() is valid

### DIFF
--- a/qucs/qucs-activefilter/main.cpp
+++ b/qucs/qucs-activefilter/main.cpp
@@ -63,6 +63,8 @@ bool saveApplSettings(QucsActiveFilter *qucs)
 
 int main(int argc, char *argv[])
 {
+    QApplication a(argc, argv);
+
     QString LangDir;
     // apply default settings
     QucsSettings.x = 200;
@@ -91,7 +93,6 @@ int main(int argc, char *argv[])
 
     loadSettings();
 
-    QApplication a(argc, argv);
     a.setFont(QucsSettings.font);
 
     QTranslator tor( 0 );

--- a/qucs/qucs-attenuator/main.cpp
+++ b/qucs/qucs-attenuator/main.cpp
@@ -64,6 +64,8 @@ bool saveApplSettings(QucsAttenuator *qucs)
 
 int main( int argc, char ** argv )
 {
+  QApplication a( argc, argv );
+
   // apply default settings
   QucsSettings.x = 200;
   QucsSettings.y = 100;
@@ -90,7 +92,6 @@ int main( int argc, char ** argv )
 
   loadSettings();
 
-  QApplication a( argc, argv );
   a.setFont(QucsSettings.font);
   QTranslator tor( 0 );
   QString lang = QucsSettings.Language;

--- a/qucs/qucs-edit/main.cpp
+++ b/qucs/qucs-edit/main.cpp
@@ -90,6 +90,8 @@ void showOptions()
 
 int main(int argc, char *argv[])
 {
+  QApplication a(argc, argv);
+
   // apply default settings
   QucsSettings.x = 200;
   QucsSettings.y = 100;
@@ -118,7 +120,6 @@ int main(int argc, char *argv[])
 
   loadSettings();
 
-  QApplication a(argc, argv);
   a.setFont(QucsSettings.font);
 
   QTranslator tor( 0 );

--- a/qucs/qucs-filter-v2/qf_main.cpp
+++ b/qucs/qucs-filter-v2/qf_main.cpp
@@ -34,6 +34,8 @@ void compute_lumped (qf_spec* spec_p, Q3TextStream& out) {
 
 int main (int argc, char * argv []) {
 
+  QApplication app (argc, argv);
+
   // apply default settings
   QucsSettings.x = 200;
   QucsSettings.y = 100;
@@ -60,7 +62,6 @@ int main (int argc, char * argv []) {
 
   loadSettings();
 
-  QApplication	    app (argc, argv);
   qf_spec*	    spec_p;
 
   int               result = 0;

--- a/qucs/qucs-filter/main.cpp
+++ b/qucs/qucs-filter/main.cpp
@@ -77,6 +77,8 @@ bool saveApplSettings(QucsFilter *qucs)
 
 int main(int argc, char *argv[])
 {
+  QApplication a(argc, argv);
+
   // apply default settings
   QucsSettings.x = 200;
   QucsSettings.y = 100;
@@ -103,7 +105,6 @@ int main(int argc, char *argv[])
 
   loadSettings();
 
-  QApplication a(argc, argv);
   a.setFont(QucsSettings.font);
 
   QTranslator tor( 0 );

--- a/qucs/qucs-lib/main.cpp
+++ b/qucs/qucs-lib/main.cpp
@@ -84,6 +84,8 @@ bool saveApplSettings(QucsLib *qucs)
 
 int main(int argc, char *argv[])
 {
+  QApplication a(argc, argv);
+
   // apply default settings
   QucsSettings.x = 100;
   QucsSettings.y = 50;
@@ -115,7 +117,6 @@ int main(int argc, char *argv[])
 
   UserLibDir.setPath(QucsSettings.QucsHomeDir.canonicalPath() + "/user_lib/");
 
-  QApplication a(argc, argv);
   a.setFont(QucsSettings.font);
 
   QTranslator tor( 0 );

--- a/qucs/qucs-rescodes/main.cpp
+++ b/qucs/qucs-rescodes/main.cpp
@@ -223,6 +223,8 @@ bool saveApplSettings(MyWidget *w)
 
 int main( int argc, char **argv )
 {
+  QApplication a(argc, argv);
+
   // apply default settings
   QucsSettings.x = 100;
   QucsSettings.y = 50;
@@ -247,7 +249,6 @@ int main( int argc, char **argv )
 
   loadSettings();
 
-  QApplication a(argc, argv);
   a.setFont(QucsSettings.font);
 
   QTranslator tor(0);

--- a/qucs/qucs-transcalc/main.cpp
+++ b/qucs/qucs-transcalc/main.cpp
@@ -97,6 +97,8 @@ bool saveApplSettings(QucsTranscalc *qucs)
 
 int main(int argc, char *argv[])
 {
+  QApplication a(argc, argv);
+
   // apply default settings
   QucsSettings.x = 100;
   QucsSettings.y = 50;
@@ -129,7 +131,6 @@ int main(int argc, char *argv[])
   }
   loadSettings();
 
-  QApplication a(argc, argv);
   a.setFont(QucsSettings.font);
 
   QTranslator tor( 0 );


### PR DESCRIPTION
...now is my turn to realize i did a sloppy review :unamused: 

In #501 the path for the language files was changed to be relative to the application path, but if a `QApplication()` object is not instantiated before calling `QCoreApplication::applicationDirPath()` this latter actually returns an empty path, so the language files are not found (unless you run the application from the `prefix` directory).
This was already fixed for `qucshelp` in #473, but after #501 all the other tools needed to be updated .

I have checked this to work but please double/triple check...
