### PR TITLE
Fix components category change when not in search mode

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -894,13 +894,17 @@ void QucsApp::slotSelectComponent(QListWidgetItem *item)
       view->selElem = (*InfosVA) (CompName, CompFile_qstr, true, filename);
     }
   }
-  if (Infos || InfosVA) {
-    // change currently selected category, so the user will
-    //   see where the component comes from
-    CompChoose->setCurrentIndex(iconCompInfo.catIdx+1); // +1 due to the added "Search Results" item
-    ccCurIdx = iconCompInfo.catIdx; // remember the category to select when exiting search
-    //!! comment out the above two lines if you would like that the search
-    //!!   returns back to the last selected category instead
+
+  // in "search mode" ?
+  if (CompChoose->itemText(0) == tr("Search results")) {
+    if (Infos || InfosVA) {
+      // change currently selected category, so the user will
+      //   see where the component comes from
+      CompChoose->setCurrentIndex(iconCompInfo.catIdx+1); // +1 due to the added "Search Results" item
+      ccCurIdx = iconCompInfo.catIdx; // remember the category to select when exiting search
+      //!! comment out the above two lines if you would like that the search
+      //!!   returns back to the last selected category instead
+    }
   }
 }
 


### PR DESCRIPTION
Fix for #586; when a component was selected in the components tab the shown category was always changed to the following one. This was a side effect of not checking if a component search was ongoing.

Seems to work correctly here but checked only quickly, please double check.

