### PR TITLE
fix makefile portability

### DIFF
--- a/qucs-core/src/components/verilog/va2cpp.makefile
+++ b/qucs-core/src/components/verilog/va2cpp.makefile
@@ -57,7 +57,7 @@ va2cpp: $(MODEL).cpp
 
 .va.cpp: $(XML_FILES)
 	@echo '# va2cpp - Creating C++ sources.'
-	# BUG: must catch stray spaces in ADMSXML, adding extra quotation
+# BUG: must catch stray spaces in ADMSXML, adding extra quotation
 	"$(ADMSXML)" $< \
                            -I "$(INC)"                    \
                            -e "$(INC)/qucsVersion.xml"    \


### PR DESCRIPTION
This PR contains various fixes for Windows:

1. Fixed `va2cpp` make rules. MinGW32 make tries to execute commented line and Verilog-A modules cannot be compiled
2. Added Octave version checking for Octave >= 4.0.0. Octave>=4.0.0 has GUI enabled by default and cannot start inside Qucs. If version is >=4.0.0 `octave-cli` is forced to start.