### PR TITLE
Add smooth() function

### DIFF
--- a/qucs-core/src/applications.h
+++ b/qucs-core/src/applications.h
@@ -738,6 +738,13 @@ struct application_t qucs::eqn::applications[] = {
   { "cumprod", TAG_COMPLEX, evaluate::cumprod_c, 1, { TAG_COMPLEX } },
   { "cumprod", TAG_VECTOR,  evaluate::cumprod_v, 1, { TAG_VECTOR  } },
 
+  { "smooth", TAG_DOUBLE, evaluate::smooth_d_d, 2,
+    { TAG_DOUBLE,  TAG_DOUBLE } },
+  { "smooth", TAG_COMPLEX, evaluate::smooth_c_d, 2,
+    { TAG_COMPLEX, TAG_DOUBLE } },
+  { "smooth", TAG_VECTOR, evaluate::smooth_v_d, 2,
+    { TAG_VECTOR,  TAG_DOUBLE } },
+
   { "rms", TAG_DOUBLE, evaluate::rms_d, 1, { TAG_DOUBLE  } },
   { "rms", TAG_DOUBLE, evaluate::rms_c, 1, { TAG_COMPLEX } },
   { "rms", TAG_DOUBLE, evaluate::rms_v, 1, { TAG_VECTOR  } },

--- a/qucs-core/src/evaluate.cpp
+++ b/qucs-core/src/evaluate.cpp
@@ -3406,6 +3406,41 @@ constant * evaluate::cumprod_v (constant * args) {
   _RETV (cumprod (*v1));
 }
 
+// ************** smoothing ****************
+constant * evaluate::smooth_d_d (constant * args) {
+  _ARD0 (y);
+  _ARD1 (a);
+  _DEFD ();
+  if (a < 0 || a > 100) {
+    THROW_MATH_EXCEPTION ("smooth: aperture percentage a must be "
+			  "between 0 and 100");
+  }
+  _RETD (y);
+}
+
+constant * evaluate::smooth_c_d (constant * args) {
+  _ARC0 (y);
+  _ARD1 (a);
+  _DEFC ();
+  if (a < 0 || a > 100) {
+    THROW_MATH_EXCEPTION ("smooth: aperture percentage a must be "
+			  "between 0 and 100");
+  }
+  _RETC (*y);
+}
+
+constant * evaluate::smooth_v_d (constant * args) {
+  _ARV0 (y);
+  _ARD1 (a);
+  _DEFV ();
+  if (a < 0 || a > 100) {
+    THROW_MATH_EXCEPTION ("smooth: aperture percentage a must be "
+			  "between 0 and 100");
+    __RETV ();
+  }
+  _RETV (smooth (*y, a));
+}
+
 // ******************* rms *********************
 constant * evaluate::rms_d (constant * args) {
   _ARD0 (d1);

--- a/qucs-core/src/evaluate.h
+++ b/qucs-core/src/evaluate.h
@@ -642,6 +642,10 @@ public:
   static constant * cumprod_c (constant *);
   static constant * cumprod_v (constant *);
 
+  static constant * smooth_d_d  (constant *);
+  static constant * smooth_c_d  (constant *);
+  static constant * smooth_v_d  (constant *);
+
   static constant * i0_d   (constant *);
   static constant * i0_c   (constant *);
   static constant * i0_v   (constant *);

--- a/qucs-core/src/vector.cpp
+++ b/qucs-core/src/vector.cpp
@@ -1260,6 +1260,28 @@ vector runavg (vector v, const int n) {
   return result;
 }
 
+// smooth a vector over an aperture a
+// done extending the vector endpoints and using a two-sided moving average
+// moving average length is always odd
+vector smooth(vector v, nr_double_t a) {
+  int len = v.getSize (), i;
+  int t2 = floor(len/2 * a / 100); // moving average is over 2*t2+1 elements
+  // auxiliary vector, extend original vector at beginning and end
+  int extvlen = len + 2 * t2;
+  vector extv(extvlen), result (len);
+  // fill auxiliary vector
+  for (i = 0; i < extvlen; i++) {
+    if (i < t2) {
+      extv.set (v(0), i);
+    } else if (i >= (len + t2)) {
+      extv.set (v(len-1), i);
+    } else {
+      extv.set (v(i - t2), i);
+    }
+  }
+  return runavg(extv, 2*t2+1);
+}
+
 #ifdef DEBUG
 // Debug function: Prints the vector object.
 void vector::print (void) {

--- a/qucs-core/src/vector.h
+++ b/qucs-core/src/vector.h
@@ -96,6 +96,7 @@ class vector : public object
   friend vector  cumsum  (vector);
   friend vector  cumprod (vector);
   friend vector  cumavg  (vector);
+  friend vector  smooth  (vector, const nr_double_t);
   friend vector  dbm     (vector, const nr_complex_t);
   friend nr_complex_t integrate (vector v, const nr_complex_t);
   friend nr_double_t integrate (vector v, const nr_double_t);
@@ -253,6 +254,7 @@ nr_complex_t avg     (vector);
 vector  cumsum  (vector);
 vector  cumprod (vector);
 vector  cumavg  (vector);
+vector  smooth  (vector, const nr_double_t);
 vector  dbm     (vector, const nr_complex_t z = 50.0);
 nr_complex_t integrate (vector v, const nr_complex_t);
 nr_double_t integrate (vector v, const nr_double_t);

--- a/qucs-doc/tutorial/functions/math.tex
+++ b/qucs-doc/tutorial/functions/math.tex
@@ -5436,7 +5436,7 @@ is located nearest to the x-value \textit{xval}; therefore the vector
 
 
 \newpage
-\tutsubsubsection{\label{sub:Differentiation-and-Integration}Differentiation and Integration}
+\tutsubsubsection{\label{sub:Differentiation-Integration-and-Smoothing}Differentiation, Integration and Smoothing}
 
 \subsubsection*{\hypertarget{ddx}{}{\Large ddx\index{ddx}()}}
 
@@ -5637,6 +5637,81 @@ using 101 points:
 \end{description}
 \textcolor{blue}{\hyperlink{diff}{diff()}}\textcolor{black}{,} \textcolor{blue}{\hyperlink{sum}{sum()}}\textcolor{black}{,}
 \textcolor{blue}{\hyperlink{max}{max()}}\textcolor{black}{,} \textcolor{blue}{\hyperlink{min}{min()}}
+
+
+\newpage
+\subsubsection*{\hypertarget{smooth}{}{\Large smooth\index{smooth}()}}
+
+
+\paragraph{\label{par:Smooth}Smooth vector.}
+
+\begin{description}
+\item [Syntax]~
+\end{description}
+z=smooth(y,a)
+
+\begin{description}
+\item [Arguments]~
+\end{description}
+\begin{tabular}{|c|c|c|c|}
+\hline 
+Name&
+Type&
+Def. Range&
+Required\tabularnewline
+\hline
+\hline 
+y&
+$\mathbb{R}$, $\mathbb{C}$, $\mathbb{R}^{n}$, $\mathbb{C}^{n}$&
+$\left]-\infty,+\infty\right[$&
+$\surd$\tabularnewline
+\hline 
+a&
+$\mathbb{R}$&
+$\left[0,100\right]$&
+$\surd$\tabularnewline
+\hline
+\end{tabular}
+
+\begin{description}
+\item [Description]~
+\end{description}
+This function smooths a vector \textit{y} over the aperture
+\textit{a}. The aperture is expressed as percentage of the input vector length. 
+The smoothing is done using a two-sided moving average filter having a length $2t+1$,
+with
+
+\medskip{}
+$t=$${\displaystyle 2 \lfloor \frac{n}{2} \frac{a}{100} \rfloor }$
+\medskip{}
+
+The two-sided moving average filtering is defined as
+
+\medskip{}
+For $y\in$$\mathbb{C}^{n}$: $z_{k}=$${\displaystyle \frac{1}{2t+1} \sum\limits _{j=-t}^{t}v_{k+j}}$,\;
+$1\leq k\leq n,\; v_{i}=\left\{ \begin{array}{ll}
+y_{1} & \mathrm{for}\: i < 1\\
+y_{i} & \mathrm{for}\: 1 \leq i \leq n\\
+y_{n} & \mathrm{for}\: i > n\end{array}\right.$
+\medskip{}
+
+note that the input vector is extended by assuming it keeps a constant value outside its definition range.
+
+For \textit{y} being a real or complex number, \textit{y} itself is returned.
+
+\medskip{}\medskip{}
+
+\begin{description}
+\item [Example]~
+\end{description}
+\begin{lyxlist}{00.00.0000}
+\item [\texttt{z=smooth([1,0,0,0,0,1,0,0,0,0,1], 20)}]
+\end{lyxlist}
+returns $\left[0.667,0.333,0,0,0.333,0.333,0.333,0,0,0.333,0.667\right]^T$; the 20~\% aperture window gives a 3-point moving average, for this vector length.
+\begin{description}
+\item [See~also]~
+\end{description}
+\textcolor{blue}{\hyperlink{runavg}{runavg()}}
 
 
 \newpage

--- a/qucs-doc/tutorial/functions/math.tex
+++ b/qucs-doc/tutorial/functions/math.tex
@@ -5614,7 +5614,7 @@ $\surd$\tabularnewline
 \begin{description}
 \item [Description]~
 \end{description}
-This function numerically integrates a vector \textit{x} with respect
+This function numerically integrates a vector \textit{y} with respect
 to a differential \textit{h}. The integration method is according
 to the trapezoidal rule:
 

--- a/qucs-doc/tutorial/functions/syntaxoverview.tex
+++ b/qucs-doc/tutorial/functions/syntaxoverview.tex
@@ -459,7 +459,7 @@ Please click on the desired function to go to its detailed description.
 \end{tabular}
 
 
-\subsubsection*{\nameref{sec:Data-Analysis}: \nameref{sub:Differentiation-and-Integration}}
+\subsubsection*{\nameref{sec:Data-Analysis}: \nameref{sub:Differentiation-Integration-and-Smoothing}}
 
 \textcolor{blue}{}\begin{tabular}{>{\raggedleft}p{3cm}>{\centering}p{0.5cm}l}
 \textcolor{blue}{\hyperlink{ddx}{ddx()}}&
@@ -471,6 +471,9 @@ Please click on the desired function to go to its detailed description.
 \textcolor{blue}{\hyperlink{integrate}{integrate()}}&
 ...&
  \begin{NoHyper} \nameref{par:Integrate} \end{NoHyper}\tabularnewline
+ \textcolor{blue}{\hyperlink{smooth}{smooth()}}&
+...&
+ \begin{NoHyper} \nameref{par:Smooth} \end{NoHyper}\tabularnewline
 \end{tabular}
 
 


### PR DESCRIPTION
I've added a `smooth()` function, similar to what is often used in VNAs to remove some noise from group delay measurements.

Here is an example of the group delay computed from some measured S-parameters, with and without smoothing:

![export](https://user-images.githubusercontent.com/9018179/32250044-4c984728-be8b-11e7-913e-41588316b4f9.png)
