### PR TITLE
Allow path settings to be overridden by env. vars

### DIFF
--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -657,6 +657,11 @@ int main(int argc, char *argv[])
   QucsSettings.dx = w*3/4;
   QucsSettings.dy = h*3/4;
 
+  // load existing settings (if any)
+  loadSettings();
+
+  // continue to set up overrides or default settings (some are saved on exit)
+
   // check for relocation env variable
   char* var = getenv("QUCSDIR");
   QDir QucsDir;
@@ -755,8 +760,6 @@ int main(int argc, char *argv[])
   } else {
       QucsSettings.QucsOctave.clear();
   }
-
-  loadSettings();
 
   if(!QucsSettings.BGColor.isValid())
     QucsSettings.BGColor.setRgb(255, 250, 225);


### PR DESCRIPTION
The `loadSettings()` must done earlier otherwise the
override by environment variables won't work.

In particular for these that are still stored in the settings.
 - AdmsXmlBinDir
 - AscoBinDir

This has to be simplified to make proper use of the PATH,
related to commens in issue #374.