### PR TITLE
Issue #578 fix

### DIFF
--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -71,7 +71,7 @@ public:
   virtual QString extraMarkerText(Marker const*) const {return "";}
   
   virtual void paint(ViewPainter*);
-  void paintDiagram(ViewPainter* p);
+  virtual void paintDiagram(ViewPainter* p);
   void paintMarkers(ViewPainter* p, bool paintAll = true);
   void    setCenter(int, int, bool relative=false);
   void    getCenter(int&, int&);

--- a/qucs/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/qucs/diagrams/tabdiagram.cpp
@@ -46,8 +46,13 @@ TabDiagram::~TabDiagram()
 {
 }
 
-// ------------------------------------------------------------
 void TabDiagram::paint(ViewPainter *p)
+{
+    paintDiagram(p);
+}
+
+// ------------------------------------------------------------
+void TabDiagram::paintDiagram(ViewPainter *p)
 {
   // paint all lines
   foreach(Line *pl, Lines) {

--- a/qucs/qucs/diagrams/tabdiagram.h
+++ b/qucs/qucs/diagrams/tabdiagram.h
@@ -29,6 +29,7 @@ public:
   virtual Diagram* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
   virtual void paint(ViewPainter*);
+  virtual void paintDiagram(ViewPainter *p);
   virtual int calcDiagram();
   virtual int scroll(int);
   virtual bool scrollTo(int, int, int);

--- a/qucs/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/qucs/diagrams/timingdiagram.cpp
@@ -45,8 +45,13 @@ TimingDiagram::~TimingDiagram()
 {
 }
 
-// ------------------------------------------------------------
 void TimingDiagram::paint(ViewPainter *p)
+{
+    paintDiagram(p);
+}
+
+// ------------------------------------------------------------
+void TimingDiagram::paintDiagram(ViewPainter *p)
 {
   // paint all lines
   foreach(Line *pl, Lines) {

--- a/qucs/qucs/diagrams/timingdiagram.h
+++ b/qucs/qucs/diagrams/timingdiagram.h
@@ -28,7 +28,8 @@ public:
 
   Diagram* newOne();
   static Element* info(QString&, char* &, bool getNewOne=false);
-  void paint(ViewPainter*);
+  void paint(ViewPainter *p);
+  void paintDiagram(ViewPainter *p);
   int calcDiagram();
   int scroll(int);
   bool scrollTo(int, int, int);


### PR DESCRIPTION
I added fix for Timing diagram printing #578 . `Diagram::paintDiagram()` is made virtual. `TimingDiagram` and `TabDiagram` override this method by their own implementations.