### PR TITLE
ticket #386 ... improve qucs/qucs/diagrams/rect3ddiagram.cpp

### DIFF
--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -324,6 +324,13 @@ void Rect3DDiagram::calcLine(tPoint3D* &p, tPoint3D* &MemEnd,
       y1_ += iy_;
     }
     
+    // LDA_20161212 ... comment added
+    // This section has significant impact to the hiding algorithm
+    //   be aware isHidden() modifies (Bounds+x)->min/max
+    // if isHidden() is replaced by  false  nearly all segments are drawn,
+    //   nothing set hidden by this section ... though few segments are hidden 
+    // if isHidden() is replaced by true  most segments are not drawn
+    //   and many line-ends are outside the diagram-are (mem/malloc-issue?)
     if( isHidden(x1_, y1_, Bounds, zBuffer) != wasHidden )
       if((p->done & 1) == 0) {
         wasHidden = !wasHidden;
@@ -342,10 +349,24 @@ void Rect3DDiagram::calcLine(tPoint3D* &p, tPoint3D* &MemEnd,
   }
 
   // extra treatment for last point (create no further point)
-  if(isHidden((p+1)->x, (p+1)->y, Bounds, zBuffer))
-    if(((p+1)->done & 1) == 0)
-      (p+1)->done |= 4;   // mark as hidden
+  // LDA_20161212 ... section replaced
+  // OLD: implementation hides most of the segmets
+  // NEW: unhide missing segments
+  if(!isHidden((p+1)->x, (p+1)->y, Bounds, zBuffer))
+  {
+    if(!isHidden((p)->x, (p)->y, Bounds, zBuffer))
+    {
+      (p+1)->done &= ~4;
+    }
+    else
+    {
+      (p)->done &= ~4;
+    }
+  }
 
+  // LDA_20161212 ... comment added
+  // If this assignment is commented-out all inner segments are not drawn.
+  // Just the surrounding boundary (all segments) of the mesh is drawn
   p->done |= 1;   // mark as already worked on
 }
 
@@ -377,8 +398,16 @@ void Rect3DDiagram::removeHiddenLines(char *zBuffer, tBound *Bounds)
       Size += g->axis(0)->count * g->countY;
 
   // "Mem" should be the last malloc to simplify realloc
-  tPointZ *zMem = (tPointZ*)malloc( (Size+2)*sizeof(tPointZ) );
-  Mem  = (tPoint3D*)malloc( 2*(Size+2)*sizeof(tPoint3D) );
+  // LDA_20161212 ... multiplicator 'malloc_8xsize' added
+  // 'malloc_8xsize' increases the requested size in the 2 malloc lines below
+  // this comment section.
+  // And it is added to the calculation of 'MemEnd'.
+  // Main reason are the segments drawn to points outside the diagram.
+  // It is assumed to be a memory issue.
+  // Note: As of today the memory calculation is still not 100% clean.
+  int malloc_8xsize=8;
+  tPointZ *zMem = (tPointZ*)malloc( malloc_8xsize*(Size+2)*sizeof(tPointZ) );
+  Mem  = (tPoint3D*)malloc( malloc_8xsize*2*(Size+2)*sizeof(tPoint3D) );
 
   pMem = Mem;
   tPointZ *zp = zMem, *zp_tmp;
@@ -503,7 +532,8 @@ void Rect3DDiagram::removeHiddenLines(char *zBuffer, tBound *Bounds)
 
   // ..........................................
   char *pc;
-  tPoint3D *MemEnd = Mem + 2*Size - 5;   // limit of buffer
+  // LDA_20161212 ... malloc_8xsize added (see comment at line 400)
+  tPoint3D *MemEnd = Mem + malloc_8xsize*2*Size - 5;   // limit of buffer
 
   zp = zMem;
   foreach(Graph *g, Graphs) {


### PR DESCRIPTION
The fix is just an improvement of the 3D data visualization. Reference for comparisioin is  Qucs/version 0.0.9

Though most segments of the surface mesh are made visible there are
* sometimes testcases have few segments missing
* the drawn segments may differ by 1 screen pixel as found by the image comparison script [img_diff.py](https://github.com/ldpgh/qucs-test/blob/master/testsuite/GUI_rect3ddiagram_prj/img_diff.py
)

Screenshots has been added to the issues https://github.com/Qucs/qucs/issues/386#issuecomment-260219711 already.

Changes in the source code (rect3ddiagram.cpp) are
* commentlines + implementation
* commentlines only