### PR TITLE
configure, qt

### DIFF
--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -258,8 +258,8 @@ case $host_os in
       QTDIR=$QT4DIR
     elif test "x$QTDIR" != "x"; then
       echo "QTDIR provided: $QTDIR"
+      QTDIR_paths="$QTDIR/lib $QTDIR/lib64"
     fi
-    QTDIR_paths="$QTDIR/lib $QTDIR/lib64"
 
     dnl Check include path to Qt.
     QT_INCLUDES=""
@@ -334,14 +334,14 @@ case $host_os in
       save_LDFLAGS="$LDFLAGS"
       save_CXXFLAGS="$CXXFLAGS"
       LIBS="$LIBS $X11_LIBS $QT_LIB"
-      LDFLAGS="$LDFLAGS $X11_LDFLAGS -L$path $QT_LDF"
+      LDFLAGS="$LDFLAGS $X11_LDFLAGS $QT_LDF"
       CXXFLAGS="$CXXFLAGS $X11_INCLUDES $QT_INCLUDES $QT_INC"
       AC_LINK_IFELSE(
           [AC_LANG_SOURCE([#include <Qt/qapplication.h>
                            int main (int argc, char ** argv) {
                            QApplication a (argc, argv); a.exec (); return 0; }])],
                            [
-                                 QT_LDFLAGS="$path";
+                                 # QT_LDFLAGS="$path";
                                  QT_INCLUDES="$QT_INCLUDES $QT_INC";
                                  break;
                            ]
@@ -357,13 +357,15 @@ case $host_os in
     LIBS="$save_LIBS"
     LDFLAGS="$save_LDFLAGS"
     CXXFLAGS="$save_CXXFLAGS"
-    if test "x$QT_LDFLAGS" != "x"; then
-      AC_MSG_RESULT([found in $QT_LDFLAGS])
-      QT_LDFLAGS="-L$QT_LDFLAGS $QT_LDF"
-      QT_LIBS="$QT_LIB"
-    else
-      AC_MSG_ERROR([not found])
-    fi
+# BUG: check for library availibility. use AC_CHECK_LIBS
+# ( no check is better than a broken one! )
+#     if test "x$QT_LDFLAGS" != "x"; then
+       AC_MSG_RESULT([found in $QT_LDFLAGS])
+#       QT_LDFLAGS="$QT_LDF"
+       QT_LIBS="$QT_LIB"
+#     else
+#       AC_MSG_ERROR([not found])
+#     fi
     ;;
 
   *darwin* )


### PR DESCRIPTION
cleaning up... removes a bogus library check, which might (or might not) be the reason for #711.

generally, configure.ac is a bit historic. should be redone, such as
* implement header/library checks using `AC_*`,
* proper (optional) `--with-<feature>` flags,
* remove undocumented hacks, such as `QTDIR`.

or (easier, more reliable) setting system specific variables (here `LDFLAGS`) should be left to the user/maintainer.