### PR TITLE
Fix for #479 (Octave window Ctrl-c)

### DIFF
--- a/qucs/qucs/octave_window.cpp
+++ b/qucs/qucs/octave_window.cpp
@@ -57,6 +57,7 @@ OctaveWindow::OctaveWindow(QDockWidget *parent_): QWidget()
   histPosition = 0;
 
   input->installEventFilter(this);
+  output->installEventFilter(this);
 }
 
 // -----------------------------------------------------------------
@@ -175,8 +176,18 @@ void OctaveWindow::slotSendCommand()
 
 
 bool OctaveWindow::eventFilter(QObject *obj, QEvent *event) {
-    Q_UNUSED(obj);
-
+  if (obj == output) {
+    // handle Ctrl-C (copy) for the output TextEdit as it seems
+    // not to be handled when it is set ReadOnly and a global
+    // action for Ctrl-C is set
+    if (event->type() == QEvent::KeyRelease) {
+      QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+      if (keyEvent->matches(QKeySequence::Copy)) {
+        output->copy();
+        return true; // no need to pass this event to the target
+      }
+    }
+  }
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
             if (keyEvent->key() == Qt::Key_PageUp) {

--- a/qucs/qucs/octave_window.cpp
+++ b/qucs/qucs/octave_window.cpp
@@ -39,9 +39,10 @@ OctaveWindow::OctaveWindow(QDockWidget *parent_): QWidget()
   output = new QTextEdit(this);
   output->setReadOnly(true);
   output->setUndoRedoEnabled(false);
-  output->setTextFormat(Qt::LogText);
   output->setLineWrapMode(QTextEdit::NoWrap);
-  output->setPaletteBackgroundColor(QucsSettings.BGColor);
+  QPalette p = output->palette();
+  p.setColor(QPalette::Base, QucsSettings.BGColor);
+  output->setPalette(p);
   allLayout->addWidget(output);
 
   input = new QLineEdit(this);
@@ -139,7 +140,7 @@ bool OctaveWindow::startOctave()
 // ------------------------------------------------------------------------
 void OctaveWindow::adjustDirectory()
 {
-  sendCommand("cd \"" + QucsSettings.QucsWorkDir.absPath() + "\"");
+  sendCommand("cd \"" + QucsSettings.QucsWorkDir.absolutePath() + "\"");
 }
 
 // ------------------------------------------------------------------------
@@ -152,14 +153,14 @@ void OctaveWindow::sendCommand(const QString& cmd)
   QString cmdstr = cmd + "\n";
   //output->insertAt(cmdstr, par, idx);
   //output->scrollToBottom();
-  octProcess.write(cmdstr);
+  octProcess.write(cmdstr.toAscii());
 }
 
 // ------------------------------------------------------------------------
 void OctaveWindow::runOctaveScript(const QString& name)
 {
   QFileInfo info(name);
-  sendCommand(info.baseName(true));
+  sendCommand(info.completeBaseName());
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
Fix/hack for #479. It seems to work _most_ of the times.

There is still something not quite right, but I cannot find where; there is a global `QAction()` defined for `Ctrl-C` in the main application and this seems to handle the `Ctrl-C` keypress event before the `QTextEdit()` used to show the Octave output **if the `QTextEdit()` is set as read only** (as it should be). If it is not set as read-only, the `Ctrl-C` works as expected and the global `QAction()` is not called when `Ctrl-C` is pressed.
If the the global `QAction()` for `Ctrl-C` is removed, everything is fine also when the `QTextEdit()` is set as read only.

I have added an `EventFilter()` so that `Ctrl-C` calls the `QTextEdit()` `copy()` function; the global `QAction()` is still called first, but apparently with no side effects.

Better solutions are of course welcome; if someone wouold like to investigate further, a minimalist example showing the above issues can be found [here](https://gist.github.com/in3otd/5ba31f80721a03b3a941ac42ac9b7fc2)
