### PR TITLE
Fix for #541 and #543

### DIFF
--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -602,7 +602,8 @@ void ComponentDialog::slotSelectProperty(QTableWidgetItem *item)
     ButtAdd->setEnabled(true);
     ButtRem->setEnabled(true);
 
-    if (Comp->Description == "equation") {
+    // enable Up/Down buttons only for the Equation component
+    if (Comp->Model == "Eqn") {
       ButtUp->setEnabled(true);
       ButtDown->setEnabled(true);
     }

--- a/qucs/qucs/module.h
+++ b/qucs/qucs/module.h
@@ -47,8 +47,8 @@ class Module
   static void unregisterModules (void);
 
  public:
-  pInfoFunc info;
-  pInfoVAFunc infoVA;
+  pInfoFunc info = 0;
+  pInfoVAFunc infoVA = 0;
   QString category;
 };
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -621,7 +621,6 @@ void QucsApp::slotSetCompView (int index)
   editText->setHidden (true); // disable text edit of component property
 
   QList<Module *> Comps;
-  CompComps->clear ();   // clear the IconView
   if (CompChoose->count () <= 0) return;
 
   // was in "search mode" ?
@@ -629,9 +628,10 @@ void QucsApp::slotSetCompView (int index)
     if (index == 0) // user selected "Search results" item
       return;
     CompChoose->removeItem(0);
-    CompSearch->clear();
+    CompSearch->clear(); // clear the search box
     --index; // adjust requested index since item 0 was removed
   }
+  CompComps->clear ();   // clear the IconView
 
   // make sure the right index is selected
   //  (might have been called by a cleared search and not by user action)

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -732,6 +732,7 @@ void QucsApp::slotSearchComponent(const QString &searchText)
   if (searchText.isEmpty()) {
     slotSetCompView(CompChoose->currentIndex());
   } else {
+    CompChoose->setCurrentIndex(0); // make sure the "Search results" category is selected
     editText->setHidden (true); // disable text edit of component property
 
     //traverse all component and match searchText with name

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -600,6 +600,7 @@ void QucsApp::fillComboBox (bool setAll)
 {
   //CompChoose->setMaxVisibleItems (13); // Increase this if you add items below.
   CompChoose->clear ();
+  CompSearch->clear(); // clear the search box, in case search was active...
 
   if (!setAll) {
     CompChoose->insertItem(CompChoose->count(), QObject::tr("paintings"));


### PR DESCRIPTION
Fix for #541 and #543 .

- for #541: Up/Down buttons in the Component Properties dialog for reordering the equations in the Equation component are enabled looking at the component Model field and not at its description

- for #543 : now every component icon in the Components tab has associated information about the the component it represents, so this can be retrieved directly when the icon is selected. Previously the association was based only on the selected category and icon position in the IconView tab. This allows to show in the IconView icons of components belonging to different categories and easily retrieve the associated component.