### PR TITLE
Fix file extension handling in Import/Export data dialog

### DIFF
--- a/qucs/qucs/dialogs/importdialog.cpp
+++ b/qucs/qucs/dialogs/importdialog.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 #include <QLabel>
 #include <QLineEdit>
-#include <QTextEdit>
+#include <QPlainTextEdit>
 #include <QGroupBox>
 #include <QComboBox>
 #include <QFileDialog>
@@ -71,9 +71,8 @@ ImportDialog::ImportDialog(QWidget *parent)
   QGroupBox *Group1 = new QGroupBox(tr("Messages"));
   
   QVBoxLayout *vMess = new QVBoxLayout();
-  MsgText = new QTextEdit();
+  MsgText = new QPlainTextEdit();
   vMess->addWidget(MsgText);
-  MsgText->setTextFormat(Qt::PlainText);
   MsgText->setReadOnly(true);
   MsgText->setWordWrapMode(QTextOption::NoWrap);
   MsgText->setMinimumSize(250, 60);
@@ -108,6 +107,7 @@ ImportDialog::~ImportDialog()
 void ImportDialog::slotBrowse()
 {
   QString s = QFileDialog::getOpenFileName(
+     this, tr("Enter a Data File Name"),
      lastDir.isEmpty() ? QString(".") : lastDir,
      tr("All known")+
      " (*.s?p *.csv *.citi *.cit *.asc *.mdl *.vcd *.dat *.cir);;"+
@@ -119,16 +119,15 @@ void ImportDialog::slotBrowse()
      tr("VCD files")+" (*.vcd);;"+
      tr("Qucs dataset files")+" (*.dat);;"+
      tr("SPICE files")+" (*.cir);;"+
-     tr("Any file")+" (*)",
-     this, 0, tr("Enter a Data File Name"));
+     tr("Any file")+" (*)");
 
   if(!s.isEmpty()) {
     QFileInfo Info(s);
-    lastDir = Info.dirPath(true);  // remember last directory
+    lastDir = Info.absolutePath();  // remember last directory
     ImportEdit->setText(s);
 
     if(OutputEdit->text().isEmpty()) {
-      switch(OutType->currentItem()) {
+      switch(OutType->currentIndex()) {
       case 0:
 	OutputEdit->setText(Info.completeBaseName()+".dat");
 	break;
@@ -207,12 +206,12 @@ void ImportDialog::slotImport()
             break;
           }
 
-    MsgText->append(tr("ERROR: Unknown file format! Please check file name extension!"));
+    MsgText->appendPlainText(tr("ERROR: Unknown file format! Please check file name extension!"));
     return;
   }
 
   CommandLine << "-of";
-  switch(OutType->currentItem()) {
+  switch(OutType->currentIndex()) {
   case 0:
     CommandLine << "qucsdata";
     break;
@@ -250,15 +249,15 @@ void ImportDialog::slotImport()
   connect(&Process, SIGNAL(readyReadStandardOutput()), SLOT(slotDisplayMsg()));
   connect(&Process, SIGNAL(finished(int)), SLOT(slotProcessEnded(int)));
 
-  MsgText->append(tr("Running command line:")+"\n");
-  MsgText->append(Program + CommandLine.join(" "));
-  MsgText->append("\n");
+  MsgText->appendPlainText(tr("Running command line:")+"\n");
+  MsgText->appendPlainText(Program + CommandLine.join(" "));
+  MsgText->appendPlainText("\n");
 
   qDebug() << "Command:" << Program << CommandLine.join(" ");
   Process.start(Program, CommandLine);
   
   if(!Process.Running)
-    MsgText->append(tr("ERROR: Cannot start converter!"));
+    MsgText->appendPlainText(tr("ERROR: Cannot start converter!"));
 }
 
 // ------------------------------------------------------------------------
@@ -296,14 +295,14 @@ void ImportDialog::slotAbort()
 // Is called when the process sends an output to stdout.
 void ImportDialog::slotDisplayMsg()
 {
-  MsgText->append(QString(Process.readAllStandardOutput()));
+  MsgText->appendPlainText(QString(Process.readAllStandardOutput()));
 }
 
 // ------------------------------------------------------------------------
 // Is called when the process sends an output to stderr.
 void ImportDialog::slotDisplayErr()
 {
-  MsgText->append(QString(Process.readAllStandardError()));
+  MsgText->appendPlainText(QString(Process.readAllStandardError()));
 }
 
 // ------------------------------------------------------------------------
@@ -314,11 +313,11 @@ void ImportDialog::slotProcessEnded(int status)
   AbortButt->setDisabled(true);
 
   if(status == 0) {    
-    MsgText->append(tr("Successfully converted file!"));
+    MsgText->appendPlainText(tr("Successfully converted file!"));
 
     disconnect(CancelButt, SIGNAL(clicked()), 0, 0);
     connect(CancelButt, SIGNAL(clicked()), SLOT(accept()));
   }
   else
-    MsgText->append(tr("Converter ended with errors!"));
+    MsgText->appendPlainText(tr("Converter ended with errors!"));
 }

--- a/qucs/qucs/dialogs/importdialog.cpp
+++ b/qucs/qucs/dialogs/importdialog.cpp
@@ -130,25 +130,25 @@ void ImportDialog::slotBrowse()
     if(OutputEdit->text().isEmpty()) {
       switch(OutType->currentItem()) {
       case 0:
-	OutputEdit->setText(Info.baseName()+".dat");
+	OutputEdit->setText(Info.completeBaseName()+".dat");
 	break;
       case 1:
-	OutputEdit->setText(Info.baseName()+".snp");
+	OutputEdit->setText(Info.completeBaseName()+".snp");
 	break;
       case 2:
-	OutputEdit->setText(Info.baseName()+".csv");
+	OutputEdit->setText(Info.completeBaseName()+".csv");
 	break;
       case 3:
-	OutputEdit->setText(Info.baseName()+".lib");
+	OutputEdit->setText(Info.completeBaseName()+".lib");
 	break;
       case 4:
-	OutputEdit->setText(Info.baseName()+".txt");
+	OutputEdit->setText(Info.completeBaseName()+".txt");
 	break;
       case 5:
-	OutputEdit->setText(Info.baseName()+".mat");
+	OutputEdit->setText(Info.completeBaseName()+".mat");
 	break;
       default:
-	OutputEdit->setText(Info.baseName()+".dat");
+	OutputEdit->setText(Info.completeBaseName()+".dat");
 	break;
       }
     }
@@ -177,7 +177,7 @@ void ImportDialog::slotImport()
       }
 
   QFileInfo Info(ImportEdit->text());
-  QString Suffix = Info.extension();
+  QString Suffix = Info.suffix();
   QString Program;
   QStringList CommandLine;
 

--- a/qucs/qucs/dialogs/importdialog.h
+++ b/qucs/qucs/dialogs/importdialog.h
@@ -23,7 +23,7 @@
 #include <QGridLayout>
 #include <QLabel>
 
-class QTextEdit;
+class QPlainTextEdit;
 class QLineEdit;
 class QGridLayout;
 class QPushButton;
@@ -54,7 +54,7 @@ public:
 
   QLabel *OutputLabel;
   QProcess Process;
-  QTextEdit *MsgText;
+  QPlainTextEdit *MsgText;
   QLineEdit *ImportEdit, *OutputEdit, *OutputData;
   QPushButton *ImportButt, *CancelButt, *AbortButt;
   QComboBox *OutType;

--- a/qucs/qucs/dialogs/loaddialog.cpp
+++ b/qucs/qucs/dialogs/loaddialog.cpp
@@ -42,11 +42,10 @@
 #include "qucsdoc.h"
 #include "components/components.h"
 
-LoadDialog::LoadDialog( QWidget* parent, const char* name, bool modal, Qt::WFlags fl )
-   : QDialog( parent, name, modal, fl )
+LoadDialog::LoadDialog( QWidget* parent )
+   : QDialog( parent )
 {
-   if ( !name )
-      setWindowTitle( tr( "Load Verilog-A symbols" ) );
+   setWindowTitle( tr( "Load Verilog-A symbols" ) );
    app = 0l;
 //   initDialog();
 }
@@ -208,7 +207,7 @@ void LoadDialog::slotSymbolFileClicked(QListWidgetItem* item)
 //  qDebug() << "slotSymbolFileClicked" << Name << vaBitmap;
 
   // check if icon exists, fall back to default
-  QString iconPath = QString(projDir.absFilePath(vaBitmap+".png"));
+  QString iconPath = QString(projDir.absoluteFilePath(vaBitmap+".png"));
   QFile iconFile(iconPath);
 
   if(iconFile.exists())

--- a/qucs/qucs/dialogs/loaddialog.cpp
+++ b/qucs/qucs/dialogs/loaddialog.cpp
@@ -270,7 +270,7 @@ void LoadDialog::slotChangeIcon()
                                         QString(projDir.absolutePath()),
                                         tr("Icon image (*.png)"));
 
-  QString newIcon =  QFileInfo(iconFileName).baseName();
+  QString newIcon =  QFileInfo(iconFileName).completeBaseName();
 //  qDebug() << "icon "<< newIcon;
 
   QString filename = fileView->currentItem()->text();

--- a/qucs/qucs/dialogs/loaddialog.h
+++ b/qucs/qucs/dialogs/loaddialog.h
@@ -54,7 +54,7 @@ public:
         Accept
     };
 
-    LoadDialog(QWidget* p = 0, const char* n = 0, bool modal = true, Qt::WFlags fl = 0 );
+    LoadDialog(QWidget* p = 0 );
     ~LoadDialog();
     void setApp(QucsApp *a);
     void initDialog();

--- a/qucs/qucs/misc.cpp
+++ b/qucs/qucs/misc.cpp
@@ -141,7 +141,7 @@ QString misc::StringNiceNum(double num)
 // #########################################################################
 void misc::str2num(const QString& s_, double& Number, QString& Unit, double& Factor)
 {
-  QString str = s_.stripWhiteSpace();
+  QString str = s_.trimmed();
 
 /*  int i=0;
   bool neg = false;
@@ -159,19 +159,19 @@ void misc::str2num(const QString& s_, double& Number, QString& Unit, double& Fac
   }*/
 
   QRegExp Expr( QRegExp("[^0-9\\x2E\\x2D\\x2B]") );
-  int i = str.find( Expr );
+  int i = str.indexOf( Expr );
   if(i >= 0)
-    if((str.at(i).latin1() | 0x20) == 'e') {
-      int j = str.find( Expr , ++i);
+    if((str.at(i).toLatin1() | 0x20) == 'e') {
+      int j = str.indexOf( Expr , ++i);
       if(j == i)  j--;
       i = j;
     }
 
   Number = str.left(i).toDouble();
-  Unit   = str.mid(i).stripWhiteSpace();
+  Unit   = str.mid(i).trimmed();
   if(Unit.length()>0)
   {
-    switch(Unit.at(0).latin1()) {
+    switch(Unit.at(0).toLatin1()) {
       case 'T': Factor = 1e12;  break;
       case 'G': Factor = 1e9;   break;
       case 'M': Factor = 1e6;   break;
@@ -233,7 +233,7 @@ void misc::convert2Unicode(QString& Text)
   int i = 0;
   QString n;
   unsigned short ch;
-  while((i=Text.find("\\x", i)) >= 0) {
+  while((i=Text.indexOf("\\x", i)) >= 0) {
     n = Text.mid(i, 6);
     ch = n.mid(2).toUShort(&ok, 16);
     if(ok)  Text.replace(n, QChar(ch));
@@ -306,13 +306,13 @@ QString misc::properName(const QString& Name)
 // Creates and returns delay time for VHDL entities.
 bool misc::VHDL_Delay(QString& td, const QString& Name)
 {
-  if(strtod(td.latin1(), 0) != 0.0) {  // delay time property
+  if(strtod(td.toLatin1(), 0) != 0.0) {  // delay time property
     if(!misc::VHDL_Time(td, Name))
       return false;    // time has not VHDL format
     td = " after " + td;
     return true;
   }
-  else if(isalpha(td.latin1()[0])) {
+  else if(isalpha(td.toLatin1()[0])) {
     td = " after " + td;
     return true;
   }
@@ -327,7 +327,7 @@ bool misc::VHDL_Delay(QString& td, const QString& Name)
 bool misc::VHDL_Time(QString& t, const QString& Name)
 {
   char *p;
-  double Time = strtod(t.latin1(), &p);
+  double Time = strtod(t.toLatin1(), &p);
   while(*p == ' ') p++;
   for(;;) {
     if(Time >= 0.0) {
@@ -353,7 +353,7 @@ bool misc::VHDL_Time(QString& t, const QString& Name)
 // Returns parameters for Verilog modules.
 QString misc::Verilog_Param(const QString Value)
 {
-  if(strtod(Value.latin1(), 0) != 0.0) {
+  if(strtod(Value.toLatin1(), 0) != 0.0) {
     QString td = Value;
     if(!misc::Verilog_Time(td, "parameter"))
       return Value;
@@ -368,13 +368,13 @@ QString misc::Verilog_Param(const QString Value)
 // Creates and returns delay time for Verilog modules.
 bool misc::Verilog_Delay(QString& td, const QString& Name)
 {
-  if(strtod(td.latin1(), 0) != 0.0) {  // delay time property
+  if(strtod(td.toLatin1(), 0) != 0.0) {  // delay time property
     if(!misc::Verilog_Time(td, Name))
       return false;    // time has not Verilog format
     td = " #" + td;
     return true;
   }
-  else if(isalpha(td.latin1()[0])) {
+  else if(isalpha(td.toLatin1()[0])) {
     td = " #" + td;
     return true;
   }
@@ -389,7 +389,7 @@ bool misc::Verilog_Delay(QString& td, const QString& Name)
 bool misc::Verilog_Time(QString& t, const QString& Name)
 {
   char *p;
-  double Time = strtod(t.latin1(), &p);
+  double Time = strtod(t.toLatin1(), &p);
   double factor = 1.0;
   while(*p == ' ') p++;
   for(;;) {
@@ -415,8 +415,8 @@ bool misc::Verilog_Time(QString& t, const QString& Name)
 // #########################################################################
 bool misc::checkVersion(QString& Line)
 {
-  QStringList sl = QStringList::split('.',PACKAGE_VERSION);
-  QStringList ll = QStringList::split('.',Line);
+  QStringList sl = QString(PACKAGE_VERSION).split('.');
+  QStringList ll = Line.split('.');
   if (ll.count() != 3 || sl.count() != 3)
     return false;
   int sv = (int)sl.at(1).toLongLong()*10000+sl.at(2).toLongLong()*100;

--- a/qucs/qucs/misc.cpp
+++ b/qucs/qucs/misc.cpp
@@ -291,8 +291,8 @@ QString misc::properName(const QString& Name)
 {
   QString s = Name;
   QFileInfo Info(s);
-  if(Info.extension() == "sch")
-    s = s.left(s.length()-4);
+  if(Info.suffix() == "sch")
+    s.chop(4);
   if(s.at(0) <= '9') if(s.at(0) >= '0')
     s = 'n' + s;
   s.replace(QRegExp("\\W"), "_"); // none [a-zA-Z0-9] into "_"

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -256,7 +256,7 @@ int Schematic::saveSymbolJSON()
 {
   QFileInfo info (DocName);
   QString jsonfile = info.dirPath () + QDir::separator()
-                   + info.baseName() + "_sym.json";
+                   + info.completeBaseName() + "_sym.json";
 
   qDebug() << "saveSymbolJson for " << jsonfile;
 


### PR DESCRIPTION
In the Import/Export data dialog a file named e.g. `LDMOS_7.5V_50mA.s2p` is currently not recognized as a `s2p` (Touchstone) file, since the file extension is taken as the part after the *first* dot, i.e. `5V_50mA.s2p`.
I have updated the code in the Import/Export data dialog to take as extension only the part after the *last* dot (i.e. use `QFileInfo::suffix()` instead of `QFileInfo::extension()` and `QFileInfo::completeBaseName()` instead of `QFileInfo::baseName()`).
I have also updated similar parts of the code where file extensions/base names appeared to be used incorrectly and updated the deprecated Qt3 functions with the Qt4 ones.
