### PR TITLE
Fix build failure and add more build dependencies in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ First make sure you have all dependencies installed:
     sudo apt-get install build-essential
     sudo apt-get install libqt4-dev libqt4-qt3support
     sudo apt-get install automake libtool gperf flex bison
+    sudo apt-get install texlive-font-utils octave-epstk
 
 The ADMS package is necessary. Please [download](https://sourceforge.net/projects/mot-adms/files/adms-source/) the latest tarball and follow the [install](https://github.com/Qucs/ADMS#users-install-from-tarball) instructions. Having`admsXml` on the path should be sufficient.
 

--- a/qucs-core/src/logging.h
+++ b/qucs-core/src/logging.h
@@ -28,6 +28,8 @@
 #define LOG_ERROR  0
 #define LOG_STATUS 1
 
+#include <stdio.h>
+
 __BEGIN_DECLS
 
 void logprint (int, const char *, ...);


### PR DESCRIPTION
Without the #include fix, the build of qucs fails on Debian which has GCC/G++  5.4.