### PR TITLE
Fix for AC and SP sweep

### DIFF
--- a/qucs-core/src/sweep.cpp
+++ b/qucs-core/src/sweep.cpp
@@ -140,8 +140,6 @@ void sweep::reverse (void) {
 nr_double_t sweep::next (void) {
   nr_double_t res = data[counter];
   if (++counter >= size) counter = 0;
-  if (size == 1)
-    return parent->getPropertyDouble ("Values");
   return res;
 }
 


### PR DESCRIPTION
It was found a bug in the AC solver while testing #682. The 'freq' variable ('acsolver.cpp', line 100) skips the first value of 'swp'. So if the sweep is performed over a list of length 1, swp->next() always returns 0.

The same logic applies to the SP solver.

P.S.: I've accidentally opened a another PR...