### PR TITLE
Pkg win portable

### DIFF
--- a/contrib/windows/portable/README.md
+++ b/contrib/windows/portable/README.md
@@ -1,0 +1,51 @@
+
+## QUCS - Quite Universal Circuit Simulator - version 0.0.19
+
+Qucs is an integrated circuit simulator which means you are able to setup a circuit with a graphical user interface (GUI) and simulate the large-signal, small-signal and noise behaviour of the circuit. After that simulation has finished you can view the simulation results on a presentation page or window.
+
+## Windows portable version
+
+It is recommended to use the script `qucs.bat` to launch QUCS.
+Please modify the script if necessary.
+
+This package is compiled with:
+  - Qt 4.6.8 [1]
+  - GCC 4.8.2 (i686-posix-dwarf-rev3) [2]
+  
+For convenience, the following packages are also included:
+  - ASCO 0.4.10 <http://asco.sourceforge.net/index.html> 
+  - FreeHDL 0.0.8  <http://www.freehdl.seul.org/>  
+    - VHDL simulations require GCC 4.8.2 from [2] or [3]
+  - ADMS 2.3.6
+    - Compilation of Verilog-A modules must performed with GCC 4.8.2 from [2] or [3]
+  
+Optional packages can be obtained elsewhere:
+  - Icarus Verilog <http://bleyer.org/icarus/>
+  - Octave <https://www.gnu.org/software/octave/download.html>
+  
+[1] <http://download.qt.io/official_releases/qt/4.8/4.8.6/qt-opensource-windows-x86-mingw482-4.8.6-1.exe>
+
+[2] <http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.8.2/threads-posix/dwarf/i686-4.8.2-release-posix-dwarf-rt_v3-rev3.7z/>
+
+[3] <https://sourceforge.net/projects/qucs/files/extra/mingw-w64-i686-4.8.2-release-posix-dwarf-rt_v3-rev3-setup.exe>
+
+
+## Resources
+  - Website: <http://qucs.sourceforge.net/>
+  - Main repository: <http://sourceforge.net/p/qucs/git/>
+  - Mirror repository: <https://github.com/Qucs/qucs>
+  - Mailing lists: <http://sourceforge.net/p/qucs/mailman/>
+  - Forum: <http://sourceforge.net/p/qucs/discussion/>
+  - Bug trackers:
+    - <http://sourceforge.net/p/qucs/_list/tickets>
+    - <https://github.com/Qucs/qucs/issues>
+  - Source code documentation:
+    - <http://qucs.github.io/qucs-doxygen/qucs/index.html>
+    - <http://qucs.github.io/qucs-doxygen/qucs-core/index.html>
+  - Downloads: <http://sourceforge.net/projects/qucs/files/>
+  - Translation platform: <https://www.transifex.com/qucs/public/>
+
+
+## License
+
+QUCS is under GNU General Public License, version 2.0+. See COPYING file.

--- a/contrib/windows/portable/qucs-portable-win32.sh
+++ b/contrib/windows/portable/qucs-portable-win32.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# This script builds Windows 32 portable package.
+#
+# Based on https://github.com/Qucs/qucs/wiki/Build-Windows
+# Section about - MinGW 4.8.2 - Qt 4.8.6 - MSYS shell
+# Reasons to do that:
+#   - Use prebuild official Qt libs
+#   - Use and redistribute the available MinGW package (matched to Qt)
+#
+# Notes:
+# - bootstrap will fail, due to blacklisted automake in MSYS
+# - need boostraped tarball made elsewhere with `make dist`
+#
+# TODO:
+# - add contrib/ to `make dist`
+# - craete target like  `make portable`
+
+# run this script from the root of the working tree, ex. ~/git/qucs/
+
+REPO=${PWD}
+echo Working from: ${REPO}
+
+# check for tarball as argument
+if [ "$#" -ne 1 ]; then
+    echo "Provide release tarball as argument..."
+    exit
+fi
+
+# Assume tarball at  ~/git/qucs/qucs-x.x.x.tar.gz
+TARBALL=$(basename $1)
+DIRNAME=$(basename $1 .tar.gz)
+
+echo Using source tarball: $TARBALL
+tar xvfz $TARBALL
+cd $DIRNAME
+
+
+# install prefix
+WINDIR=/c/qucs-win32-bin
+
+# Set QTDIR
+export QTDIR=/C/Qt/4.8.6
+
+
+./configure --disable-doc --prefix=${WINDIR} --disable-dependency-tracking
+make install
+
+
+# add to installer content GPL notice, Icons, site locations
+cp ${REPO}/qucs/COPYING $WINDIR
+cp ${REPO}/NEWS.md $WINDIR
+cp ${REPO}/contrib/windows/portable/README.md $WINDIR
+cp ${REPO}/contrib/windows/portable/qucs.bat $WINDIR
+
+echo Copy runtime libraries...
+cp $QTDIR/bin/Qt3Support4.dll $WINDIR/bin
+cp $QTDIR/bin/QtCore4.dll     $WINDIR/bin
+cp $QTDIR/bin/QtGui4.dll      $WINDIR/bin
+cp $QTDIR/bin/QtNetwork4.dll  $WINDIR/bin
+cp $QTDIR/bin/QtXml4.dll      $WINDIR/bin
+cp $QTDIR/bin/QtSql4.dll      $WINDIR/bin
+cp $QTDIR/bin/QtSvg4.dll      $WINDIR/bin
+cp $QTDIR/bin/QtScript4.dll   $WINDIR/bin
+
+cp $QTDIR/bin/libgcc_s_dw2-1.dll  $WINDIR/bin
+cp $QTDIR/bin/libstdc++-6.dll     $WINDIR/bin
+cp $QTDIR/bin/libwinpthread-1.dll $WINDIR/bin
+
+
+# TODO
+# - copy qucs-doc pdfs
+#
+# TODO (optional)
+# - bundle asco
+# - bundle admsXml,
+# - bundle freehdl
+#
+# Update Readme info about
+# - mingw
+# - octave
+# - icarus
+
+# TODO create redistributable zip at this point
+
+

--- a/contrib/windows/portable/qucs.bat
+++ b/contrib/windows/portable/qucs.bat
@@ -1,0 +1,41 @@
+Rem Wrapper script for QUCS
+@echo off
+
+Rem Silently unset environment variables used until 0.0.18
+set QUCSDIR=
+set ASCOBINDIR=
+set FREEHDL=
+set OCTAVEDIR=
+set MINGWDIR=
+
+Rem Get the location of this batch file.
+Rem Note: QUCSPREFIX ends with a backslash
+set QUCSPREFIX=%~dp0
+
+Rem Set QUCS into the path
+set PATH=%QUCSPREFIX%bin;%PATH%
+
+Rem Set up admsXml
+Rem   - Override needed for now. Else it could be using QucsSettings from version 0.0.18
+set ADMSXMLBINDIR=%QUCSPREFIX%bin
+
+Rem Set up FreeHDL variable
+rem   - Portable version assume FreeHDL installed in the same prefix as QUCS
+Rem   - qucsdigi.bat and qucsdigilib.bat set %FREEHDL%\bin on the path
+set FREEHDL=%QUCSPREFIX%
+
+Rem Set up MingGW
+Rem   - GCC 4.8.2 / MinGW must be on the path for FreeHDL and Verilog-A module compilation
+set MINGWDIR=C:\mingw32
+set PATH=%MINGWDIR%\bin;%PATH%
+
+Rem Set up Icarus into path, 
+Rem   - upstream installer does not set the path
+set ICARUS_PREFIX=C:\iverilog
+set PATH=%ICARUS_PREFIX%\bin;%PATH%
+
+Rem  Start Qucs-GUI
+start qucs.exe
+
+Rem Close cmd.exe window
+exit

--- a/qucs/qucs/qucsdigi.bat
+++ b/qucs/qucs/qucsdigi.bat
@@ -45,7 +45,7 @@ set CXXFLAGS=-O2 -I"%FREEHDL%/include"
 set LDFLAGS=-L"%FREEHDL%/lib" -L"%FREEHDL%/lib/freehdl" -Wl,--enable-auto-import -s
 set LIBS=-lfreehdl-kernel -lfreehdl-std -lieee -lregex
 
-set PATH=%PATH%;%FREEHDL%/bin;%MINGWDIR%/bin;%QUCSDIR%/bin
+set PATH=%PATH%;%FREEHDL%/bin
 
 echo running C++ conversion...
 freehdl-v2cc -m %NAME%._main_.cc -L"%FREEHDL%/share/freehdl/lib" -Lvhdl -o %NAME%.cc %NAME%.vhdl

--- a/qucs/qucs/qucsdigilib.bat
+++ b/qucs/qucs/qucsdigilib.bat
@@ -42,7 +42,7 @@ set CXXFLAGS=-O2 -I"%FREEHDL%/include"
 set AR=ar
 set RANLIB=ranlib
 
-set PATH=%PATH%;%FREEHDL%/bin;%MINGWDIR%/bin;%QUCSDIR%/bin
+set PATH=%PATH%;%FREEHDL%/bin
 
 echo running C++ conversion...
 freehdl-v2cc -l%LIBRARY% -Lvhdl -L"%FREEHDL%/share/freehdl/lib" -o %NAME%.cc %NAME%.vhdl

--- a/qucs/qucs/qucsveri.bat
+++ b/qucs/qucs/qucsveri.bat
@@ -39,8 +39,6 @@ if not exist %NAME% goto nofile
 copy %NAME% digi.v > NUL
 set NAME=digi
 
-set PATH=%PATH%;%QUCSDIR%/bin
-
 echo running VerilogHDL conversion...
 iverilog -o%NAME%.bin -sTestBench %NAME%.v
 


### PR DESCRIPTION
First version of scripts for Windows portable package.
Unsed QUCSDIR on batch script to allow older and new versions side by side, see #627 for comments.