### PR TITLE
Fix "export as image" with non integer scale factor

### DIFF
--- a/qucs/qucs/dialogs/exportdialog.cpp
+++ b/qucs/qucs/dialogs/exportdialog.cpp
@@ -200,8 +200,8 @@ void ExportDialog::calcWidth()
 {
     if (cbRatio->isChecked()) {
         float h = editResolutionY->text().toFloat();
-        float w =  round((h*dwidth)/dheight);
-        editResolutionX->setText(QString::number(w));
+        float w =  (h*dwidth)/dheight;
+        editResolutionX->setText(QString::number(w, 'f', 0)); // integer number of pixels
     }
 }
 
@@ -210,8 +210,8 @@ void ExportDialog::calcHeight()
 {
     if (cbRatio->isChecked()) {
         float w = editResolutionX->text().toFloat();
-        float h =  round((w*dheight)/dwidth);
-        editResolutionY->setText(QString::number(h));
+        float h =  (w*dheight)/dwidth;
+        editResolutionY->setText(QString::number(h, 'f', 0)); // integer number of pixels
     }
 
 }
@@ -345,11 +345,11 @@ void ExportDialog::recalcScale()
 {
     scale = editScale->text().toFloat();
     if (cbSelected->isChecked()) {
-        editResolutionX->setText(QString::number(scale*dwidthsel));
-        editResolutionY->setText(QString::number(scale*dheightsel));
+        editResolutionX->setText(QString::number(scale*dwidthsel, 'f', 0));  // integer number of pixels
+        editResolutionY->setText(QString::number(scale*dheightsel, 'f', 0)); // integer number of pixels
     } else {
-        editResolutionX->setText(QString::number(scale*dwidth));
-        editResolutionY->setText(QString::number(scale*dheight));
+        editResolutionX->setText(QString::number(scale*dwidth, 'f', 0));
+        editResolutionY->setText(QString::number(scale*dheight, 'f', 0));
     }
 
 }


### PR DESCRIPTION
When setting a non-integer scaling factor for the exported image, Qucs silently fails to create the image.
This is because the scaled image dimensions are written as floating points numbers in the Width/Height line edits and then wrongly converted to zero by `QString.toInt()`.
The `QIntValidator()` on those line edits is not used when setting the contents using `setText()` as pointed out in the [docs](http://doc.qt.io/qt-4.8/qlineedit.html).

Steps to reproduce:
- open a schematic
- *File*->*Export as image...*
- uncheck *Original size*
- enter a floating point *Scale factor*, check that *Width in pixels* and/or *Height in pixels* contains a floating point number instead of an integer
- click *Export*
- verify that no image is created

