### PR TITLE
Avoid crash in net::sortChildAnalyses

### DIFF
--- a/qucs-core/src/net.cpp
+++ b/qucs-core/src/net.cpp
@@ -350,7 +350,13 @@ void net::orderAnalysis (void) {
 void net::sortChildAnalyses (analysis * parent) {
   ptrlist<analysis> * alist = parent->getAnalysis ();
   if (alist != nullptr) {
-    for (auto *a: *alist) {
+
+    for (auto it = alist->begin(); it != alist->end(); /* empty */) {
+      // Copy the value of the element (a pointer), and advance the
+      // iterator prior to manipulating the list.
+      analysis *a = *it;
+      ++it;
+
       if (a->getType () == ANALYSIS_DC
 	  || containsAnalysis (a, ANALYSIS_DC)) {
 	parent->delAnalysis (a);


### PR DESCRIPTION
Removing an element from a list invalidates any iterators pointing at
these elements. As a result, (indirectly) calling remove() on a list
while it is traversed using a range-based for loop triggers undefined
behaviour.

Rewrite the loop, so no invalidated iterators are referenced anymore.
This is arguably not the neatest solution.

Fixes issue #710