### PR TITLE
BSIM6 and other XML fixes

### DIFF
--- a/qucs-core/src/components/verilog/analogfunction.xml
+++ b/qucs-core/src/components/verilog/analogfunction.xml
@@ -1027,14 +1027,17 @@ inline double _d0_vt(double)               { return 1.3806503e-23/1.602176462e-1
     <admst:apply-templates select="." match="v2c:converttype"/><admst:text format=" %s"/>
   </admst:join>)
 <admst:text format="\n{\n"/>
-<admst:text format="double $function=0.0;\n"/>
+<admst:text format="double $function=0.0; (void) $function;\n"/> <!-- silence unused warning -->
   <admst:for-each select="variable[input='no' and output='no']">
     <admst:value-of select="name"/>
     <admst:apply-templates select="." match="v2c:converttype"/>
     <admst:text format=" %s"/>
     <admst:if test="[type='integer']">=0</admst:if>
     <admst:if test="[type='real']">=0.0</admst:if>
-    <admst:text format=";\n"/>
+    <admst:text format="; "/>
+    <!-- silence unused warning -->
+    <admst:value-of select="name"/>
+    <admst:text format=" (void) %s;\n"/>
   </admst:for-each>
   <admst:apply-templates select="tree" match="af:print">
     <admst:value-of select="returned('x')/value"/>
@@ -1049,7 +1052,7 @@ double $(module)_d_$(function) (<admst:join select="variable[input='yes']" separ
     <admst:apply-templates select="." match="v2c:converttype"/><admst:text format=" d_%s"/>
   </admst:join>)
 <admst:text format="\n{\n"/>
-<admst:text format="double $function=0.0;\n"/>
+<admst:text format="double $function=0.0; (void) $function;\n"/> <!-- silence unused warning -->
   <admst:for-each select="$globalanalogfunction/variable[input='yes']">
     <admst:value-of select="name"/>
     <admst:variable name="ddx" select="%s"/>
@@ -1062,7 +1065,8 @@ double $(module)_d_$(function) (<admst:join select="variable[input='yes']" separ
     <admst:text format=" $(name)"/>
     <admst:if test="[type='integer']">=0</admst:if>
     <admst:if test="[type='real']">=0.0</admst:if>
-    <admst:text format=";\n"/>
+    <admst:text format=";"/>
+    <admst:text format=" (void) $(name);\n"/>  <!-- silence unused warning -->
     <admst:for-each select="$globalanalogfunction/variable[input='yes']">
       <admst:value-of select="name"/>
       <admst:variable name="ddx" select="%s"/>
@@ -1070,7 +1074,8 @@ double $(module)_d_$(function) (<admst:join select="variable[input='yes']" separ
       <admst:text format=" $(name)_$(ddx)"/>
       <admst:if test="[type='integer']">=0</admst:if>
       <admst:if test="[type='real']">=0.0</admst:if>
-      <admst:text format=";\n"/>
+      <admst:text format=";"/>
+      <admst:text format=" (void) $(name)_$(ddx);\n"/>  <!-- silence unused warning -->
     </admst:for-each>
   </admst:for-each>
   <admst:apply-templates select="tree" match="af:print:derivate">

--- a/qucs-core/src/components/verilog/qucsMODULEcore.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEcore.xml
@@ -425,6 +425,7 @@ using qucs::matrix;
 <admst:text format="/* Evaluate Verilog-AMS equations in analog block. */\n"/>
 <admst:text format="void $module::calcVerilog (void)\n{\n"/>
 /* ----------------- evaluate verilog analog equations -------------------- */
+// Note: (void) NAME; is used to silence warnings about unused variables.
 <admst:text format="\n"/>
 
 <admst:apply-templates select="analog/code" match="analog:evaluate"/>

--- a/qucs-core/src/components/verilog/qucsMODULEdefs.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEdefs.xml
@@ -59,6 +59,59 @@
   <admst:apply-templates select="arg1" match=":%s" required="yes"/>
 </admst:template>
 
+<!-- Handle mapply_ternary on parameter definition, see bsim6 model -->
+<admst:template match="aamapply_ternary">
+     <admst:if test="[name='conditional']">
+             <admst:apply-templates select="arg1" match=":%(datatypename)" required="yes"/>
+             <admst:apply-templates select="arg2" match=":%(datatypename)" required="yes"/>
+             <admst:apply-templates select="arg3" match=":%(datatypename)" required="yes"/>
+     </admst:if>
+</admst:template>
+
+<admst:template match=":mapply_binary">
+  <admst:text format="("/>
+  <admst:apply-templates select="arg1" match=":%(adms/datatypename)" required="yes"/>
+  <admst:if test="[name='bw_or']"> <admst:text format="|"/> </admst:if>
+  <admst:if test="[name='bw_and']"> <admst:text format="&amp;"/> </admst:if>
+  <admst:if test="[name='addp']"> <admst:text format="+"/> </admst:if>
+  <admst:if test="[name='addm']"> <admst:text format="-"/> </admst:if>
+  <admst:if test="[name='multtime']"> <admst:text format="*"/> </admst:if>
+  <admst:if test="[name='multdiv']"> <admst:text format="/"/> </admst:if>
+  <admst:if test="[name='and']"> <admst:text format="&amp;&amp;"/> </admst:if>
+  <admst:if test="[name='equ']"> <admst:text format="=="/> </admst:if>
+  <admst:if test="[name='gt']"> <admst:text format="&gt;"/> </admst:if>
+  <admst:if test="[name='gt_equ']"> <admst:text format="&gt;="/> </admst:if>
+  <admst:if test="[name='lt']"> <admst:text format="&lt;"/> </admst:if>
+  <admst:if test="[name='lt_equ']"> <admst:text format="&lt;="/> </admst:if>
+  <admst:if test="[name='notequ']"> <admst:text format="!="/> </admst:if>
+  <admst:if test="[name='or']"> <admst:text format="||"/> </admst:if>
+  <admst:if test="[name='multmod']"> <admst:text format="%%"/> </admst:if>
+  <admst:apply-templates select="arg2" match=":%(adms/datatypename)" required="yes"/>
+  <admst:text format=")"/>
+</admst:template>
+<admst:template match=":mapply_ternary">
+  <admst:if test="[name='conditional']">
+    <admst:text format="("/>
+    <admst:apply-templates select="arg1" match=":%(adms/datatypename)" required="yes"/>
+    <admst:text format="?"/>
+    <admst:apply-templates select="arg2" match=":%(adms/datatypename)" required="yes"/>
+    <admst:text format=":"/>
+    <admst:apply-templates select="arg3" match=":%(adms/datatypename)" required="yes"/>
+    <admst:text format=")"/>
+  </admst:if>
+</admst:template>
+
+<admst:template match=":function">
+  <admst:text format="%(name)"/>
+  <admst:if test="arguments">
+    <admst:text format="("/>
+    <admst:join select="arguments" separator=",">
+      <admst:apply-templates select="." match=":%(adms/datatypename)" required="yes"/>
+    </admst:join>
+    <admst:text format=")"/>
+  </admst:if>
+</admst:template>
+
 <admst:template match=":string">
   <admst:text format="&quot;%(value)&quot;"/>
 </admst:template>

--- a/qucs-core/src/components/verilog/qucsMODULEdefs.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEdefs.xml
@@ -112,12 +112,26 @@
   </admst:if>
 </admst:template>
 
+<admst:template match=":function">
+  <admst:text format="%(name)"/>
+  <admst:if test="arguments">
+    <admst:text format="("/>
+    <admst:join select="arguments" separator=",">
+      <admst:apply-templates select="." match=":%(adms/datatypename)" required="yes"/>
+    </admst:join>
+    <admst:text format=")"/>
+  </admst:if>
+</admst:template>
+
+
 <admst:template match=":string">
   <admst:text format="&quot;%(value)&quot;"/>
 </admst:template>
 
+<!-- recurse, till it retuns the value of the independent variable -->
 <admst:template match=":variable">
-  <admst:text format="&quot;%(name)&quot;"/>
+  <!-- admst:text format="&quot;%(name)&quot;"/ -->
+  <admst:apply-templates select="default" match=":expression"/>
 </admst:template>
 
 <admst:template match=":range">
@@ -182,6 +196,7 @@
   </admst:choose>
 </admst:template>
 
+
 <admst:template match=":property">
   <!-- name -->
   <admst:value-of select="name"/>
@@ -202,6 +217,7 @@
 
   <!-- default value -->
   <admst:text format=", { "/>
+
   <admst:apply-templates select="default" match=":expression"/>
   <admst:text format=", PROP_NO_STR }, "/>
 
@@ -296,6 +312,7 @@ PROP_REQ [] = {
     </admst:if>
   </admst:if>
 </admst:for-each>
+
 <admst:text format="  PROP_NO_PROP };\n"/>
 // optional properties
 PROP_OPT [] = {
@@ -321,6 +338,7 @@ PROP_OPT [] = {
   <admst:text format=", PROP_NO_STR }, PROP_MIN_VAL (qucs::K) },\n"/>
   </admst:if>
 </admst:if>
+
 <admst:text format="  PROP_NO_PROP };\n"/>
 // device definition
 struct define_t $module::cirdef =

--- a/qucs-core/src/components/verilog/qucsMODULEgui.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEgui.xml
@@ -64,7 +64,9 @@
 </admst:template>
 
 <admst:template match=":variable">
-  <admst:value-of select="name"/>%s
+  <!--admst:value-of select="name"/>%s-->
+  <!-- recurse, return final value -->
+  <admst:apply-templates select="default" match=":expression"/>
 </admst:template>
 
 <!-- handling of device: starting point -->

--- a/qucs-core/src/components/verilog/qucsMODULEguiJSONsymbol.xml
+++ b/qucs-core/src/components/verilog/qucsMODULEguiJSONsymbol.xml
@@ -68,8 +68,10 @@
   <admst:value-of select="value"/>%s
 </admst:template>
 
+<!-- recurse, return final value -->
 <admst:template match=":variable">
-  <admst:value-of select="name"/>%s
+  <!--admst:value-of select="name"/>%s-->
+  <admst:apply-templates select="default" match=":expression"/>
 </admst:template>
 
 <!-- handling of device: starting point -->

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -92,6 +92,9 @@
     <admst:when test="[name='shiftl']">
       <admst:return name="bname" string="&lt;&lt;"/>
     </admst:when>
+    <admst:when test="[name='multmod']">
+      <admst:return name="bname" value="%"/>
+    </admst:when>
     <admst:otherwise>
       <admst:fatal format="variable type unknown\n"/>
     </admst:otherwise>

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -2128,6 +2128,8 @@
 #define m20_abs(v00)           0.0
 #define m20_pow(x,y)            ((y)*((y)-1.0)*pow(x,y)/(x)/(x))
 
+#define m20_tanh(x)   -8*sinh(2*x)*pow(cosh(x),2)/(pow(cosh(2*x)+1,3))
+#define m20_asinh(x)  -(x/pow((1 + pow(x,2)),1.5))
 </admst:template>
 
 <!-- simulator settings -->

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -96,7 +96,7 @@
       <admst:return name="bname" value="%"/>
     </admst:when>
     <admst:otherwise>
-      <admst:fatal format="variable type unknown\n"/>
+      <admst:fatal format="variable type unknown %(name)\n"/>
     </admst:otherwise>
   </admst:choose>
 </admst:template>

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -950,7 +950,13 @@
       <admst:assert test="arguments[count(.)=2]" format="%(name): should have two arguments exactly\n"/>
       <admst:assert test="arguments[2]/adms[datatypename='probe']" format="%(name): second argument is not a probe\n"/>
       <admst:apply-templates select="arguments[1]" match="ddx"/>
+      <!--
+      FIXME what does  not-used is suposed do mean??,
+       partial derivative of a independent variable? if so, return zero...
+
       <admst:variable name="e" select="not-used"/>
+      -->
+      <admst:variable name="e" select="0."/>
     </admst:when>
     <admst:when test="[name='floor']">
       <admst:assert test="arguments[count(.)=1]" format="%(name): should have one argument exactly\n"/>

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -1316,7 +1316,8 @@
         </admst:otherwise>
       </admst:choose>
     </admst:when>
-    <admst:when test="[name='div' or name='pow' or name='hypot' or name='min' or name='max']">
+    <!-- warn of missing feature -->
+    <admst:when test="[name='div' or name='hypot' or name='min' or name='max']">
       <admst:variable name="epq" string="fixme"/>
       <admst:warning format="%(name): ddx dependency not implemented %(arguments[1]|' '|arguments[2])\n"/>
     </admst:when>

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -1264,7 +1264,17 @@
       </admst:choose>
     </admst:when>
     <admst:otherwise>
-      <admst:variable name="eq" select="d_$(fname)($args,$dargs)"/>
+      <!--
+      handle derivatives of builtin or provide analog function
+      -->
+      <admst:choose>
+        <admst:when test="[class='builtin']">
+          <admst:variable name="ep" select="d_$(fname)($args,$dargs)"/>
+        </admst:when>
+        <admst:otherwise>
+          <admst:variable name="ep" select="$(module)_d_$(fname)($args,$dargs)"/>
+        </admst:otherwise>
+      </admst:choose>
     </admst:otherwise>
   </admst:choose>
 

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -1350,7 +1350,7 @@
 
 <!-- analog//blockvariable -->
 <admst:template match="blockvariable">
-  <admst:text select="variable" format="%(vtype(.)) %(name);\n"/>
+  <admst:text select="variable" format="%(vtype(.)) %(name); (void) %(name);\n"/> <!-- void silence unused warnings --> 
   <admst:if test="variable[insource='yes']/probe">
 
     <admst:for-each select="variable">
@@ -1363,7 +1363,8 @@
           </admst:if>
           <admst:text test="[$ddxinsidethisprobe='yes']" format="#if defined(_DERIVATEFORDDX)\n"/>
           <admst:text test="[$ddxinsidethisprobe='no']" format="#if defined(_DERIVATE)\n"/>
-          <admst:text format="double %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/>
+          <admst:text format="double %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);  "/>
+          <admst:text format="(void) %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/> <!-- void silence unused warnings --> 
           <admst:text format="#endif\n"/>
       </admst:for-each>
     </admst:for-each>
@@ -1382,7 +1383,8 @@
         <admst:variable name="pprobe" path="."/>
         <admst:for-each select="$myvariable/probe">
           <admst:variable name="qprobe" path="."/>
-          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value);\n"/>
+          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value); "/>
+          <admst:text format=" (void) %(ddxname($myvariable)/[name='ddxname']/value);\n"/> <!-- void silence unused warnings -->
         </admst:for-each>
       </admst:for-each>
       <admst:text test="$ddxprobes/item" format="#endif\n"/>
@@ -1844,7 +1846,7 @@
   </admst:new>
   <admst:if test="block/adms[datatypename='module']">
     <admst:text test="[static='no' and dynamic='yes']" format="#if defined(_DYNAMIC)\n"/>
-    <admst:text test="[scope='local']" format="%(vtype(.)) %(name);\n"/>
+    <admst:text test="[scope='local']" format="%(vtype(.)) %(name); (void) %(name);\n"/> <!-- void silence unused warnings --> 
     <admst:if test="[insource='yes']/probe">
       <admst:variable name="ddxinsidederivate" string="no"/>
       <admst:for-each select="probe">
@@ -1861,13 +1863,14 @@
           <admst:text format="#if defined(_DERIVATE)\n"/>
         </admst:otherwise>
       </admst:choose>
-      <admst:text select="probe" format="double %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/>
+      <admst:text select="probe" format="double %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name); (void) %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/> <!-- void silence unused warnings --> 
       <admst:text test="[$ddxinsidederivate='yes']" format="#if defined(_DERIVATE)\n"/>
       <admst:for-each select="$ddxprobes/item">
         <admst:variable name="pprobe" path="."/>
         <admst:for-each select="$myvariable/probe">
           <admst:variable name="qprobe" path="."/>
-          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value);\n"/>
+          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value); "/>
+          <admst:text format="(void) %(ddxname($myvariable)/[name='ddxname']/value);\n"/> <!-- void silence unused warnings -->
         </admst:for-each>
       </admst:for-each>
       <admst:text test="[$ddxinsidederivate='yes']" format="#endif\n"/>

--- a/qucs-core/src/components/verilog/qucsVersion.xml
+++ b/qucs-core/src/components/verilog/qucsVersion.xml
@@ -1350,7 +1350,7 @@
 
 <!-- analog//blockvariable -->
 <admst:template match="blockvariable">
-  <admst:text select="variable" format="%(vtype(.)) %(name); (void) %(name);\n"/> <!-- void silence unused warnings --> 
+  <admst:text select="variable" format="%(vtype(.)) %(name) = 0; (void) %(name);\n"/> <!-- void silence unused warnings -->
   <admst:if test="variable[insource='yes']/probe">
 
     <admst:for-each select="variable">
@@ -1363,7 +1363,7 @@
           </admst:if>
           <admst:text test="[$ddxinsidethisprobe='yes']" format="#if defined(_DERIVATEFORDDX)\n"/>
           <admst:text test="[$ddxinsidethisprobe='no']" format="#if defined(_DERIVATE)\n"/>
-          <admst:text format="double %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);  "/>
+          <admst:text format="double %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name) = 0;  "/>
           <admst:text format="(void) %($myvariable/name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/> <!-- void silence unused warnings --> 
           <admst:text format="#endif\n"/>
       </admst:for-each>
@@ -1383,7 +1383,7 @@
         <admst:variable name="pprobe" path="."/>
         <admst:for-each select="$myvariable/probe">
           <admst:variable name="qprobe" path="."/>
-          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value); "/>
+          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value) = 0; "/>
           <admst:text format=" (void) %(ddxname($myvariable)/[name='ddxname']/value);\n"/> <!-- void silence unused warnings -->
         </admst:for-each>
       </admst:for-each>
@@ -1846,7 +1846,7 @@
   </admst:new>
   <admst:if test="block/adms[datatypename='module']">
     <admst:text test="[static='no' and dynamic='yes']" format="#if defined(_DYNAMIC)\n"/>
-    <admst:text test="[scope='local']" format="%(vtype(.)) %(name); (void) %(name);\n"/> <!-- void silence unused warnings --> 
+    <admst:text test="[scope='local']" format="%(vtype(.)) %(name) = 0; (void) %(name);\n"/> <!-- void silence unused warnings --> 
     <admst:if test="[insource='yes']/probe">
       <admst:variable name="ddxinsidederivate" string="no"/>
       <admst:for-each select="probe">
@@ -1863,13 +1863,13 @@
           <admst:text format="#if defined(_DERIVATE)\n"/>
         </admst:otherwise>
       </admst:choose>
-      <admst:text select="probe" format="double %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name); (void) %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/> <!-- void silence unused warnings --> 
+      <admst:text select="probe" format="double %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name) = 0; (void) %(../name)_%(nature/access)%(branch/pnode/name)_%(branch/nnode/name);\n"/> <!-- void silence unused warnings --> 
       <admst:text test="[$ddxinsidederivate='yes']" format="#if defined(_DERIVATE)\n"/>
       <admst:for-each select="$ddxprobes/item">
         <admst:variable name="pprobe" path="."/>
         <admst:for-each select="$myvariable/probe">
           <admst:variable name="qprobe" path="."/>
-          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value); "/>
+          <admst:text format="  double %(ddxname($myvariable)/[name='ddxname']/value) = 0; "/>
           <admst:text format="(void) %(ddxname($myvariable)/[name='ddxname']/value);\n"/> <!-- void silence unused warnings -->
         </admst:for-each>
       </admst:for-each>


### PR DESCRIPTION
These fixes are needed if one wants to compile the (patched) BSIM6 model. 
The patched BSIM6 model will be added to the qucs-nonfree repo later on.
