### PR TITLE
Fix issue 526

### DIFF
--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -1467,10 +1467,13 @@ void ComponentDialog::slotHHeaderClicked(int headerIdx)
   QString s;
   QTableWidgetItem *cell;
 
-  if (setAllVisible)
+  if (setAllVisible) {
     s = tr("yes");
-  else
+    disp->setChecked(true);
+  } else {
     s = tr("no");
+    disp->setChecked(false);
+  }
 
   // go through all the properties table and set the visibility cell
   for (int row = 0; row < prop->rowCount(); row++) {

--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -379,25 +379,21 @@ ComponentDialog::ComponentDialog(Component *c, Schematic *d)
   // keep group above together
   v1->addStretch(5);
 
-  QHBoxLayout *h4 = new QHBoxLayout;
-  v1->addLayout(h4);
-  h4->setSpacing(5);
+  QGridLayout *bg = new QGridLayout;
+  v1->addLayout(bg);
   ButtAdd = new QPushButton(tr("Add"));
-  h4->addWidget(ButtAdd);
+  bg->addWidget(ButtAdd, 0, 0);
   ButtAdd->setEnabled(false);
   ButtRem = new QPushButton(tr("Remove"));
-  h4->addWidget(ButtRem);
+  bg->addWidget(ButtRem, 0, 1);
   ButtRem->setEnabled(false);
   connect(ButtAdd, SIGNAL(clicked()), SLOT(slotButtAdd()));
   connect(ButtRem, SIGNAL(clicked()), SLOT(slotButtRem()));
-
   // Buttons to move equations up/down on the list
-  QHBoxLayout *hUpDown = new QHBoxLayout;
-  v1->addLayout(hUpDown);
   ButtUp = new QPushButton(tr("Move Up"));
-  hUpDown->addWidget(ButtUp);
+  bg->addWidget(ButtUp, 1, 0);
   ButtDown = new QPushButton(tr("Move Down"));
-  hUpDown->addWidget(ButtDown);
+  bg->addWidget(ButtDown, 1, 1);
   connect(ButtUp,   SIGNAL(clicked()), SLOT(slotButtUp()));
   connect(ButtDown, SIGNAL(clicked()), SLOT(slotButtDown()));
 

--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -718,7 +718,7 @@ void ComponentDialog::slotApplyProperty()
 //        item->setText(0, "Export_");   // name must not be "Export" !!!
 //      else
 //      item->setText(0, NameEdit->text());  // apply property name
-      prop->item(row, 0)->setText(edit->text());
+      prop->item(row, 0)->setText(NameEdit->text());
     }
 
   // step to next item

--- a/qucs/qucs/components/componentdialog.h
+++ b/qucs/qucs/components/componentdialog.h
@@ -77,6 +77,7 @@ private slots:
 
 protected slots:
     void reject();
+    bool eventFilter(QObject *obj, QEvent *event);
 
 private:
   QVBoxLayout *all;   // the mother of all widgets


### PR DESCRIPTION
- the first commit is a fix for #526: apparently a copy/paste error was made during the conversion to Qt4 in e4d02f60bfab9b7c15804467b3dae83a23baf6e6
- the other commits are just "nice to have" or cosmetic stuff, feel free to skip and/or put in `develop`
  - one is for making "Enter" always advance to the next property, also for properties whose values is selected using a ComboBox. Until now pressing Enter for these properties did nothing.
 - one for a (better?) alignment of buttons
 - last one fixes a small sync issue between a property visibility status and the corresponding checkbox
