### PR TITLE
blacklist automake-1.10, like -1.11

### DIFF
--- a/qucs-core/bootstrap
+++ b/qucs-core/bootstrap
@@ -24,23 +24,6 @@
 #
 
 AUTOMAKE=${AUTOMAKE:-automake}
-AUTOMAKE_VERSION_CHECK=${AUTOMAKE_VERSION_CHECK:-yes}
-
-if [ "$AUTOMAKE_VERSION_CHECK" = yes ]; then
-	AUTOMAKE_VERSION=$($AUTOMAKE --version | head -1 | cut -d' ' -f4)
-	case ${AUTOMAKE_VERSION} in
-		1.1[01]*)
-			cat >&2 <<__EOF__
-We experience trouble with your automake (version $AUTOMAKE_VERSION).
-Giving up.
-
-If you feel adventurous, please set AUTOMAKE_VERSION_CHECK=no in your
-environment and try again.
-__EOF__
-			exit 1
-			;;
-	esac
-fi
 
 here=`pwd`
 cd `dirname $0`

--- a/qucs-core/bootstrap
+++ b/qucs-core/bootstrap
@@ -29,7 +29,7 @@ AUTOMAKE_VERSION_CHECK=${AUTOMAKE_VERSION_CHECK:-yes}
 if [ "$AUTOMAKE_VERSION_CHECK" = yes ]; then
 	AUTOMAKE_VERSION=$($AUTOMAKE --version | head -1 | cut -d' ' -f4)
 	case ${AUTOMAKE_VERSION} in
-		1.11*)
+		1.1[01]*)
 			cat >&2 <<__EOF__
 We experience trouble with your automake (version $AUTOMAKE_VERSION).
 Giving up.

--- a/qucs-core/bootstrap
+++ b/qucs-core/bootstrap
@@ -30,22 +30,22 @@ cd `dirname $0`
 
 echo "bootstrapping the qucs-core sources..."
 echo -n "Creating aclocal.m4... "
-${ACLOCAL:-aclocal} -I m4
+${ACLOCAL:-aclocal} -I m4 || exit 1
 echo "done."
 echo -n "Creating config.h.in... "
-${AUTOHEADER:-autoheader}
+${AUTOHEADER:-autoheader} || exit 1
 echo "done."
 echo -n "Libtoolizing... "
 LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}
 case `uname` in
   *Darwin*) LIBTOOLIZE=glibtoolize ;;
 esac
-$LIBTOOLIZE
+$LIBTOOLIZE || exit 1
 echo "done."
 echo -n "Creating Makefile.in(s)... "
-$AUTOMAKE -a -f -c
+$AUTOMAKE -a -f -c || exit 1
 echo "done."
 echo -n "Creating configure... "
-${AUTOCONF:-autoconf}
+${AUTOCONF:-autoconf} || exit 1
 echo "done"
 

--- a/qucs-core/configure.ac
+++ b/qucs-core/configure.ac
@@ -22,7 +22,7 @@ AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
 dnl AM_INIT_AUTOMAKE does several things, including defining VERSION and PACKAGE
-AM_INIT_AUTOMAKE([no-define])
+AM_INIT_AUTOMAKE([1.12 no-define])
 
 AC_PREFIX_DEFAULT([/usr/local])
 test "x$prefix" = xNONE && prefix="/usr/local"


### PR DESCRIPTION
this is related to the ypp->hpp rules, which only newer automakes do
the way we need.

i assume that automake-1.10 causes #512. I DID NOT CHECK (sorry).