### PR TITLE
"init" is 2nd parameter, not 1st

### DIFF
--- a/qucs/qucs/components/digi_source.cpp
+++ b/qucs/qucs/components/digi_source.cpp
@@ -110,7 +110,7 @@ QString Digi_Source::vhdlCode(int NumPorts)
   int z = 0;
   char State;
   if(NumPorts <= 0) {  // time table simulation ?
-    if(Props.at(0)->Value == "low")
+    if(Props.at(1)->Value == "low")
       State = '0';
     else
       State = '1';


### PR DESCRIPTION
Properties are:
```
  Props.append(new Property("Num", "1", true,
		QObject::tr("number of the port")));
  Props.append(new Property("init", "low", false,
		QObject::tr("initial output value")+" [low, high]"));
  Props.append(new Property("times", "1ns; 1ns", false,
		QObject::tr("list of times for changing output value")));
  Props.append(new Property("V", "1 V", false,
		QObject::tr("voltage of high level")));
```
We want to get value of "init" property, so we should access Props[1], not Props[0]