### PR TITLE
[WIP] Open non-Qucs files with associated program, if defined

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2268,7 +2268,9 @@ void QucsApp::slotOpenContent(const QModelIndex &idx)
   }
 
   // If no appropriate program was found, open as text file.
-  editFile(Info.absoluteFilePath());  // open datasets with text editor
+  bool ok = QDesktopServices::openUrl(QUrl::fromLocalFile(Info.absoluteFilePath()));
+  if (not ok)
+    editFile(Info.absoluteFilePath());  // open datasets with text editor
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
(just little more than a placeholder for the moment)

When double-clicking on some non-Qucs files in the Project View (e.g. PDF, shown in the *Others* section) they are always opened in Qucs as text files. This PR tries to open them with the OS-registered application first.

Still need to define some common types (e.g. `.cpp`) that should be still be handled by Qucs and not an external application (maybe)
