### PR TITLE
Add context menu to documents tabs

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2979,6 +2979,9 @@ void ContextMenuTabWidget::showContextMenu(const QPoint& point)
   APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseLeft, "Close all to the left")
   APPEND_MENU(ActionCxMenuCloseOthers, slotCxMenuCloseRight, "Close all to the right")
   APPEND_MENU(ActionCxMenuCloseAll, slotCxMenuCloseAll, "Close all")
+  menu.addSeparator();
+  APPEND_MENU(ActionCxMenuCopyPath, slotCxMenuCopyPath, "Copy full path")
+  APPEND_MENU(ActionCxMenuOpenFolder, slotCxMenuOpenFolder, "Open containing folder")
 #undef APPEND_MENU
 
     menu.exec(tabBar()->mapToGlobal(point));
@@ -3015,6 +3018,27 @@ void ContextMenuTabWidget::slotCxMenuCloseAll()
   App->closeAllFiles();
   // create empty schematic
   App->slotFileNew();
+}
+
+void ContextMenuTabWidget::slotCxMenuCopyPath()
+{
+  // get the document where the context menu was opened
+  QucsDoc *d = App->getDoc(contextTabIndex);
+  // copy the document full path to the clipboard
+  QClipboard *cb = QApplication::clipboard();
+  cb->setText(d->DocName);
+}
+
+void ContextMenuTabWidget::slotCxMenuOpenFolder()
+{
+  // get the document where the context menu was opened
+  QucsDoc *d = App->getDoc(contextTabIndex);
+  QString dName = d->DocName;
+  // a not-yet-saved document does not have a DocName
+  if (!dName.isEmpty()) {
+    QFileInfo Info(dName);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(Info.canonicalPath()));
+  }
 }
 
 // #########################################################################

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1340,16 +1340,22 @@ void QucsApp::slotButtonProjDel()
 // #####  documents.                                          #####
 // ################################################################
 
-void QucsApp::slotFileNew()
+void QucsApp::slotFileNew(bool enableOpenDpl)
 {
   statusBar()->showMessage(tr("Creating new schematic..."));
   slotHideEdit(); // disable text edit of component property
 
   Schematic *d = new Schematic(this, "");
+  d->SimOpenDpl = enableOpenDpl;
   int i = DocumentTab->addTab(d, QPixmap(":/bitmaps/empty.xpm"), QObject::tr("untitled"));
   DocumentTab->setCurrentIndex(i);
 
   statusBar()->showMessage(tr("Ready."));
+}
+
+void QucsApp::slotFileNewNoDD()
+{
+  slotFileNew(false);
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1635,6 +1635,34 @@ void QucsApp::slotFileClose(int index)
     closeFile(index);
 }
 
+// Close all documents except the current one
+void QucsApp::slotFileCloseOthers()
+{
+  closeAllFiles(DocumentTab->currentIndex());
+}
+
+// Close all documents to the left of the current one
+void QucsApp::slotFileCloseAllLeft()
+{
+  closeAllLeft(DocumentTab->currentIndex());
+}
+
+// Close all documents to the right of the current one
+void QucsApp::slotFileCloseAllRight()
+{
+  closeAllRight(DocumentTab->currentIndex());
+}
+
+// Close all documents
+void QucsApp::slotFileCloseAll()
+{
+  // close all tabs
+  closeAllFiles();
+  // create empty schematic
+  slotFileNew();
+}
+
+//
 // --------------------------------------------------------------
 // Common function to close a file tab specified by its index
 // checking for changes in the file before doing so. If called
@@ -3020,10 +3048,7 @@ void ContextMenuTabWidget::slotCxMenuCloseRight()
 
 void ContextMenuTabWidget::slotCxMenuCloseAll()
 {
-  // close all tabs
-  App->closeAllFiles();
-  // create empty schematic
-  App->slotFileNew();
+  App->slotFileCloseAll();
 }
 
 void ContextMenuTabWidget::slotCxMenuCopyPath()

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -24,6 +24,11 @@
 #include <QStack>
 #include <QDir>
 
+/**
+ * @file qucs.h
+ * @brief definition of the main Qucs application class and other helper classes
+ */
+
 class QucsDoc;
 class Schematic;
 class SimMessage;
@@ -32,6 +37,7 @@ class SearchDialog;
 class OctaveWindow;
 class MessageDock;
 class ProjectView;
+class ContextMenuTabWidget;
 class VersionTriplet;
 class QucsApp;
 
@@ -131,7 +137,7 @@ class QucsApp : public QMainWindow {
 public:
   QucsApp();
  ~QucsApp();
-  bool closeAllFiles();
+  bool closeAllFiles(int exceptTab = -1);
   bool gotoPage(const QString&);   // to load a document
   QucsDoc *getDoc(int No=-1);
   QucsDoc* findDoc (QString, int * Pos = 0);
@@ -227,7 +233,7 @@ signals:
 
 public:
   MouseActions *view;
-  QTabWidget *DocumentTab;
+  ContextMenuTabWidget *DocumentTab;
   QListWidget *CompComps;
   QTreeWidget *libTreeWidget;
 
@@ -441,6 +447,26 @@ private:
   void launchTool(const QString&, const QString&, const QString& = ""); // tool, description and args
   friend class SaveDialog;
   QString lastExportFilename;
+};
+
+/**
+ * @brief a QTabWidget with context menu for tabs
+ *
+ */
+class ContextMenuTabWidget : public QTabWidget
+{
+  Q_OBJECT
+public:
+  ContextMenuTabWidget(QucsApp *parent = 0);
+public slots:
+  void showContextMenu(const QPoint& point);
+private:
+  int contextTabIndex; // index of tab where context menu was opened
+  QucsApp *App; // the main application - parent widget
+private slots:
+  void slotCxMenuClose();
+  void slotCxMenuCloseOthers();
+  void slotCxMenuCloseAll();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -472,6 +472,8 @@ private slots:
   void slotCxMenuCloseAll();
   void slotCxMenuCloseRight();
   void slotCxMenuCloseLeft();
+  void slotCxMenuCopyPath();
+  void slotCxMenuOpenFolder();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -471,6 +471,7 @@ public slots:
   void showContextMenu(const QPoint& point);
 private:
   int contextTabIndex; // index of tab where context menu was opened
+  QString docName; // name of the document where context menu was opened
   QucsApp *App; // the main application - parent widget
 private slots:
   void slotCxMenuClose();

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -164,7 +164,8 @@ protected:
   void closeEvent(QCloseEvent*);
 
 public slots:
-  void slotFileNew();     // generate a new schematic in the view TabBar
+  void slotFileNew(bool enableOpenDpl=true); // generate a new schematic in the view TabBar
+  void slotFileNewNoDD(); // as above, but with "open Data Display" unchecked
   void slotTextNew();     // edit text in the built editor or user defined editor
   void slotFileOpen();    // open a document
   void slotFileSave();    // save a document
@@ -246,7 +247,7 @@ public:
   // corresponding actions
   QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuInsert;
 
-  QAction *fileNew, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
+  QAction *fileNew, *fileNewNoDD, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
           *fileSaveAll, *fileClose, *fileExamples, *fileSettings, *filePrint, *fileQuit,
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magOne, *magMinus, *filePrintFit,

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -137,7 +137,10 @@ class QucsApp : public QMainWindow {
 public:
   QucsApp();
  ~QucsApp();
+  bool closeTabsRange(int startTab, int stopTab, int exceptTab = -1);
   bool closeAllFiles(int exceptTab = -1);
+  bool closeAllLeft(int);
+  bool closeAllRight(int);
   bool gotoPage(const QString&);   // to load a document
   QucsDoc *getDoc(int No=-1);
   QucsDoc* findDoc (QString, int * Pos = 0);
@@ -467,6 +470,8 @@ private slots:
   void slotCxMenuClose();
   void slotCxMenuCloseOthers();
   void slotCxMenuCloseAll();
+  void slotCxMenuCloseRight();
+  void slotCxMenuCloseLeft();
 };
 
 #endif /* QUCS_H */

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -171,7 +171,11 @@ public slots:
   void slotFileSave();    // save a document
   void slotFileSaveAs();  // save a document under a different filename
   void slotFileSaveAll(); // save all open documents
-  void slotFileClose();   // close the actual file
+  void slotFileClose();   // close the current file
+  void slotFileCloseOthers();   // close all documents except the current one
+  void slotFileCloseAllLeft();  // close all documents to the left of the current one
+  void slotFileCloseAllRight(); // close all documents to the right of the current one
+  void slotFileCloseAll();      //  close all documents
   void slotFileExamples();   // show the examples in a file browser
   void slotHelpTutorial();   // Open a pdf tutorial
   void slotHelpReport();   // Open a pdf report
@@ -248,7 +252,8 @@ public:
   QAction *ActionCMenuOpen, *ActionCMenuCopy, *ActionCMenuRename, *ActionCMenuDelete, *ActionCMenuInsert;
 
   QAction *fileNew, *fileNewNoDD, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
-          *fileSaveAll, *fileClose, *fileExamples, *fileSettings, *filePrint, *fileQuit,
+          *fileSaveAll, *fileClose, *fileCloseOthers, *fileCloseAllLeft, *fileCloseAllRight,
+          *fileCloseAll, *fileExamples, *fileSettings, *filePrint, *fileQuit,
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magOne, *magMinus, *filePrintFit,
           *symEdit, *intoH, *popH, *simulate, *dpl_sch, *undo, *redo, *dcbias;

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -31,6 +31,7 @@
 
 class QucsDoc;
 class Schematic;
+class TextDoc;
 class SimMessage;
 class MouseActions;
 class SearchDialog;
@@ -467,6 +468,9 @@ class ContextMenuTabWidget : public QTabWidget
   Q_OBJECT
 public:
   ContextMenuTabWidget(QucsApp *parent = 0);
+  Schematic *createEmptySchematic(const QString &name);
+  TextDoc *createEmptyTextDoc(const QString &name);
+  void setSaveIcon(bool state=true, int index=-1);
 public slots:
   void showContextMenu(const QPoint& point);
 private:

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -95,6 +95,26 @@ void QucsApp::initActions()
   fileClose->setWhatsThis(tr("Close File\n\nCloses the current document"));
   connect(fileClose, SIGNAL(triggered()), SLOT(slotFileClose()));
 
+  fileCloseOthers = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all but current"), this);
+  fileCloseOthers->setStatusTip(tr("Closes all documents except the current one"));
+  fileCloseOthers->setWhatsThis(tr("Close all but current\n\nCloses all documents except the current one"));
+  connect(fileCloseOthers, SIGNAL(triggered()), SLOT(slotFileCloseOthers()));
+
+  fileCloseAllLeft = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all left"), this);
+  fileCloseAllLeft->setStatusTip(tr("Closes all documents to the left of the current one"));
+  fileCloseAllLeft->setWhatsThis(tr("Close all left\n\nCloses all documents to the left of the current one"));
+  connect(fileCloseAllLeft, SIGNAL(triggered()), SLOT(slotFileCloseAllLeft()));
+
+  fileCloseAllRight = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close all right"), this);
+  fileCloseAllRight->setStatusTip(tr("Closes all documents to the right of the current one"));
+  fileCloseAllRight->setWhatsThis(tr("Close all right\n\nCloses all documents to the right of the current one"));
+  connect(fileCloseAllRight, SIGNAL(triggered()), SLOT(slotFileCloseAllRight()));
+
+  fileCloseAll = new QAction(QIcon((":/bitmaps/fileclose.png")), tr("Close &All"), this);
+  fileCloseAll->setStatusTip(tr("Closes all documents"));
+  fileCloseAll->setWhatsThis(tr("Close All\n\nCloses all documents"));
+  connect(fileCloseAll, SIGNAL(triggered()), SLOT(slotFileCloseAll()));
+
   for (int i = 0; i < MaxRecentFiles; ++i) {
     fileRecentAction[i] = new QAction(this);
     fileRecentAction[i]->setVisible(false);
@@ -679,9 +699,16 @@ void QucsApp::initMenuBar()
   newFileMenu->addAction(fileNewNoDD);
   newFileMenu->addAction(textNew);
   fileMenu->addMenu(newFileMenu);
-  
+
   fileMenu->addAction(fileOpen);
-  fileMenu->addAction(fileClose);
+
+  QMenu *closeFileMenu = new QMenu(tr("Close"), fileMenu);
+  closeFileMenu->addAction(fileClose);
+  closeFileMenu->addAction(fileCloseOthers);
+  closeFileMenu->addAction(fileCloseAllLeft);
+  closeFileMenu->addAction(fileCloseAllRight);
+  closeFileMenu->addAction(fileCloseAll);
+  fileMenu->addMenu(closeFileMenu);
 
   recentFilesMenu = new QMenu(tr("Open Recent"),fileMenu);
   fileMenu->addMenu(recentFilesMenu);

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -52,6 +52,7 @@ void QucsApp::initActions()
   connect(fileNew, SIGNAL(triggered()), SLOT(slotFileNew()));
 
   fileNewNoDD = new QAction(QIcon((":/bitmaps/filenew.png")), tr("Stand-alone Document"), this);
+  fileNewNoDD->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_H);
   fileNewNoDD->setStatusTip(tr("Creates a new stand-alone document"));
   fileNewNoDD->setWhatsThis(
 	        tr("New\n\nCreates a new stand-alone schematic or data display document"));

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -44,14 +44,20 @@ void QucsApp::initActions()
 
   // note: first argument of QAction() for backward compatibility Qt < 3.2
 
-  fileNew = new QAction(QIcon((":/bitmaps/filenew.png")), tr("&New"), this);
+  fileNew = new QAction(QIcon((":/bitmaps/filenew.png")), tr("Document"), this);
   fileNew->setShortcut(Qt::CTRL+Qt::Key_N);
   fileNew->setStatusTip(tr("Creates a new document"));
   fileNew->setWhatsThis(
 	        tr("New\n\nCreates a new schematic or data display document"));
   connect(fileNew, SIGNAL(triggered()), SLOT(slotFileNew()));
 
-  textNew = new QAction(QIcon((":/bitmaps/textnew.png")), tr("New &Text"), this);
+  fileNewNoDD = new QAction(QIcon((":/bitmaps/filenew.png")), tr("Stand-alone Document"), this);
+  fileNewNoDD->setStatusTip(tr("Creates a new stand-alone document"));
+  fileNewNoDD->setWhatsThis(
+	        tr("New\n\nCreates a new stand-alone schematic or data display document"));
+  connect(fileNewNoDD, SIGNAL(triggered()), SLOT(slotFileNewNoDD()));
+
+  textNew = new QAction(QIcon((":/bitmaps/textnew.png")), tr("&Text Document"), this);
   textNew->setShortcut(Qt::CTRL+Qt::SHIFT+Qt::Key_V);
   textNew->setStatusTip(tr("Creates a new text document"));
   textNew->setWhatsThis(tr("New Text\n\nCreates a new text document"));
@@ -667,8 +673,13 @@ void QucsApp::initActions()
 void QucsApp::initMenuBar()
 {
   fileMenu = new QMenu(tr("&File"));  // menuBar entry fileMenu
-  fileMenu->addAction(fileNew);
-  fileMenu->addAction(textNew);
+
+  QMenu *newFileMenu = new QMenu(tr("New"), fileMenu);
+  newFileMenu->addAction(fileNew);
+  newFileMenu->addAction(fileNewNoDD);
+  newFileMenu->addAction(textNew);
+  fileMenu->addMenu(newFileMenu);
+  
   fileMenu->addAction(fileOpen);
   fileMenu->addAction(fileClose);
 


### PR DESCRIPTION
since I sometimes open a lot of tabs, e.g. while looking for a particular schematic/feature, I needed a convenient way of closing all the tabs currently open *except* the one of interest.
I've then added a context menu to the tabs, like  this

![image](https://user-images.githubusercontent.com/9018179/29253185-fdd258c4-8076-11e7-85f3-cdc6e688feea.png)

I've also added a *Close all* action and, why not, a simple *Close* for the current tab.

Works fine here, I do not actually plan big modifications to the code, just maybe a little cleanup to `qucs.cpp`.
