### PR TITLE
ci: skip qucsator tests on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,9 @@ script:
   - echo ${DISTCHECK_CONFIGURE_FLAGS}
   - ./configure --disable-dependency-tracking --with-gtest=/tmp/gtest ${CONFIGURE_FLAGS}
   - if [ "$OSX" = true ]; then
-      make check;
+      make;
+      make qucscheck;
+      make eqncheck;
     else
       make distcheck DISTCHECK_CONFIGURE_FLAGS="${DISTCHECK_CONFIGURE_FLAGS}";
     fi


### PR DESCRIPTION
Random issues keep on showing up on the OSX Travis CI while running
the qucs-test projects.

Might be related to the Python multiprocessing module used to run
the simulations.

Disabling tests as no one is able to reproduce the environment or
the issues.