### PR TITLE
Fix polar() function

### DIFF
--- a/qucs-core/src/math/complex.cpp
+++ b/qucs-core/src/math/complex.cpp
@@ -550,7 +550,7 @@ nr_complex_t limexp (const nr_complex_t z)
 */
 nr_complex_t polar (const nr_double_t mag, const nr_double_t ang )
 {
-#ifdef HAVE_CXX_COMPLEX_POLAR_COMPLEX
+#ifdef HAVE_CXX_COMPLEX_POLAR
     return std::polar (mag, ang);
 #else
     return nr_complex_t (mag * cos (ang), mag * sin (ang));

--- a/qucs-core/src/math/complex.cpp
+++ b/qucs-core/src/math/complex.cpp
@@ -568,7 +568,7 @@ nr_complex_t polar (const nr_complex_t a, const nr_complex_t p)
 #ifdef HAVE_CXX_COMPLEX_POLAR_COMPLEX
     return std::polar (a, p);
 #else
-    return a * exp (nr_complex_t (imag (p),-real (p)));
+    return a * exp(nr_complex_t(0.0, 1.0) * p);
 #endif
 }
 


### PR DESCRIPTION
It was found a bug in the polar() function while trying to help with this issue https://sourceforge.net/p/qucs/discussion/311050/thread/005906e4/?limit=25#e2b9

The line which converts the argument from polar to Cartesian coordinates is wrong:
 r·exp(j*theta) =  r·exp(nr_complex_t(0, Re{theta}))                r, theta \in R