### PR TITLE
Fix for #541 - use Model field to identify the Equation component

### DIFF
--- a/qucs/qucs/components/componentdialog.cpp
+++ b/qucs/qucs/components/componentdialog.cpp
@@ -602,7 +602,8 @@ void ComponentDialog::slotSelectProperty(QTableWidgetItem *item)
     ButtAdd->setEnabled(true);
     ButtRem->setEnabled(true);
 
-    if (Comp->Description == "equation") {
+    // enable Up/Down buttons only for the Equation component
+    if (Comp->Model == "Eqn") {
       ButtUp->setEnabled(true);
       ButtDown->setEnabled(true);
     }


### PR DESCRIPTION
The Up/Down buttons in the Component Properties dialog for reordering the equations in the Equation component are now enabled looking at the component Model field and not at its textual description, so it works independently of the selected language for the GUI.

As said elsewhere, it certainly not future proof and there are currently a lot of other places where the component Model field is used to identify a particular component.
