### PR TITLE
VHDL: Fix char* to QString conversion

### DIFF
--- a/qucs/qucs/misc.cpp
+++ b/qucs/qucs/misc.cpp
@@ -327,7 +327,8 @@ bool misc::VHDL_Delay(QString& td, const QString& Name)
 bool misc::VHDL_Time(QString& t, const QString& Name)
 {
   char *p;
-  double Time = strtod(t.toLatin1(), &p);
+  QByteArray ba = t.toLatin1();
+  double Time = strtod(ba.data(), &p);
   while(*p == ' ') p++;
   for(;;) {
     if(Time >= 0.0) {
@@ -389,7 +390,8 @@ bool misc::Verilog_Delay(QString& td, const QString& Name)
 bool misc::Verilog_Time(QString& t, const QString& Name)
 {
   char *p;
-  double Time = strtod(t.toLatin1(), &p);
+  QByteArray ba = t.toLatin1();
+  double Time = strtod(ba.data(), &p);
   double factor = 1.0;
   while(*p == ' ') p++;
   for(;;) {


### PR DESCRIPTION
This is causing VHDL simulation to fail.
For some reason the scale part is not converting correcty, generating
garbage in place of the time scale.

0.0.18    :    netCLEAR <= '1'; wait for 10 ns;
before fix:    netCLEAR <= '1'; wait for 10 1;