### PR TITLE
Fix regression on VHDL netlisting.

### DIFF
--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -1689,15 +1689,15 @@ int NumPorts)
           ID_Text *pid = (ID_Text*)pi;
           QList<SubParameter *>::const_iterator it;
 
-          (*tstream) << " generic (";
-
-          for(it = pid->Parameter.constBegin(); it != pid->Parameter.constEnd(); it++) {
-            s = (*it)->Name;
-            QString t = (*it)->Type.isEmpty() ? "real" : (*it)->Type;
-            (*tstream) << s.replace("=", " : "+t+" := ") << ";\n ";
+          if (pid->Parameter.size()) {
+            (*tstream) << " generic (";
+            for(it = pid->Parameter.constBegin(); it != pid->Parameter.constEnd(); it++) {
+              s = (*it)->Name;
+              QString t = (*it)->Type.isEmpty() ? "real" : (*it)->Type;
+              (*tstream) << s.replace("=", " : "+t+" := ") << ";\n ";
+            }
+            (*tstream) << ");\n";
           }
-
-          (*tstream) << ");\n";
           break;
         }
 


### PR DESCRIPTION
When netlisting for VHDL simulation a `generic();` entry
is being added without parameters which is an error.

Bug introduced in 8a30ad998bb6fe, after 0.0.18.