### PR TITLE
Fix for #615

### DIFF
--- a/qucs/qucs/imagewriter.cpp
+++ b/qucs/qucs/imagewriter.cpp
@@ -155,6 +155,16 @@ int ImageWriter::print(QWidget *doc)
 
   if (dlg->exec()) {
     QString filename = dlg->FileToSave();
+    if (QFile::exists(filename)) {
+        int r = QMessageBox::question(0, QObject::tr("Overwrite"),
+                                         QObject::tr("File \"%1\" already exists.\nOverwrite ?")
+                                         .arg(filename),
+                                         QMessageBox::Yes|QMessageBox::No);
+        if (r == QMessageBox::No) {
+            delete dlg;
+            return -1;
+        }
+    }
     lastExportFilename = filename;
 
     bool exportAll;


### PR DESCRIPTION
This PR is fix for #615. Added a dialog when image file to export already exists. It will preserve image file form automatic overwriting.