### PR TITLE
Revert "Replaced QLineedit by QComboBox for frequency input (for phasor and AC temporal diagram dialogs)"

### DIFF
--- a/qucs/qucs/diagrams/diagramdialog.h
+++ b/qucs/qucs/diagrams/diagramdialog.h
@@ -24,7 +24,6 @@
 #include <QRegExp>
 #include <Q3PtrList>
 
-
 class QVBoxLayout;
 class Cross3D;
 class QLabel;
@@ -93,7 +92,7 @@ protected slots:
 
 private:
   void SelectGraph(Graph*);
-  QStringList LoadAvailableFreqs();
+
   Diagram *Diag;
   QString defaultDataSet;
   QString Var2;
@@ -118,7 +117,7 @@ private:
   QLineEdit   *startY, *stepY, *stopY;
   QLineEdit   *startZ, *stepZ, *stopZ;
   QLineEdit   *rotationX, *rotationY, *rotationZ;
-  QComboBox   *freqCombobox;
+  QLineEdit   *freq;
   QLabel      *GridLabel1, *GridLabel2, *Label1, *Label2, *Label3, *Label4;
   QComboBox   *PropertyBox, *GridStyleBox, *yAxisBox;
   QPushButton *ColorButt, *GridColorButt;


### PR DESCRIPTION
Reverts Qucs/qucs#723

The original intention was to input and plot several frequencies. The combobox does not allow that.