### PR TITLE
Fix of #633: Part 1

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -883,7 +883,7 @@ void QucsApp::initCursorMenu()
   }
   
   APPEND_MENU(ActionCMenuOpen, slotCMenuOpen, "Open")
-  APPEND_MENU(ActionCMenuCopy, slotCMenuCopy, "Duplicate")
+  APPEND_MENU(ActionCMenuCopy, slotCMenuCopy, "Copy file")
   APPEND_MENU(ActionCMenuRename, slotCMenuRename, "Rename")
   APPEND_MENU(ActionCMenuDelete, slotCMenuDelete, "Delete")
   APPEND_MENU(ActionCMenuInsert, slotCMenuInsert, "Insert")


### PR DESCRIPTION
Here is a first part of fix for #633. I renamed "Duplicate" to "Copy file". This name is more relevant to actual function of this menu item. The update of documentation will follow soon.