### PR TITLE
Fix of issue #738

### DIFF
--- a/qucs-core/src/components/mutualx.cpp
+++ b/qucs-core/src/components/mutualx.cpp
@@ -99,7 +99,7 @@ void mutualx::calcAC (nr_double_t frequency) {
       nr_double_t l1 = real (L->get (r));
       nr_double_t l2 = real (L->get (c));
       nr_double_t k = real (C->get (state)) * std::sqrt (l1 * l2);
-      setD (VSRC_1 + r, VSRC_1 + c, nr_complex_t (0.0, k * o));
+      setD (VSRC_1 + r, VSRC_1 + c, nr_complex_t (0.0, - k * o));
     }
   }
 }


### PR DESCRIPTION
There was a missing minus in MNA matrix of mutual inductances. Now the AC and S-param simulation results are matching for "N mutual inductances" component.
![mutx](https://user-images.githubusercontent.com/4920080/31582967-868b3bc0-b1a2-11e7-8bf2-b84bf2e47a3d.png)
