### PR TITLE
Fixed issue #591

### DIFF
--- a/qucs/qucs-lib/main.cpp
+++ b/qucs/qucs-lib/main.cpp
@@ -35,6 +35,7 @@
 
 tQucsSettings QucsSettings;
 QDir UserLibDir;
+QDir SysLibDir;
 
 
 // #########################################################################
@@ -115,6 +116,7 @@ int main(int argc, char *argv[])
 
   loadSettings();
 
+  SysLibDir.setPath(QucsSettings.LibDir);
   UserLibDir.setPath(QucsSettings.QucsHomeDir.canonicalPath() + "/user_lib/");
 
   a.setFont(QucsSettings.font);

--- a/qucs/qucs-lib/qucslib.cpp
+++ b/qucs/qucs-lib/qucslib.cpp
@@ -318,7 +318,6 @@ void QucsLib::slotSelectLibrary(int Index)
 
     CompList->clear ();
     LibraryComps.clear ();
-    DefaultSymbol = "";
 
     QString filename;
 
@@ -346,9 +345,6 @@ void QucsLib::slotSelectLibrary(int Index)
         default:
             break;
     }
-
-    // copy the contents of default symbol section to a string
-    DefaultSymbol = parsedlib.defaultSymbol;
 
     // Now go through the rest of the component library, extracting each
     // component name
@@ -429,7 +425,6 @@ void QucsLib::slotSearchComponent(const QString &searchText)
       // does search criterion match ?
       if(CompName.indexOf(searchText, 0, Qt::CaseInsensitive) >= 0) {
         if(!findComponent) {
-	  DefaultSymbol = "";
 	  CompList->clear();
 	  LibraryComps.clear();
         }
@@ -488,8 +483,6 @@ void QucsLib::slotShowComponent(QListWidgetItem *Item)
         return;
     }
     Symbol->ModelString = content;
-    if(Symbol->ModelString.count('\n') < 2)
-        Symbol->createSymbol(LibName, Item->text());
 
     if(!getSection("VHDLModel", CompString, content))
     {
@@ -510,8 +503,6 @@ void QucsLib::slotShowComponent(QListWidgetItem *Item)
         QMessageBox::critical(this, tr("Error"), tr("Library is corrupt."));
         return;
     }
-
-
     Symbol->setSymbol(content, LibName, Item->text());
 
       

--- a/qucs/qucs-lib/qucslib.h
+++ b/qucs/qucs-lib/qucslib.h
@@ -45,6 +45,7 @@ struct tQucsSettings {
 
 extern tQucsSettings QucsSettings;
 extern QDir UserLibDir;
+extern QDir SysLibDir;
 
 class QucsLib : public QMainWindow  {
    Q_OBJECT

--- a/qucs/qucs-lib/qucslib.h
+++ b/qucs/qucs-lib/qucslib.h
@@ -53,7 +53,6 @@ public:
   ~QucsLib();
 
   QListWidget *CompList;
-  QStringList   LibraryComps;
   QComboBox    *Library;
 
 private slots:

--- a/qucs/qucs-lib/qucslib.h
+++ b/qucs/qucs-lib/qucslib.h
@@ -55,7 +55,6 @@ public:
   QListWidget *CompList;
   QStringList   LibraryComps;
   QComboBox    *Library;
-  QString DefaultSymbol;
 
 private slots:
   void slotAbout();

--- a/qucs/qucs-lib/qucslib_common.h
+++ b/qucs/qucs-lib/qucslib_common.h
@@ -31,6 +31,9 @@ enum LIB_PARSE_RESULT { QUCS_COMP_LIB_OK,
                         QUCS_COMP_LIB_CORRUPT,
                         QUCS_COMP_LIB_EMPTY };
 
+enum LIB_PARSE_WHAT { QUCS_COMP_LIB_HEADER_ONLY,
+                      QUCS_COMP_LIB_FULL };
+
 struct ComponentLibraryItem
 {
     QString name;
@@ -47,7 +50,7 @@ struct ComponentLibrary
 } ;
 
 
-// gets the contents of a section from a coponent description
+// gets the contents of a section from a component description
 //
 // sections are between <secname> </secname> pairs
 inline bool getSection(QString section, QString &list, QString &content)
@@ -209,7 +212,7 @@ inline int makeModelString (QString libname, QString compname, QString compstrin
 
 }
 
-inline int parseComponentLibrary (QString filename, ComponentLibrary &library)
+inline int parseComponentLibrary (QString filename, ComponentLibrary &library, LIB_PARSE_WHAT what = QUCS_COMP_LIB_FULL)
 {
 
     int Start, End, NameStart, NameEnd;
@@ -226,8 +229,8 @@ inline int parseComponentLibrary (QString filename, ComponentLibrary &library)
     QString LibraryString = ReadWhole.readAll();
     file.close();
 
-	LibraryString.replace(QRegExp("\\r\\n"), "\n");
-	
+    LibraryString.replace(QRegExp("\\r\\n"), "\n");
+
     // The libraries have a header statement like the following:
     //
     // <Qucs Library 0.0.18 "libname">
@@ -271,6 +274,12 @@ inline int parseComponentLibrary (QString filename, ComponentLibrary &library)
         // copy the contents of default symbol section to a string
         library.defaultSymbol = LibraryString.mid(Start+16, End-Start-16);
         Start = End + 3;
+    }
+
+    if (what == QUCS_COMP_LIB_HEADER_ONLY)
+    {
+        // only the header was requested, stop here
+        return QUCS_COMP_LIB_OK;
     }
 
     // Now go through the rest of the component library, extracting each

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -384,6 +384,8 @@ int SymbolWidget::setSymbol( QString& SymbolString,
     SymbolString = parsedlib.defaultSymbol;
   }
 
+  if (SymbolString.isEmpty()) return 0;
+
   Arcs.clear();
   Lines.clear();
   Rects.clear();

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -364,7 +364,8 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   {
       //Load the default symbol for the current Qucs library
       ComponentLibrary parsedlib;
-      QString libpath = QucsSettings.LibDir + Lib_ + ".lib";
+      QDir libdir(QucsSettings.LibDir); // resolve system library paths
+      QString libpath = libdir.absoluteFilePath(Lib_ + ".lib");
       int result = parseComponentLibrary (libpath, parsedlib);
 
       switch (result)//Check if the library was properly loaded

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -371,15 +371,16 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   {
       //Load the default symbol for the current Qucs library
       ComponentLibrary parsedlib;
-      QDir libdir(QucsSettings.LibDir); // resolve system library paths
-      QString libpath = libdir.absoluteFilePath(Lib_ + ".lib");
-      int result = parseComponentLibrary (libpath, parsedlib);
+      int result = parseComponentLibrary (Lib_, parsedlib, QUCS_COMP_LIB_HEADER_ONLY); // need just the default symbol
 
       switch (result)//Check if the library was properly loaded
       {
         case QUCS_COMP_LIB_IO_ERROR:
-            QMessageBox::critical(0, tr ("Error"), tr("Cannot open \"%1\".").arg (libpath));
+        {
+            QString filename = getLibAbsPath(Lib_);
+            QMessageBox::critical(0, tr ("Error"), tr("Cannot open \"%1\".").arg (filename));
             return -1;
+        }
         case QUCS_COMP_LIB_CORRUPT:
             QMessageBox::critical(0, tr("Error"), tr("Library is corrupt."));
             return -1;

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -81,7 +81,7 @@ QString SymbolWidget::theModel()
   return "<Lib " + Prefix + " 1 0 0 " +
          QString::number(Text_x) + " " +
          QString::number(Text_y) + " 0 0 \"" +
-         LibraryName + "\" 0 \"" + ComponentName + "\" 0>";
+         LibraryPath + "\" 0 \"" + ComponentName + "\" 0>";
 }
 
 // ************************************************************
@@ -168,7 +168,7 @@ int SymbolWidget::createStandardSymbol(const QString& Lib_, const QString& Comp_
   Rects.clear();
   Ellips.clear();
   Texts.clear();
-  LibraryName = Lib_;
+  LibraryPath = Lib_;
   ComponentName = Comp_;
 
   Warning.clear();
@@ -398,7 +398,7 @@ int SymbolWidget::setSymbol( QString& SymbolString,
   Rects.clear();
   Ellips.clear();
   Texts.clear();
-  LibraryName = Lib_;
+  LibraryPath = Lib_;
   ComponentName = Comp_;
 
   QString Line;

--- a/qucs/qucs-lib/symbolwidget.cpp
+++ b/qucs/qucs-lib/symbolwidget.cpp
@@ -156,12 +156,12 @@ void SymbolWidget::paintEvent(QPaintEvent*)
 }
 
 /*!
- * \brief Creates a symbol from the model name of a component.
+ * \brief Creates a symbol from the model name of a standard component.
  * \param Lib_
  * \param Comp_
  * \return number of symbol ports
  */
-int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
+int SymbolWidget::createStandardSymbol(const QString& Lib_, const QString& Comp_)
 {
   Arcs.clear();
   Lines.clear();
@@ -352,6 +352,8 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
 
 /*!
  * \brief Loads the symbol for the component from the symbol field
+ *        or create a default symbol for a standard component
+ *        or use the library default symbol if the component does not define one
  * \param SymbolString
  * \param Lib_
  * \param Comp_
@@ -360,6 +362,11 @@ int SymbolWidget::createSymbol(const QString& Lib_, const QString& Comp_)
 int SymbolWidget::setSymbol( QString& SymbolString,
                             const QString& Lib_, const QString& Comp_)
 {
+  Warning.clear(); // clear any message possibly previously set by createStandardSymbol()
+
+  if(ModelString.count('\n') < 2) // single-line model: is a standard component
+      return createStandardSymbol(Lib_, Comp_);  // build symbol from component type
+
   if (SymbolString.isEmpty())//Whenever SymbolString is empty, it tries to load the default symbol
   {
       //Load the default symbol for the current Qucs library
@@ -384,7 +391,7 @@ int SymbolWidget::setSymbol( QString& SymbolString,
     SymbolString = parsedlib.defaultSymbol;
   }
 
-  if (SymbolString.isEmpty()) return 0;
+  if (SymbolString.isEmpty()) return -1; // should not happen...
 
   Arcs.clear();
   Lines.clear();

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -47,7 +47,6 @@ public:
 
   QString theModel();
   int setSymbol( QString&, const QString&, const QString&);
-  int createSymbol(const QString&, const QString&);
 
   // component properties
   int Text_x, Text_y;
@@ -58,6 +57,8 @@ protected:
   void mouseMoveEvent(QMouseEvent*);
 
 private:
+  int createStandardSymbol(const QString&, const QString&);
+
   void  paintEvent(QPaintEvent*);
 
   int  analyseLine(const QString&);

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -50,7 +50,7 @@ public:
 
   // component properties
   int Text_x, Text_y;
-  QString Prefix, LibraryName, ComponentName;
+  QString Prefix, LibraryPath, ComponentName;
   QString ModelString, VerilogModelString, VHDLModelString;
 
 protected:


### PR DESCRIPTION
I have added quick fix for #591. Library name is checked is it relative (system libraries) or absolute (user libraries). It will allow to process user libraries in `SymbolWidget::setSymbol()` method. Otherwise we always have an error when trying to process user library which is defined by absolute path.  