### PR TITLE
Replaced QLineedit by QComboBox for frequency input (for phasor and AC temporal diagram dialogs)

### DIFF
--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -37,7 +37,6 @@
 #include <QLineEdit>
 #include <QCheckBox>
 #include <QSlider>
-#include <QComboBox>
 #include <QListWidget>
 #include <QTableWidget>
 #include <QPainter>
@@ -46,6 +45,7 @@
 #include <QHeaderView>
 #include <QDir>
 #include <QDebug>
+#include <QComboBox>
 
 
 #define CROSS3D_SIZE   30
@@ -306,17 +306,7 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
     DataGroupLayout->addWidget(inputZ);
     connect(inputZ, SIGNAL(stateChanged(int)), SLOT(PhasorvalZ(int)));
   }
-  //for Phasor and waveac,it will have a new input for frequency
-  if(Diag->Name == "Phasor" || Diag->Name == "Waveac") 
-  {
-    DataGroupLayout->addWidget(new QLabel(tr("frequency in Hertz")));
-    freq = new QLineEdit();
-    DataGroupLayout->addWidget(freq);
-    freq->setValidator(Validator);
-    if(Diag->sfreq.isEmpty())
-      Diag->sfreq = "0 Hz";
-    freq->setText(Diag->sfreq);
-  }
+
   if(Diag->Name != "Phasor")
   {
     Name=Diag->Name;
@@ -775,6 +765,30 @@ DiagramDialog::DiagramDialog(Diagram *d, QWidget *parent, Graph *currentGraph)
       if(testvar(".S")) inputP->setChecked(true);
       if(testvar(".Ohm")) inputZ->setChecked(true);
   }
+
+  if(Diag->Name == "Phasor" || Diag->Name == "Waveac") 
+  {
+    DataGroupLayout->addWidget(new QLabel(tr("Frequency")));
+    freqCombobox = new QComboBox();
+    DataGroupLayout->addWidget(freqCombobox);
+    freqCombobox->setValidator(Validator);
+    QStringList data = LoadAvailableFreqs();
+    freqCombobox->addItems(data);
+    
+    //Find the current index
+    int current_index=0;
+    QString current_freq = Diag->sfreq;
+    current_freq.remove(";");
+    for (int i = 0; i < data.length(); i++)
+    {
+       if (data.at(i) == current_freq)
+       {
+         current_index = i;
+         break;
+       }
+    }
+    freqCombobox->setCurrentIndex(current_index);
+  }
 }
 
 DiagramDialog::~DiagramDialog()
@@ -784,6 +798,40 @@ DiagramDialog::~DiagramDialog()
   delete ValDouble;
   delete Validator;
 }
+
+QStringList DiagramDialog::LoadAvailableFreqs()
+{
+  QFileInfo Info(defaultDataSet);
+  QString DocName = ChooseData->currentText()+".dat";
+  QStringList AvailableFreqs;
+  QFile file(Info.path() + QDir::separator() + DocName);
+  if(!file.open(QIODevice::ReadOnly)) {qDebug() <<Info.path() + QDir::separator() + DocName;
+    return AvailableFreqs;
+  }
+
+  QTextStream in(&file);
+  QString line;
+  while (!in.atEnd())
+  {
+    line = in.readLine();
+    if (line.indexOf("<indep acfrequency") != -1)
+    {
+      line = in.readLine();
+      while(line != "</indep>")
+      {
+       //The list of frequencies stored in the dataset use the scientific format, so they
+       //need to be converted into human readable format
+       AvailableFreqs.append(QString("%1Hz").arg(misc::num2str(line.toDouble())));
+       line = in.readLine();
+      }
+      break;
+    }
+  }
+  file.close();
+  return AvailableFreqs;
+}
+
+
 
 // --------------------------------------------------------------------------
 void DiagramDialog::slotReadVars(int)
@@ -872,6 +920,7 @@ void DiagramDialog::slotReadVars(int)
   } while(i > 0);
   // sorting should be enabled only after adding items
   ChooseVars->setSortingEnabled(true);
+  LoadAvailableFreqs();
 }
 
 // ------------------------------------------------------------------------
@@ -1184,8 +1233,8 @@ void DiagramDialog::slotApply()
     // Use string compares for all floating point numbers, in
     // order to avoid rounding problems.
     if(Diag->Name == "Phasor" || Diag->Name == "Waveac")
-      if(Diag->sfreq != freq->text()) {
-	 Diag->sfreq = freq->text();
+      if(Diag->sfreq != freqCombobox->currentText()) {
+	 Diag->sfreq = freqCombobox->currentText();
 	  changed = true;
       }
     if(QString::number(Diag->xAxis.limit_min) != startX->text()) {

--- a/qucs/qucs/diagrams/diagramdialog.h
+++ b/qucs/qucs/diagrams/diagramdialog.h
@@ -28,6 +28,7 @@
 #include <QRegExp>
 #include <Q3PtrList>
 
+
 class QVBoxLayout;
 class Cross3D;
 class QLabel;
@@ -96,7 +97,7 @@ protected slots:
 
 private:
   void SelectGraph(Graph*);
-
+  QStringList LoadAvailableFreqs();
   Diagram *Diag;
   QString defaultDataSet;
   QString Var2;
@@ -121,7 +122,7 @@ private:
   QLineEdit   *startY, *stepY, *stopY;
   QLineEdit   *startZ, *stepZ, *stopZ;
   QLineEdit   *rotationX, *rotationY, *rotationZ;
-  QLineEdit   *freq;
+  QComboBox   *freqCombobox;
   QLabel      *GridLabel1, *GridLabel2, *Label1, *Label2, *Label3, *Label4;
   QComboBox   *PropertyBox, *GridStyleBox, *yAxisBox;
   QPushButton *ColorButt, *GridColorButt;


### PR DESCRIPTION
The aim of this PR is to replace the QLineEdit by a QComboBox as the frequency input widget at the dialog window in the phasor and AC temporal diagrams. This way, the QCombo shows only the available frequencies.

In order to do that, a function named 'LoadAvailableFreqs()' has been added to diagramdialog constructor. The purpose of this function is to explore the content of the 'acfrequency' field of the current dataset and, finally, it returns that data as a QStringList which is used to feed the QComboBox.

'LoadAvailableFreqs()' is called at the constructor but also when the click() event of the 'ChooseData' combo is triggered.

![diagramdialogcombo](https://user-images.githubusercontent.com/13180689/31310968-916ea834-aba2-11e7-8b57-c363cd6c773e.png)

[Screencast here](https://drive.google.com/open?id=0BwDjrwGfd_z7ck03TzZXMHdiR2s)
