### PR TITLE
[CI] Qt install error, set OSX to version 10.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ install:
       brew link --force flex;
       brew install bison;
       brew link --force bison;
+      brew install python;
       pip install matplotlib;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ python:
 virtualenv:
   system_site_packages: true
 
+# Force OSX 10.10 as Qt 4.8.7 installer does not work with OSX 10.11
+osx_image: xcode7.1
+
 matrix:
   exclude:
     - os: osx


### PR DESCRIPTION
The Qt 4.8.7 installer no longer works with OSX 10.11.
https://forum.qt.io/topic/60173/install-qt-4-8-7-on-a-mac-running-os-x-10-11-el-capitan

Force Travis to use OSX 10.10.
https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version