### PR TITLE
Issue 543 fix

### DIFF
--- a/qucs/qucs/module.h
+++ b/qucs/qucs/module.h
@@ -47,8 +47,8 @@ class Module
   static void unregisterModules (void);
 
  public:
-  pInfoFunc info;
-  pInfoVAFunc infoVA;
+  pInfoFunc info = 0;
+  pInfoVAFunc infoVA = 0;
   QString category;
 };
 

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -621,7 +621,6 @@ void QucsApp::slotSetCompView (int index)
   editText->setHidden (true); // disable text edit of component property
 
   QList<Module *> Comps;
-  CompComps->clear ();   // clear the IconView
   if (CompChoose->count () <= 0) return;
 
   // was in "search mode" ?
@@ -629,9 +628,10 @@ void QucsApp::slotSetCompView (int index)
     if (index == 0) // user selected "Search results" item
       return;
     CompChoose->removeItem(0);
-    CompSearch->clear();
+    CompSearch->clear(); // clear the search box
     --index; // adjust requested index since item 0 was removed
   }
+  CompComps->clear ();   // clear the IconView
 
   // make sure the right index is selected
   //  (might have been called by a cleared search and not by user action)

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -732,6 +732,7 @@ void QucsApp::slotSearchComponent(const QString &searchText)
   if (searchText.isEmpty()) {
     slotSetCompView(CompChoose->currentIndex());
   } else {
+    CompChoose->setCurrentIndex(0); // make sure the "Search results" category is selected
     editText->setHidden (true); // disable text edit of component property
 
     //traverse all component and match searchText with name

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -600,6 +600,7 @@ void QucsApp::fillComboBox (bool setAll)
 {
   //CompChoose->setMaxVisibleItems (13); // Increase this if you add items below.
   CompChoose->clear ();
+  CompSearch->clear(); // clear the search box, in case search was active...
 
   if (!setAll) {
     CompChoose->insertItem(CompChoose->count(), QObject::tr("paintings"));


### PR DESCRIPTION
Fix for #543. 
Now every component icon in the Components tab has associated information about the the component it represents, so the component can be retrieved directly when the icon is selected. 

Previously the association was based only on the selected category and icon position in the IconView tab. If the icon position did not correspond to the component position in its category (as it was for the "Search Results" category) it was not possible to unequivocally retrieve the component corresponding to a particular icon. The components corresponding to the icons which were put in the "Search Results" view were identified only looking at their description and this did work with components having the same description (e.g. `n-MOSFET` is used as description for bot the 3-terminal MOS and the 4-terminal (with substrate) one.

The last 3 commits are small fixes for the "component search" functions, while I was at it.
