### PR TITLE
Introduce a setting to hold Octave executable path

### DIFF
--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -426,7 +426,7 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     homeEdit->setText(QucsSettings.QucsHomeDir.canonicalPath());
     admsXmlEdit->setText(QucsSettings.AdmsXmlBinDir.canonicalPath());
     ascoEdit->setText(QucsSettings.AscoBinDir.canonicalPath());
-    octaveEdit->setText(QucsSettings.OctaveBinDir.canonicalPath());
+    octaveEdit->setText(QucsSettings.OctaveExecutable);
 
 
     resize(300, 200);
@@ -617,7 +617,7 @@ void QucsSettingsDialog::slotApply()
     /*! Update QucsSettings, tool paths */
     QucsSettings.AdmsXmlBinDir = admsXmlEdit->text();
     QucsSettings.AscoBinDir = ascoEdit->text();
-    QucsSettings.OctaveBinDir = octaveEdit->text();
+    QucsSettings.OctaveExecutable = octaveEdit->text();
 
     QucsSettings.IgnoreFutureVersion = checkLoadFromFutureVersions->isChecked();
 
@@ -911,10 +911,8 @@ void QucsSettingsDialog::slotAscoDirBrowse()
 
 void QucsSettingsDialog::slotOctaveDirBrowse()
 {
-  QString d = QFileDialog::getExistingDirectory
-    (this, tr("Select the octave bin directory"),
-     octaveEdit->text(),
-     QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+  QString d = QFileDialog::getOpenFileName(this, tr("Select the octave executable"),
+                                           octaveEdit->text(), "All files (*)");
 
   if(!d.isEmpty())
     octaveEdit->setText(d);

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -101,7 +101,14 @@ bool loadSettings()
     //if(settings.contains("OctaveDir"))QucsSettings.OctaveDir = settings.value("OctaveDir").toString();
     //if(settings.contains("ExamplesDir"))QucsSettings.ExamplesDir = settings.value("ExamplesDir").toString();
     //if(settings.contains("DocDir"))QucsSettings.DocDir = settings.value("DocDir").toString();
-    if(settings.contains("OctaveBinDir"))QucsSettings.OctaveBinDir.setPath(settings.value("OctaveBinDir").toString());
+    if(settings.contains("OctaveExecutable")) {
+        QucsSettings.OctaveExecutable = settings.value("OctaveExecutable").toString();
+    } else {
+        if(settings.contains("OctaveBinDir")) {
+            QucsSettings.OctaveExecutable = settings.value("OctaveBinDir").toString() +
+                    QDir::separator() + "octave" + QString(executableSuffix);
+        } else QucsSettings.OctaveExecutable = "octave" + QString(executableSuffix);
+    }
     if(settings.contains("QucsHomeDir"))
       if(settings.value("QucsHomeDir").toString() != "")
          QucsSettings.QucsHomeDir.setPath(settings.value("QucsHomeDir").toString());
@@ -177,7 +184,8 @@ bool saveApplSettings()
     //settings.setValue("OctaveDir", QucsSettings.OctaveDir);
     //settings.setValue("ExamplesDir", QucsSettings.ExamplesDir);
     //settings.setValue("DocDir", QucsSettings.DocDir);
-    settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
+    // settings.setValue("OctaveBinDir", QucsSettings.OctaveBinDir.canonicalPath());
+    settings.setValue("OctaveExecutable",QucsSettings.OctaveExecutable);
     settings.setValue("QucsHomeDir", QucsSettings.QucsHomeDir.canonicalPath());
     settings.setValue("IgnoreVersion", QucsSettings.IgnoreFutureVersion);
     settings.setValue("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);
@@ -740,20 +748,14 @@ int main(int argc, char *argv[])
         QucsSettings.AscoBinDir.setPath(QucsSettings.BinDir);
   }
 
-  var = getenv("OCTAVEBINDIR");
-  if(var != NULL)  {
-      QucsSettings.OctaveBinDir.setPath(QString(var));
+
+  var = getenv("QUCS_OCTAVE");
+  if (var != NULL) {
+      QucsSettings.QucsOctave = QString(var);
+  } else {
+      QucsSettings.QucsOctave.clear();
   }
-  else  {
-#ifdef __MINGW32__
-      QucsSettings.OctaveBinDir.setPath(QString("C:/Software/Octave-3.6.4/bin/"));
-#else
-      QFile octaveExec("/usr/bin/octave");
-      if(octaveExec.exists())QucsSettings.OctaveBinDir.setPath(QString("/usr/bin/"));
-      QFile octaveExec1("/usr/local/bin/octave");
-      if(octaveExec1.exists()) QucsSettings.OctaveBinDir.setPath(QString("/usr/local/bin/"));
-#endif
-  }
+
   loadSettings();
 
   if(!QucsSettings.BGColor.isValid())

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -63,7 +63,9 @@ struct tQucsSettings {
   QDir QucsHomeDir;
   QDir AdmsXmlBinDir;  // dir of admsXml executable
   QDir AscoBinDir;     // dir of asco executable
-  QDir OctaveBinDir;   // dir of octave executable
+  // QDir OctaveBinDir;   // dir of octave executable
+  QString OctaveExecutable; // OctaveExecutable location
+  QString QucsOctave; // OUCS_OCTAVE variable
 
   // registered filename extensions with program to open the file
   QStringList FileTypes;

--- a/qucs/qucs/octave_window.cpp
+++ b/qucs/qucs/octave_window.cpp
@@ -84,25 +84,15 @@ bool OctaveWindow::startOctave()
   if(octProcess.state()==QProcess::Running)
     return true;
 
-  QString OctavePath=QucsSettings.OctaveBinDir.canonicalPath();
-
-
   QString Program;
   QStringList Arguments;
 
-  OctavePath = QDir::toNativeSeparators(OctavePath+"/"+"octave"+QString(executableSuffix));
+  QString OctavePath = QDir::toNativeSeparators(QucsSettings.OctaveExecutable);
 
-  QFileInfo progOctave(OctavePath);
+  // Override Octave path by enviroment variable if it is set
+  if (QucsSettings.QucsOctave.isEmpty()) Program = OctavePath;
+  else Program = QucsSettings.QucsOctave;
 
-  if (! progOctave.exists()) {
-      qDebug() << "Octave not found: " << OctavePath;
-      QMessageBox::critical(0, QObject::tr("Error"),
-                            QObject::tr("Octave not found in: %1\n\n"
-                                        "Set the Octave location on the application settings.").arg(OctavePath));
-      return false;
-  }
-
-  Program = OctavePath;
   Arguments << "--no-history" << "-i" << "-f" << "-p"
             << QDir::toNativeSeparators(QucsSettings.OctaveDir); // m-files location
 
@@ -124,9 +114,9 @@ bool OctaveWindow::startOctave()
 
   qDebug() << "Command :" << Program << Arguments.join(" ");
   octProcess.start(Program, Arguments);
+  octProcess.waitForStarted();
 
-  if(octProcess.state()!=QProcess::Running&&
-          octProcess.state()!=QProcess::Starting) {
+  if(octProcess.state()!=QProcess::Running) {
     output->setText(tr("ERROR: Cannot start Octave!"));
     return false;
   }


### PR DESCRIPTION
This may be solution for #521. I have modified Octave location setting (using QSettings) to hold executable location instead of Octave directory location. This new setting is fully compatible with previous method. The logic of first Qucs start is following:
1. At first start Qucs tries to load `OctaveExecutable` setting. If is found it loads it.
2. If this setting is not found, Qucs tries to load `OctaveBinDir` setting. If it is found, `OctaveExecutable` will be set as `OctaveBinDir+octave`. 
3. If `OctaveBinDir` is not found (clean installation), `OctaveExecutable` will be initialized by default value.

Also  `OCTAVEBINDIR` environment variable and related hardcoded paths were removed and related GUI controls were corrected.
