### PR TITLE
Allow pasting from future versions

### DIFF
--- a/qucs/qucs/components/libcomp.cpp
+++ b/qucs/qucs/components/libcomp.cpp
@@ -102,8 +102,9 @@ int LibComp::loadSection(const QString& Name, QString& Section,
 
   int Start, End = Section.indexOf(' ', 14);
   if(End < 15) return -3;
-  QString Line = Section.mid(14, End-14);
-  if(!misc::checkVersion(Line)) // wrong version number ?
+  QString Line = Section.mid(14, End-14); // extract version string
+  VersionTriplet LibVersion = VersionTriplet(Line);
+  if (LibVersion > QucsVersion) // wrong version number ?
     return -3;
 
   if(Name == "Symbol") {

--- a/qucs/qucs/components/subcircuit.cpp
+++ b/qucs/qucs/components/subcircuit.cpp
@@ -162,7 +162,8 @@ int Subcircuit::loadSymbol(const QString& DocName)
     return -3;
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) // wrong version number ?
+  VersionTriplet SymbolVersion = VersionTriplet(Line);
+  if (SymbolVersion > QucsVersion) // wrong version number ?
     return -4;
 
   // read content *************************

--- a/qucs/qucs/dialogs/packagedialog.cpp
+++ b/qucs/qucs/dialogs/packagedialog.cpp
@@ -365,6 +365,7 @@ void PackageDialog::extractPackage()
 
   QDir currDir = QucsSettings.QucsHomeDir;
   QString Version;
+  VersionTriplet PackageVersion;
   Q_UINT16 Checksum;
   Q_UINT32 Code, Length;
 
@@ -376,7 +377,8 @@ void PackageDialog::extractPackage()
   }
 
   Version = QString(Content.data()+13);
-  if(!misc::checkVersion(Version)) {
+  PackageVersion = VersionTriplet(Version);
+  if (PackageVersion > QucsVersion) { // wrong version number ?
     MsgText->append(tr("ERROR: Wrong version number!"));
     goto ErrorEnd;
   }

--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -501,6 +501,8 @@ void QucsSettingsDialog::slotOK()
 
 // -----------------------------------------------------------
 // Applies any changed settings
+/// \todo simplify the conditionals involving `changed = true`
+///  if user hit apply, save settings and refresh everything
 void QucsSettingsDialog::slotApply()
 {
     bool changed = false;
@@ -619,7 +621,11 @@ void QucsSettingsDialog::slotApply()
     QucsSettings.AscoBinDir = ascoEdit->text();
     QucsSettings.OctaveExecutable = octaveEdit->text();
 
-    QucsSettings.IgnoreFutureVersion = checkLoadFromFutureVersions->isChecked();
+    if (QucsSettings.IgnoreFutureVersion != checkLoadFromFutureVersions->isChecked())
+    {
+      QucsSettings.IgnoreFutureVersion = checkLoadFromFutureVersions->isChecked();
+      changed = true;
+    }
 
     if (QucsSettings.GraphAntiAliasing != checkAntiAliasing->isChecked())
     {

--- a/qucs/qucs/main.cpp
+++ b/qucs/qucs/main.cpp
@@ -45,6 +45,7 @@
 
 #include "schematic.h"
 #include "module.h"
+#include "misc.h"
 
 #include "components/components.h"
 
@@ -63,6 +64,7 @@ tQucsSettings QucsSettings;
 QucsApp *QucsMain = 0;  // the Qucs application itself
 QString lastDir;    // to remember last directory for several dialogs
 QStringList qucsPathList;
+VersionTriplet QucsVersion; // Qucs version string
 
 // #########################################################################
 // Loads the settings file and stores the settings.
@@ -641,6 +643,9 @@ void createListComponentEntry(){
 int main(int argc, char *argv[])
 {
   qInstallMsgHandler(qucsMessageOutput);
+  // set the Qucs version string
+  QucsVersion = VersionTriplet(PACKAGE_VERSION);
+
   // apply default settings
   QucsSettings.font = QFont("Helvetica", 12);
   QucsSettings.largeFontSize = 16.0;

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -33,6 +33,7 @@
 
 class QucsApp;
 class Component;
+class VersionTriplet;
 
 static const double pi = 3.1415926535897932384626433832795029;  /* pi   */
 
@@ -85,6 +86,7 @@ extern tQucsSettings QucsSettings;  // extern because nearly everywhere used
 extern QucsApp *QucsMain;  // the Qucs application itself
 extern QString lastDir;    // to remember last directory for several dialogs
 extern QStringList qucsPathList;
+extern VersionTriplet QucsVersion;
 
 bool loadSettings();
 bool saveApplSettings();

--- a/qucs/qucs/misc.cpp
+++ b/qucs/qucs/misc.cpp
@@ -425,3 +425,81 @@ bool misc::checkVersion(QString& Line)
     return false;
   return true;
 }
+
+// a small class to handle the application version string
+//   loosely modeled after the standard Semantic Versioning...
+VersionTriplet::VersionTriplet(const QString& version) {
+  // TODO should be likely made more robust...
+  if (version.isEmpty()) {
+    major = minor = patch = 0;
+  } else {
+    QStringList vl = QStringList::split('.', version);
+    major = vl.at(0).toUInt();
+    minor = vl.at(1).toUInt();
+    patch = vl.at(2).toUInt();
+  }
+}
+
+VersionTriplet::VersionTriplet(){
+  major = minor = patch = 0;
+}
+
+bool VersionTriplet::operator==(const VersionTriplet& v2) {
+  if (this->major != v2.major)
+    return false;
+  if (this->minor != v2.minor)
+    return false;
+  if (this->patch != v2.patch)
+    return false;
+  return true;
+}
+
+bool VersionTriplet::operator>(const VersionTriplet& v2) {
+  if (this->major < v2.major)
+    return false;
+  if (this->major > v2.major)
+    return true;
+
+  if (this->minor < v2.minor)
+    return false;
+  if (this->minor > v2.minor)
+    return true;
+
+  if (this->patch < v2.patch)
+    return false;
+  if (this->patch > v2.patch)
+    return true;
+
+  return false;
+}
+
+bool VersionTriplet::operator<(const VersionTriplet& v2) {
+  if (this->major > v2.major)
+    return false;
+  if (this->major < v2.major)
+    return true;
+
+  if (this->minor > v2.minor)
+    return false;
+  if (this->minor < v2.minor)
+    return true;
+
+  if (this->patch > v2.patch)
+    return false;
+  if (this->patch < v2.patch)
+    return true;
+
+  return false;
+}
+
+bool VersionTriplet::operator>=(const VersionTriplet& v2) {
+  return !((*this) < v2);
+}
+
+bool VersionTriplet::operator<=(const VersionTriplet& v2) {
+  return !((*this) > v2);
+}
+
+QString VersionTriplet::toString() {
+  return QString("%1.%2.%3").arg(major).arg(minor).arg(patch);
+}

--- a/qucs/qucs/misc.h
+++ b/qucs/qucs/misc.h
@@ -41,3 +41,24 @@ namespace misc {
   QString Verilog_Param(const QString);
   bool    checkVersion(QString&);
 }
+
+/*! handle the application version string
+ *
+ *  loosely modeled after the standard Semantic Versioning
+ */
+class VersionTriplet {
+ public:
+  VersionTriplet();
+  VersionTriplet(const QString&);
+
+  bool operator==(const VersionTriplet& v2);
+  bool operator>(const VersionTriplet& v2);
+  bool operator<(const VersionTriplet& v2);
+  bool operator>=(const VersionTriplet& v2);
+  bool operator<=(const VersionTriplet& v2);
+
+  QString toString();
+
+ private:
+  int major, minor, patch;
+};

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -128,13 +128,14 @@ ProjectView::refresh()
       APPEND_CHILD(5, columnData);
     }
     else if(extName == "sch") {
+      // test if it's a valid schematic file
       int n = Schematic::testFile(workPath.filePath(fileName));
       if(n >= 0) {
-        if(n > 0) {
+        if(n > 0) { // is a subcircuit
           columnData.append(new QStandardItem(QString::number(n)+tr("-port")));
         }
+        APPEND_CHILD(6, columnData);
       }
-      APPEND_CHILD(6, columnData);
     }
     else {
       APPEND_CHILD(7, columnData);

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -128,10 +128,13 @@ bool Schematic::pasteFromClipboard(QTextStream *stream, Q3PtrList<Element> *pe)
 
   QString s = PACKAGE_VERSION;
   Line = Line.mid(16, Line.length()-17);
-  if(Line != s) {  // wrong version number ?
-    QMessageBox::critical(0, QObject::tr("Error"),
-                 QObject::tr("Wrong document version: ")+Line);
-    return false;
+  VersionTriplet DocVersion = VersionTriplet(Line);
+  if (DocVersion > QucsVersion) { // wrong version number ?
+    if (!QucsSettings.IgnoreFutureVersion) {
+      QMessageBox::critical(0, QObject::tr("Error"),
+                            QObject::tr("Wrong document version: ")+Line);
+      return false;
+    }
   }
 
   // read content in symbol edit mode *************************
@@ -867,22 +870,10 @@ bool Schematic::loadDocument()
   Line = Line.mid(16, Line.length()-17);
   VersionTriplet DocVersion = VersionTriplet(Line);
   if (DocVersion > QucsVersion) { // wrong version number ?
-
-    QMessageBox::StandardButton result;
-    result = QMessageBox::warning(0,
-                                  QObject::tr("Warning"),
-                                  QObject::tr("Wrong document version \n"
-                                              "%1\n"
-                                              "Try to open it anyway?").arg(DocName),
-                                  QMessageBox::Yes|QMessageBox::No);
-
-    if (result==QMessageBox::No) {
-        file.close();
-        return false;
+    if (!QucsSettings.IgnoreFutureVersion) {
+      QMessageBox::critical(0, QObject::tr("Error"),
+                            QObject::tr("Wrong document version: %1").arg(DocVersion.toString()));
     }
-
-    //QMessageBox::critical(0, QObject::tr("Error"),
-        // QObject::tr("Wrong document version: ")+Line);
   }
 
   // read content *************************

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -865,7 +865,8 @@ bool Schematic::loadDocument()
   }
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) { // wrong version number ?
+  VersionTriplet DocVersion = VersionTriplet(Line);
+  if (DocVersion > QucsVersion) { // wrong version number ?
 
     QMessageBox::StandardButton result;
     result = QMessageBox::warning(0,
@@ -1103,7 +1104,8 @@ int Schematic::testFile(const QString& DocName)
   }
 
   Line = Line.mid(16, Line.length()-17);
-  if(!misc::checkVersion(Line)) { // wrong version number ?
+  VersionTriplet DocVersion = VersionTriplet(Line);
+  if (DocVersion > QucsVersion) { // wrong version number ?
       if (!QucsSettings.IgnoreFutureVersion) {
           file.close();
           return -4;

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -126,13 +126,12 @@ bool Schematic::pasteFromClipboard(QTextStream *stream, Q3PtrList<Element> *pe)
   if(Line.left(16) != "<Qucs Schematic ")   // wrong file type ?
     return false;
 
-  QString s = PACKAGE_VERSION;
   Line = Line.mid(16, Line.length()-17);
   VersionTriplet DocVersion = VersionTriplet(Line);
   if (DocVersion > QucsVersion) { // wrong version number ?
     if (!QucsSettings.IgnoreFutureVersion) {
       QMessageBox::critical(0, QObject::tr("Error"),
-                            QObject::tr("Wrong document version: ")+Line);
+                            QObject::tr("Wrong document version: %1").arg(DocVersion.toString()));
       return false;
     }
   }


### PR DESCRIPTION
Fix for #593, as described there, copied here for convenience:

- if *load from future versions* is enabled:
  - show future-version schematic in the tree view
  - open them without any warning message
  - paste from future versions without any warning message
- if *load from future versions* is **not** enabled:
  - do **not** show future-version schematic in the tree view
  - abort opening them (if forced thru the *Open* dialog) with an error message
  - abort pasting from future versions with an error message
