### PR TITLE
veriloga makefile: set default SHELL for Windows.

### DIFF
--- a/qucs-core/src/components/verilog/va2cpp.makefile
+++ b/qucs-core/src/components/verilog/va2cpp.makefile
@@ -25,6 +25,7 @@ VA=.va
 # handle deletion if Windows cmd.exe or MinGW MSYS terminal
 ifeq ($(OS),Windows_NT)
   RM=del
+  SHELL=cmd.exe
   ifeq ($(MSYSTEM),MINGW32)
 	RM=rm -f
   endif


### PR DESCRIPTION
It was reported that having Git Bash installed could create issues
while running the va2cpp makefile.

This workaround sets the default shell/terminal as the cmd.exe on
Windows.

See issue #637 for reference.
