### PR TITLE
Admittance/impedance marker data management at Smith chart diagrams

### DIFF
--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -383,9 +383,11 @@ int Diagram::regionCode(float x, float y) const
 // Is virtual. This one is for round diagrams only.
 bool Diagram::insideDiagram(float x, float y) const
 {
-  float R = float(x2)/2.0 + 1.0; // +1 seems better (graph sometimes little outside)
+  float R = x2/2.0;
   x -= R;
   y -= R;
+  R += 1.0; // +1 seems better ? (allow graph to go a little outside)
+  //qDebug() << "insideDiagram" << x << y << R << (x*x + y*y- R*R);
   return ((x*x + y*y) <= R*R);
 }
 

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -60,6 +60,12 @@ Marker::Marker(Graph *pg_, int branchNo, int cx_, int cy_) :
   cy = -cy_;
   fCX = float(cx);
   fCY = float(cy);
+
+  //Default setting for displaying extra parameters. The markers will show the impedance data if the chart is type "Smith".
+  //In the case of having an admittance chart, admittance will be display. 
+  DisplayZ = (diag()->Name == "Smith");
+  DisplayY = (diag()->Name == "ySmith");
+
   if(!pGraph){
     makeInvalid();
   }else{
@@ -576,8 +582,18 @@ QString Marker::save()
 
   s += QString::number(x1) +" "+ QString::number(y1) +" "
       +QString::number(Precision) +" "+ QString::number(numMode);
-  if(transparent)  s += " 1>";
-  else  s += " 0>";
+  if(transparent)  s += " 1 ";
+  else  s += " 0 ";
+
+  if (diag()->Name.count("Smith"))//Impedance/admittance smith charts
+  {
+  (DisplayZ) ? s+="1 ":s+= "0 ";
+  (DisplayY) ? s+="1>":s+= "0>";
+  }
+  else
+  {
+    s+=">"; 
+  }
 
   return s;
 }
@@ -629,6 +645,14 @@ bool Marker::load(const QString& _s)
   if(n.isEmpty()) return true;  // is optional
   if(n == "0")  transparent = false;
   else  transparent = true;
+
+  //Display impedance data in case of having a Smith chart
+  n  = s.section(' ',7,7);
+  DisplayZ = (n.toInt()!=0);
+
+  //Display admittance data in case of having a Smith chart
+  n  = s.section(' ',8,8);
+  DisplayY = (n.toInt()!=0);
 
   return true;
 }

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -63,8 +63,13 @@ Marker::Marker(Graph *pg_, int branchNo, int cx_, int cy_) :
 
   //Default setting for displaying extra parameters. The markers will show the impedance data if the chart is type "Smith".
   //In the case of having an admittance chart, admittance will be display. 
-  DisplayZ = (diag()->Name == "Smith");
-  DisplayY = (diag()->Name == "ySmith");
+  if (diag()->Name == "Smith") {
+    optText = Marker::SHOW_Z;
+  } else if (diag()->Name == "ySmith") {
+    optText = Marker::SHOW_Y;
+  } else {
+    optText = 0;
+  }
 
   if(!pGraph){
     makeInvalid();
@@ -582,18 +587,15 @@ QString Marker::save()
 
   s += QString::number(x1) +" "+ QString::number(y1) +" "
       +QString::number(Precision) +" "+ QString::number(numMode);
-  if(transparent)  s += " 1 ";
-  else  s += " 0 ";
+  if(transparent)  s += " 1";
+  else  s += " 0";
 
   if (diag()->Name.count("Smith"))//Impedance/admittance smith charts
   {
-  (DisplayZ) ? s+="1 ":s+= "0 ";
-  (DisplayY) ? s+="1>":s+= "0>";
+    s += " " + QString::number(optText);
   }
-  else
-  {
-    s+=">"; 
-  }
+
+  s+=">"; 
 
   return s;
 }
@@ -646,13 +648,13 @@ bool Marker::load(const QString& _s)
   if(n == "0")  transparent = false;
   else  transparent = true;
 
-  //Display impedance data in case of having a Smith chart
+  // for Smith charts; optional parameters to be displayed
   n  = s.section(' ',7,7);
-  DisplayZ = (n.toInt()!=0);
-
-  //Display admittance data in case of having a Smith chart
-  n  = s.section(' ',8,8);
-  DisplayY = (n.toInt()!=0);
+  if(n.isEmpty()) return true;  // backward compatibility
+  int numOpt = n.toInt(&ok);
+  if(!ok) return false;
+  
+  optText = static_cast<extraText>(numOpt);
 
   return true;
 }

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -85,11 +85,21 @@ public:
 // private: // not yet, cross-manipulated by MarkerDialog
   int Precision; // number of digits to show
   int numMode;   // real/imag or polar (deg/rad)
-  bool DisplayZ, DisplayY;//Only for Smith charts. These flags indicate the optional parameters to be displayed
 
 public: // shouldn't be there, cross-manipulated by MarkerDialog
         // to be implemented within SmithDiagram.
 	double Z0;		//Only used in smith chart marker, to convert S to Z
+
+  // These flags indicate the optional parameters to be displayed
+  // Currently used only for Smith charts
+  enum extraText {
+    SHOW_Z  = 0x01,
+    SHOW_Y  = 0x02,
+    SHOW_ZS = 0x04,
+    SHOW_ZP = 0x08
+  };
+
+  unsigned optText;  // selected optional parameters
 };
 
 #endif

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -85,6 +85,7 @@ public:
 // private: // not yet, cross-manipulated by MarkerDialog
   int Precision; // number of digits to show
   int numMode;   // real/imag or polar (deg/rad)
+  bool DisplayZ, DisplayY;//Only for Smith charts. These flags indicate the optional parameters to be displayed
 
 public: // shouldn't be there, cross-manipulated by MarkerDialog
         // to be implemented within SmithDiagram.

--- a/qucs/qucs/diagrams/markerdialog.cpp
+++ b/qucs/qucs/diagrams/markerdialog.cpp
@@ -51,19 +51,31 @@ MarkerDialog::MarkerDialog(Marker *pm_, QWidget *parent)
   g->addWidget(NumberBox, 1, 1);
 
   assert(pMarker->diag());
-  if(pMarker->diag()->Name=="Smith") // BUG
+  if(pMarker->diag()->Name.count("Smith")) // BUG
   {
     //S parameter also displayed as Z, need Z0 here
-		SourceImpedance = new QLineEdit();
-  	SourceImpedance->setText(QString::number(pMarker->Z0));
+    SourceImpedance = new QLineEdit();
+    SourceImpedance->setText(QString::number(pMarker->Z0));
 
-		g->addWidget(new QLabel(tr("Z0: ")), 2,0);
-		g->addWidget(SourceImpedance,2,1);
-	}
+    g->addWidget(new QLabel(tr("Z0: ")), 2,0);
+    g->addWidget(SourceImpedance,2,1);
+    ZYSelectBox = new QWidget();
+    QGridLayout *gridZY = new QGridLayout();
+    ZCheckBox = new QCheckBox("Impedance");
+    YCheckBox = new QCheckBox("Admittance");
+    gridZY->addWidget(ZCheckBox, 0, 0);
+    gridZY->addWidget(YCheckBox, 0, 1);
+    ZCheckBox->setChecked(pMarker->DisplayZ);
+    YCheckBox->setChecked(pMarker->DisplayY);
+    ZYSelectBox->setLayout(gridZY);
+
+    g->addWidget(new QLabel("Extra parameters"),3,0);
+    g->addWidget(ZYSelectBox,3,1);
+   }
   
   TransBox = new QCheckBox(tr("transparent"));
   TransBox->setChecked(pMarker->transparent);
-  g->addWidget(TransBox,3,0);
+  g->addWidget(TransBox,4,0);
 
   // first => activated by pressing RETURN
   QPushButton *ButtOK = new QPushButton(tr("OK"));
@@ -76,7 +88,7 @@ MarkerDialog::MarkerDialog(Marker *pm_, QWidget *parent)
   b->setSpacing(5);
   b->addWidget(ButtOK);
   b->addWidget(ButtCancel);
-  g->addLayout(b,4,0,1,2);
+  g->addLayout(b,5,0,1,2);
 
   this->setLayout(g);
 }
@@ -95,15 +107,20 @@ void MarkerDialog::slotAcceptValues()
     changed = true;
   }
   assert(pMarker->diag());
-  if(pMarker->diag()->Name=="Smith") // BUG: need generic MarkerDialog.
-	{
-			double SrcImp = SourceImpedance->text().toDouble();
-			if(SrcImp != pMarker->Z0)
-			{
-					pMarker->Z0 = SrcImp;
-					changed = true;
-			}
-	}
+
+   if(pMarker->diag()->Name.count("Smith")) // BUG: need generic MarkerDialog.
+   {
+      double SrcImp = SourceImpedance->text().toDouble();
+      if(SrcImp != pMarker->Z0)
+      {
+	pMarker->Z0 = SrcImp;
+      }
+    //Update extra marker data display settings
+    pMarker->DisplayZ = ZCheckBox->isChecked(); 
+    pMarker->DisplayY = YCheckBox->isChecked();
+    changed = true;
+   }
+
   if(NumberBox->currentIndex() != pMarker->numMode) {
     pMarker->numMode = NumberBox->currentIndex();
     changed = true;

--- a/qucs/qucs/diagrams/markerdialog.cpp
+++ b/qucs/qucs/diagrams/markerdialog.cpp
@@ -63,10 +63,16 @@ MarkerDialog::MarkerDialog(Marker *pm_, QWidget *parent)
     QGridLayout *gridZY = new QGridLayout();
     ZCheckBox = new QCheckBox("Impedance");
     YCheckBox = new QCheckBox("Admittance");
+    ZSCheckBox = new QCheckBox("Series eq. circuit");
+    ZPCheckBox = new QCheckBox("Parallel eq. circuit");    
     gridZY->addWidget(ZCheckBox, 0, 0);
     gridZY->addWidget(YCheckBox, 0, 1);
-    ZCheckBox->setChecked(pMarker->DisplayZ);
-    YCheckBox->setChecked(pMarker->DisplayY);
+    gridZY->addWidget(ZSCheckBox, 1, 0);
+    gridZY->addWidget(ZPCheckBox, 1, 1);
+    ZCheckBox->setChecked(pMarker->optText & Marker::SHOW_Z);
+    YCheckBox->setChecked(pMarker->optText & Marker::SHOW_Y);
+    ZSCheckBox->setChecked(pMarker->optText & Marker::SHOW_ZS);
+    ZPCheckBox->setChecked(pMarker->optText & Marker::SHOW_ZP);
     ZYSelectBox->setLayout(gridZY);
 
     g->addWidget(new QLabel("Extra parameters"),3,0);
@@ -116,8 +122,12 @@ void MarkerDialog::slotAcceptValues()
 	pMarker->Z0 = SrcImp;
       }
     //Update extra marker data display settings
-    pMarker->DisplayZ = ZCheckBox->isChecked(); 
-    pMarker->DisplayY = YCheckBox->isChecked();
+      pMarker->optText =
+        (ZCheckBox->isChecked()) * Marker::SHOW_Z +
+        (YCheckBox->isChecked()) * Marker::SHOW_Y +
+        (ZSCheckBox->isChecked()) * Marker::SHOW_ZS +
+        (ZPCheckBox->isChecked()) * Marker::SHOW_ZP;
+
     changed = true;
    }
 

--- a/qucs/qucs/diagrams/markerdialog.h
+++ b/qucs/qucs/diagrams/markerdialog.h
@@ -41,7 +41,7 @@ public:
   QLineEdit  *SourceImpedance;
   QCheckBox  *TransBox;
   QWidget *ZYSelectBox;
-  QCheckBox *ZCheckBox, *YCheckBox;
+  QCheckBox *ZCheckBox, *YCheckBox, *ZSCheckBox, *ZPCheckBox;
 };
 
 #endif

--- a/qucs/qucs/diagrams/markerdialog.h
+++ b/qucs/qucs/diagrams/markerdialog.h
@@ -40,6 +40,8 @@ public:
   QLineEdit  *Precision;
   QLineEdit  *SourceImpedance;
   QCheckBox  *TransBox;
+  QWidget *ZYSelectBox;
+  QCheckBox *ZCheckBox, *YCheckBox;
 };
 
 #endif

--- a/qucs/qucs/diagrams/smithdiagram.cpp
+++ b/qucs/qucs/diagrams/smithdiagram.cpp
@@ -135,20 +135,30 @@ QString SmithDiagram::extraMarkerText(Marker const* m) const
   std::vector<double> const& Pos = m->varPos();
   unsigned nVarPos = pGraph->numAxes();
   assert(nVarPos == Pos.size());
-  double Zr, Zi;
+  double Zr, Zi, Yr, Yi;
   double Z0 = m->Z0;
   double Precision = m->precision(); // hmmm
+  QString ExtraParamsText;//Variable used for displaying extra marker data (impedance and/or admittance)
 
   Zr = m->powReal();
   Zi = m->powImag();
 
   MatchDialog::r2z(Zr, Zi, Z0);
+  Yr = 1/Zr; Yi = 1/Zi;//The impedance data are converted into admittance.
   QString Var = pGraph->Var;
+  QString Var_ =Var;
+
+  QString valMarkerZ = misc::complexRect(Zr, Zi, Precision);
+  QString valMarkerY = misc::complexRect(Yr, Yi, Precision);
 
   if(Var.startsWith("S")) { // uuh, ooh hack.
-    return "\n"+ Var.replace('S', 'Z')+": " +misc::complexRect(Zr, Zi, Precision);
+      if (m->DisplayZ) ExtraParamsText = "\n"+ Var.replace('S', 'Z')+": " +valMarkerZ;
+      if (m->DisplayY) ExtraParamsText += "\n"+ Var_.replace('S', 'Y')+": " +valMarkerY;//Var_ is a copy of pGraph->Var. It is used to guarantee the display is correct even if DisplayZ is true
+    return ExtraParamsText;
   }else{
-    return "\nZ("+ Var+"): " +misc::complexRect(Zr, Zi, Precision);
+      if (m->DisplayZ) ExtraParamsText = "\nZ("+ Var+"): " +valMarkerZ;
+      if (m->DisplayY) ExtraParamsText += "\nY("+ Var+"): " +valMarkerY;
+    return ExtraParamsText;
   }
 }
 

--- a/qucs/qucs/diagrams/smithdiagram.cpp
+++ b/qucs/qucs/diagrams/smithdiagram.cpp
@@ -144,7 +144,13 @@ QString SmithDiagram::extraMarkerText(Marker const* m) const
   Zi = m->powImag();
 
   MatchDialog::r2z(Zr, Zi, Z0);
-  Yr = 1/Zr; Yi = 1/Zi;//The impedance data are converted into admittance.
+  // convert impedance to admittance
+  Yr = Zr; Yi = Zi;
+  MatchDialog::c2p(Yr, Yi);
+  Yr = 1.0 / Yr; // magnitude
+  Yi = -Yi; // angle
+  MatchDialog::p2c(Yr, Yi);
+    
   QString Var = pGraph->Var;
   QString Var_ =Var;
 

--- a/qucs/qucs/diagrams/smithdiagram.cpp
+++ b/qucs/qucs/diagrams/smithdiagram.cpp
@@ -187,8 +187,8 @@ QString SmithDiagram::extraMarkerText(Marker const* m) const
       Ds = Zi / omega; // equivalent series inductance
       unitSymbol = "H";
     }
-    ExtraParamsText += "\n" + misc::num2str(Zr) + QChar(0x2126)
-      + "+" + misc::num2str(Ds) + unitSymbol;
+    ExtraParamsText += "\n" + misc::num2str(Zr, Precision) + QChar(0x2126)
+      + "+" + misc::num2str(Ds, Precision) + unitSymbol;
   }
 
   if (m->optText & Marker::SHOW_ZP) {
@@ -199,10 +199,11 @@ QString SmithDiagram::extraMarkerText(Marker const* m) const
       Ds = -1.0 / (omega * Yi); // equivalent parallel inductance
       unitSymbol = "H";
     }
-    ExtraParamsText += "\n" + misc::num2str(1/Yr) + QChar(0x2126)
-      + "||" + misc::num2str(Ds) + unitSymbol;
+    ExtraParamsText += "\n" + misc::num2str(1/Yr, Precision) + QChar(0x2126)
+      + "||" + misc::num2str(Ds, Precision) + unitSymbol;
   }
   return ExtraParamsText;
 }
 
 // vim:ts=8:sw=2:noet
+ 


### PR DESCRIPTION
So far, when placing a marker at a Smith chart diagram (both impedance and admittance types), the markers always show S-par and impedance data. In this sense, this PR fixes this and includes a new option in marker dialog so as to let the user decide which of these parameters (impedance, admittance, both or none) wants to see.

![selection_001](https://user-images.githubusercontent.com/13180689/28494352-0cf7ff54-6f2c-11e7-88bd-fa3aeb0cdde5.png)

The default behavior is to show impedance data at conventional Smith charts and admittance data at  admittance Smith chart diagrams.

It was added two extra fields ('display admittance' and 'display impedance') to the format employed to save the marker settings on the .dpl file.

I'll try to implement this feature in #407 soon. After that, if #407 gets merged, this PR can be closed.
