### PR TITLE
Fix crash in Octave window is Page Down was pressed with empty history

### DIFF
--- a/qucs/qucs/octave_window.cpp
+++ b/qucs/qucs/octave_window.cpp
@@ -190,7 +190,8 @@ bool OctaveWindow::eventFilter(QObject *obj, QEvent *event) {
             }
             else if(keyEvent->key() == Qt::Key_PageDown) {
                 //if(histIterator == cmdHistory.end())
-                if(histPosition == cmdHistory.length()-1)
+                if ((histPosition == cmdHistory.length()-1) ||
+                    cmdHistory.isEmpty())
                     return false;
                 //histIterator++;
                 histPosition++;


### PR DESCRIPTION
While working on #527 I noticed that if Page Down was pressed in the Octave command window edit line before any command was entered (so the command history was empty) Qucs crashed.
This is due to the command history pointer being advanced without checking if there were actually any command in the command history.