### PR TITLE
Fix CMake and various warnings after merging #682

### DIFF
--- a/qucs/qucs-filter/ccoupled_shunt_resonators.cpp
+++ b/qucs/qucs-filter/ccoupled_shunt_resonators.cpp
@@ -42,7 +42,7 @@ CCoupled_Shunt_Resonator_Filter::CCoupled_Shunt_Resonator_Filter()
 
 // -----------------------------------------------------------------------
 // This function generates the schematic
-QString* CCoupled_Shunt_Resonator_Filter::createSchematic(tFilter *Filter, tSubstrate *Substrate, bool isMicrostrip)
+QString* CCoupled_Shunt_Resonator_Filter::createSchematic(tFilter *Filter)
 {
 //Design equations
 double f0 = Filter->Frequency+0.5*(Filter->Frequency2-Filter->Frequency);//Central frequency

--- a/qucs/qucs-filter/ccoupled_shunt_resonators.h
+++ b/qucs/qucs-filter/ccoupled_shunt_resonators.h
@@ -31,7 +31,7 @@ class CCoupled_Shunt_Resonator_Filter : public TL_Filter {
 public:
   CCoupled_Shunt_Resonator_Filter();
 
-  static QString* createSchematic(tFilter*, tSubstrate*, bool);
+  static QString* createSchematic(tFilter*);
 };
 
 #endif

--- a/qucs/qucs-filter/qucsfilter.cpp
+++ b/qucs/qucs-filter/qucsfilter.cpp
@@ -418,7 +418,7 @@ QString * QucsFilter::calculateFilter(struct tFilter * Filter)
         s = QW_Coupled_Ring_Filter::createSchematic(Filter, &Substrate, isMicrostrip);
         return s;
       case 7: // Capacitively coupled shunt resonators
-        s = CCoupled_Shunt_Resonator_Filter::createSchematic(Filter, &Substrate, isMicrostrip);
+        s = CCoupled_Shunt_Resonator_Filter::createSchematic(Filter);
         return s;
       case 8:  // equation defined filter
         s = Equation_Filter::createSchematic(Filter);

--- a/qucs/qucs-filter/qw_coupled_ring_filter.cpp
+++ b/qucs/qucs-filter/qw_coupled_ring_filter.cpp
@@ -52,9 +52,7 @@ QString* QW_Coupled_Ring_Filter::createSchematic(tFilter *Filter, tSubstrate *Su
   double y = 0.01; // Bandpass ripple (dB)
   double Ye = 1/Ze;
   double x = -pow(10,(-y/20));
-  double rf = ftz/f0;//Ratio between the first transmission zero and the central frequency
   double TZ = (sin(pi*ftz/(2*f0))*sin(pi*ftz/(2*f0)))/(1 + cos(pi*ftz/(2*f0))*cos(pi*ftz/(2*f0)));
-  double theta_tz = pi*ftz/(2*f0);
   double SQ = sqrt((1-x*x)*(TZ*TZ-1)*(TZ*TZ-1)*Z0*Z0);
   double R = -Ye*Z0*(Z0*(x*x-2)+2*SQ);
   double Q = 2*TZ*TZ*Ye*Z0*(Z0*(x*x-2)+SQ);

--- a/qucs/qucs/diagrams/CMakeLists.txt
+++ b/qucs/qucs/diagrams/CMakeLists.txt
@@ -13,7 +13,7 @@ diagrams.h
 graph.h
 marker.h
 markerdialog.h
-phasor.h
+phasordiagram.h
 polardiagram.h
 psdiagram.h
 rect3ddiagram.h
@@ -29,7 +29,7 @@ SET(DIAGRAMS_SRCS
 curvediagram.cpp	graph.cpp		polardiagram.cpp	smithdiagram.cpp
 diagram.cpp		marker.cpp		psdiagram.cpp		tabdiagram.cpp
 diagramdialog.cpp	markerdialog.cpp	rect3ddiagram.cpp	timingdiagram.cpp
-rectdiagram.cpp		phasor.cpp		truthdiagram.cpp	waveac.cpp
+rectdiagram.cpp		phasordiagram.cpp		truthdiagram.cpp	waveac.cpp
 )
 
 SET(DIAGRAMS_MOC_HDRS

--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -1639,10 +1639,9 @@ void DiagramDialog::addvar(QString a)
     m = GraphList->findItems(Var2, Qt::MatchExactly);
     l = Var2.indexOf(a,0,Qt::CaseSensitive);
 
-    if( l != -1 && Var2.size() == (l + a.size()) && !m.size()>0)//Var2.size == (l + a.size()) in case of voltage (.v) to don't let pass a variable like (name.var)
+    if( l != -1 && Var2.size() == (l + a.size()) && !(m.size()>0))//Var2.size == (l + a.size()) in case of voltage (.v) to don't let pass a variable like (name.var)
     {
-      QTableWidgetItem* I;
-      slotTakeVar(I);
+      slotTakeVar(NULL);//In the case of the phasor diagram, the table ChooseVars is not used. Instead of that, the graph is put in the list bu using Var2.
     }
 
   } while(i > 0);

--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -228,13 +228,13 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     PropertyBox->addItem(tr("solid line"));
     if(Diag->Name != "Phasor")
     {
-      PropertyBox->insertItem(tr("dash line"));
-      PropertyBox->insertItem(tr("dot line"));
+      PropertyBox->addItem(tr("dash line"));
+      PropertyBox->addItem(tr("dot line"));
       if(Diag->Name != "Time") {
-	PropertyBox->insertItem(tr("long dash line"));
-	PropertyBox->insertItem(tr("stars"));
-	PropertyBox->insertItem(tr("circles"));
-	PropertyBox->insertItem(tr("arrows"));
+    PropertyBox->addItem(tr("long dash line"));
+    PropertyBox->addItem(tr("stars"));
+    PropertyBox->addItem(tr("circles"));
+    PropertyBox->addItem(tr("arrows"));
       }
     }
     connect(PropertyBox, SIGNAL(activated(int)),
@@ -1598,7 +1598,7 @@ void DiagramDialog::addvar(QString a)
   QFileInfo Info(defaultDataSet);
   QString DocName = ChooseData->currentText()+".dat";
 
-  QFile file(Info.dirPath() + QDir::separator() + DocName);
+  QFile file(Info.path() + QDir::separator() + DocName);
   if(!file.open(QIODevice::ReadOnly)) {
     return;
   }

--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -1673,7 +1673,6 @@ void DiagramDialog::remvar(QString a)
 /*checks if a type of graph is on screen*/
 bool DiagramDialog::testvar (QString a)
 {
-  int i;
   QString Var;
 
   foreach(Graph *pg, Diag->Graphs) {

--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -231,10 +231,10 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       PropertyBox->addItem(tr("dash line"));
       PropertyBox->addItem(tr("dot line"));
       if(Diag->Name != "Time") {
-    PropertyBox->addItem(tr("long dash line"));
-    PropertyBox->addItem(tr("stars"));
-    PropertyBox->addItem(tr("circles"));
-    PropertyBox->addItem(tr("arrows"));
+        PropertyBox->addItem(tr("long dash line"));
+        PropertyBox->addItem(tr("stars"));
+        PropertyBox->addItem(tr("circles"));
+        PropertyBox->addItem(tr("arrows"));
       }
     }
     connect(PropertyBox, SIGNAL(activated(int)),

--- a/qucs/qucs/diagrams/graph.cpp
+++ b/qucs/qucs/diagrams/graph.cpp
@@ -305,7 +305,7 @@ int Graph::getSelectedP(int x, int y)
           yn = d1 * float(x) + b1;
         }
       }
-      if(((f1 >= f3) && (xn >= f3)  && (xn <= f1)) || (f3 >= f1) && (xn >= f1)  && (xn <= f3))
+      if(((f1 >= f3) && (xn >= f3)  && (xn <= f1)) || ((f3 >= f1) && (xn >= f1)  && (xn <= f3)))
         if(((f2 >= f4) && (yn >= f4) && (yn <= f2)) || ((f4 >= f2) && (yn >= f2) && (yn <= f4)))
           if((y >= int(yn) - 5) && (y <= int(yn) + 5) && (x >= int(xn) - 5) && (x <= int(xn) + 5))
             return 1;

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -385,7 +385,7 @@ bool Marker::moveLeftRight(bool left)
       x=diag()->freq[n];
       if(VarPos[0] == x) break;
     }
-    if(n == diag()->nfreqt) n == diag()->nfreqt-1;
+    if(n == diag()->nfreqt) n = diag()->nfreqt-1;
 
     if(left) {
       if(n == 0) return false;


### PR DESCRIPTION
This PR solves the following issues after merging #682:

* CMake became broken. Added proper filenames in `diagrams/CMakeLists.txt`
* There was a lot of deprecation warnings in `diagramdialog.cpp` on `QComboBox::inserItem()`. Replased by `QComboBox::addItem()`.
* Fixed "unused variable"  `i` in `diagramdialog.cpp`. This variable was indeed unused.

There remains an unfixed warning in `marker.cpp` Line 388. It contains the following code: 
~~~
if(n == diag()->nfreqt) n == diag()->nfreqt-1;
~~~

I didn't understand what this code should do. It seems, the  comparison `==` should be replaced by assignment `=`. The current line does nothing, but all works as expected. @gildias, Could you please clarify, what exactly did you mean?