### PR TITLE
Fix for issues #550 and #553

### DIFF
--- a/qucs-core/src/logging.c
+++ b/qucs-core/src/logging.c
@@ -26,7 +26,7 @@
 # include <config.h>
 #endif
 
-#include <stdio.h>
+
 #include <stdlib.h>
 #include <stdarg.h>
 

--- a/qucs-core/src/logging.h
+++ b/qucs-core/src/logging.h
@@ -27,7 +27,7 @@
 
 #define LOG_ERROR  0
 #define LOG_STATUS 1
-
+#include <stdio.h>
 __BEGIN_DECLS
 
 void logprint (int, const char *, ...);

--- a/qucs/qucs-lib/qucslib.cpp
+++ b/qucs/qucs-lib/qucslib.cpp
@@ -48,7 +48,6 @@
 #include "displaydialog.h"
 #include "symbolwidget.h"
 
-
 /* Constructor setups the GUI. */
 QucsLib::QucsLib()
 {
@@ -112,6 +111,7 @@ QucsLib::QucsLib()
     CompList = new QListWidget();
     connect(CompList, SIGNAL(itemActivated(QListWidgetItem*)), SLOT(slotShowComponent(QListWidgetItem*)));
     connect(CompList,SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)),SLOT(slotShowComponent(QListWidgetItem*)));
+    connect(CompList, SIGNAL(itemClicked(QListWidgetItem*)), SLOT(slotShowComponent(QListWidgetItem*)));
 
     CompSearch = new QLineEdit(this);
     CompSearch->setPlaceholderText(tr("Search Lib Components"));
@@ -458,7 +458,6 @@ void QucsLib::slotSearchClear()
 // ----------------------------------------------------
 void QucsLib::slotShowComponent(QListWidgetItem *Item)
 {
-
     if(!Item) return;
 
     //QString CompString = LibraryComps.at(CompList->index(Item));
@@ -467,6 +466,7 @@ void QucsLib::slotShowComponent(QListWidgetItem *Item)
     CompDescr->setText("Name: " + Item->text());
     CompDescr->append("Library: " + LibName);
     CompDescr->append("----------------------------");
+
 
     // FIXME: here we assume that LibName is the same as the actual filename...
     int i = Library->findText(LibName);
@@ -510,11 +510,11 @@ void QucsLib::slotShowComponent(QListWidgetItem *Item)
         QMessageBox::critical(this, tr("Error"), tr("Library is corrupt."));
         return;
     }
-    if(!content.isEmpty())
-        Symbol->setSymbol(content, LibName, Item->text());
-    else if(!DefaultSymbol.isEmpty())   // has library a default symbol ?
-        Symbol->setSymbol(DefaultSymbol, LibName, Item->text());
 
+
+    Symbol->setSymbol(content, LibName, Item->text());
+
+      
     // change currently selected category, so the user will 
     //   learn where the component comes from
     Library->setCurrentIndex(i);

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -360,6 +360,29 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
 int SymbolWidget::setSymbol( QString& SymbolString,
                             const QString& Lib_, const QString& Comp_)
 {
+  if (SymbolString.isEmpty())//Whenever SymbolString is empty, it tries to load the default symbol
+  {
+      //Load the default symbol for the current Qucs library
+      ComponentLibrary parsedlib;
+      QString libpath = QucsSettings.LibDir + Lib_ + ".lib";
+      int result = parseComponentLibrary (libpath, parsedlib);
+
+      switch (result)//Check if the library was properly loaded
+      {
+        case QUCS_COMP_LIB_IO_ERROR:
+            QMessageBox::critical(0, tr ("Error"), tr("Cannot open \"%1\".").arg (libpath));
+            return -1;
+        case QUCS_COMP_LIB_CORRUPT:
+            QMessageBox::critical(0, tr("Error"), tr("Library is corrupt."));
+            return -1;
+        default:
+            break;
+      }
+
+    // copy the contents of default symbol section to a string
+    SymbolString = parsedlib.defaultSymbol;
+  }
+
   Arcs.clear();
   Lines.clear();
   Rects.clear();

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -27,6 +27,7 @@
 #include <QList>
 #include <QMouseEvent>
 #include <QPaintEvent>
+#include <QMessageBox>
 
 #include "element.h"
 


### PR DESCRIPTION
It was found that QucsLib tool didn't update neither the default
symbol nor the name/library of the selected component.

LoadDefaultSymbol() was removed and its code was placed where the
function was called.

The code for reloading the default symbol was moved to SymbolWidget
class.