### PR TITLE
groupdelay() function

### DIFF
--- a/qucs-core/src/applications.h
+++ b/qucs-core/src/applications.h
@@ -745,6 +745,13 @@ struct application_t qucs::eqn::applications[] = {
   { "smooth", TAG_VECTOR, evaluate::smooth_v_d, 2,
     { TAG_VECTOR,  TAG_DOUBLE } },
 
+  { "groupdelay", TAG_VECTOR, evaluate::groupdelay_mv, 1,
+    { TAG_MATVEC} },
+  { "groupdelay", TAG_VECTOR, evaluate::groupdelay_v, 1,
+    { TAG_VECTOR} },
+  { "groupdelay", TAG_VECTOR, evaluate::groupdelay_mv_i_i, 3,
+    { TAG_MATVEC, TAG_DOUBLE, TAG_DOUBLE } },
+
   { "rms", TAG_DOUBLE, evaluate::rms_d, 1, { TAG_DOUBLE  } },
   { "rms", TAG_DOUBLE, evaluate::rms_c, 1, { TAG_COMPLEX } },
   { "rms", TAG_DOUBLE, evaluate::rms_v, 1, { TAG_VECTOR  } },

--- a/qucs-core/src/evaluate.cpp
+++ b/qucs-core/src/evaluate.cpp
@@ -3441,6 +3441,77 @@ constant * evaluate::smooth_v_d (constant * args) {
   _RETV (smooth (*y, a));
 }
 
+// Calculates the delay group between two ports specified by the user
+constant * evaluate::groupdelay_mv_i_i (constant * args) {
+  _ARMV0 (S);
+  int index1 = D (_ARES(1))-1;//Input port
+  int index2 = D (_ARES(2))-1;//Output port
+  _DEFV ();
+  
+  strlist * deps = _ARG(0)->collectDataDependencies ();  
+  if (!deps || deps->length () != 1) {//Check there's an unique dependency
+    THROW_MATH_EXCEPTION ("Not an appropriate dependent data vector");
+    _RETC (0.0);
+  }
+  qucs::vector * freq = SOLVEE(0)->getDataVector (deps->get (0));
+
+  //Check if the length of S matvec and the freq vector are the same.
+  if (freq->getSize() != S->getSize()) {
+    THROW_MATH_EXCEPTION ("The S matrix and the frequency vector must have the same length");
+    __RETV ();
+  }
+  //Check if the input matrix is square
+  if (S->getRows() != S->getCols())
+  {
+    THROW_MATH_EXCEPTION ("The S matrix must be square");
+    __RETV ();
+  }
+
+  //Check if the port numbers are valid
+  if ((index1 < 0) || (index1 > S->getRows()-1))
+  {
+    THROW_MATH_EXCEPTION ("The 3rd argument must be a valid port number");
+    __RETV ();
+  }
+  if ((index2 < 0) || (index2 > S->getRows()-1))
+  {
+    THROW_MATH_EXCEPTION ("The 4th argument must be a valid port number");
+    __RETV ();
+  }
+
+  qucs::vector svec = S->get (index1, index2);
+  _RETV (groupdelay(svec, *freq));
+}
+
+
+constant * evaluate::groupdelay_mv (constant * args) {
+  _ARMV0 (S);
+  _DEFV ();
+  qucs::vector svec = S->get (1, 0);
+  
+  strlist * deps = _ARG(0)->collectDataDependencies ();  
+  if (!deps || deps->length () != 1) {//Check there's an unique dependency
+    THROW_MATH_EXCEPTION ("Not an appropriate dependent data vector");
+    _RETC (0.0);
+  }
+
+  qucs::vector * freq = SOLVEE(0)->getDataVector (deps->get (0));
+  _RETV (groupdelay(svec, *freq));
+}
+
+constant * evaluate::groupdelay_v (constant * args) {
+  _ARV0 (svec);
+  _DEFV ();
+  
+  strlist * deps = _ARG(0)->collectDataDependencies ();  
+  if (!deps || deps->length () != 1) {//Check there's an unique dependency
+    THROW_MATH_EXCEPTION ("Not an appropriate dependent data vector");
+    _RETC (0.0);
+  }
+  qucs::vector * freq = SOLVEE(0)->getDataVector (deps->get (0));
+  _RETV (groupdelay(*svec, *freq));
+}
+
 // ******************* rms *********************
 constant * evaluate::rms_d (constant * args) {
   _ARD0 (d1);

--- a/qucs-core/src/evaluate.h
+++ b/qucs-core/src/evaluate.h
@@ -646,6 +646,10 @@ public:
   static constant * smooth_c_d  (constant *);
   static constant * smooth_v_d  (constant *);
 
+  static constant * groupdelay_mv_i_i  (constant *);
+  static constant * groupdelay_mv (constant *);
+  static constant * groupdelay_v (constant *);
+
   static constant * i0_d   (constant *);
   static constant * i0_c   (constant *);
   static constant * i0_v   (constant *);

--- a/qucs-core/src/vector.cpp
+++ b/qucs-core/src/vector.cpp
@@ -1282,6 +1282,12 @@ vector smooth(vector v, nr_double_t a) {
   return runavg(extv, 2*t2+1);
 }
 
+//Ths function calculates the group delay from the svec=S[i,j] and frequency vectors
+vector groupdelay(vector svec, vector freq)
+{
+ return -diff(unwrap(arg(svec)), (2*pi)*(freq));
+}
+
 #ifdef DEBUG
 // Debug function: Prints the vector object.
 void vector::print (void) {

--- a/qucs-core/src/vector.h
+++ b/qucs-core/src/vector.h
@@ -97,6 +97,7 @@ class vector : public object
   friend vector  cumprod (vector);
   friend vector  cumavg  (vector);
   friend vector  smooth  (vector, const nr_double_t);
+  friend vector  groupdelay  (vector, vector);
   friend vector  dbm     (vector, const nr_complex_t);
   friend nr_complex_t integrate (vector v, const nr_complex_t);
   friend nr_double_t integrate (vector v, const nr_double_t);

--- a/qucs-doc/tutorial/functions/math.tex
+++ b/qucs-doc/tutorial/functions/math.tex
@@ -5711,7 +5711,8 @@ returns $\left[0.667,0.333,0,0,0.333,0.333,0.333,0,0,0.333,0.667\right]^T$; the 
 \begin{description}
 \item [See~also]~
 \end{description}
-\textcolor{blue}{\hyperlink{runavg}{runavg()}}
+\textcolor{blue}{\hyperlink{runavg}{runavg()}}\textcolor{black}{,}
+\textcolor{blue}{\hyperlink{groupdelay}{groupdelay()}}
 
 
 \newpage
@@ -6324,3 +6325,62 @@ is assumed.
 \end{description}
 \textcolor{blue}{\hyperlink{dft}{dft()}}\textcolor{black}{,} \textcolor{blue}{\hyperlink{ifft}{ifft()}}\textcolor{black}{,}
 \textcolor{blue}{\hyperlink{fft}{fft()}}
+
+\newpage
+\subsubsection*{\hypertarget{groupdelay}{}{\Large groupdelay\index{groupdelay}()}}
+\paragraph{\label{par:groupdelay}Group delay calculation.}
+
+\begin{description}
+\item [Syntax]~
+\end{description}
+y=groupdelay(S,P2, P1)
+
+y=groupdelay(S)
+
+\begin{description}
+\item [Arguments]~
+\end{description}
+\begin{tabular}{|c|c|c|c|c|}
+\hline 
+Name&
+Type&
+Def. Range&
+Required&
+Default\tabularnewline
+\hline
+\hline 
+S&
+$\mathbb{R}^{nxnxp}, \mathbb{C}^{nxnxp}, \mathbb{R}^{p}, \mathbb{C}^{p}$&
+$\left]-\infty,+\infty\right[$&
+$\surd$&
+\tabularnewline
+\hline 
+P2&
+$\mathbb{N}$&
+$\left[1,+\infty\right[$&
+&
+2\tabularnewline
+\hline 
+P1&
+$\mathbb{N}$&
+$\left[1,+\infty\right[$&
+&
+1\tabularnewline
+\hline
+\end{tabular}
+
+\begin{description}
+\item [Description]~
+\end{description}
+This function calculates the delay group between ports P2 and P1 such that:
+
+\begin{equation}
+  \tau(f) =  -\frac{1}{2 \pi}\frac{\partial \phi(f)}{\partial f}
+\end{equation}
+
+where $\phi(f) = \angle S_{P2, P1}(f)$, $S_{P2, P1}(f)$ is the element (P2, P1) of the S matrix and $f$ is the dependency vector of S.
+
+\begin{description}
+\item [See~also]~
+\end{description}
+\textcolor{blue}{\hyperlink{smooth}{smooth()}}

--- a/qucs-doc/tutorial/functions/syntaxoverview.tex
+++ b/qucs-doc/tutorial/functions/syntaxoverview.tex
@@ -504,6 +504,9 @@ Please click on the desired function to go to its detailed description.
 \textcolor{blue}{\hyperlink{kbd}{kbd()}}&
 ...&
  \begin{NoHyper} \nameref{par:Kaiser-Bessel-window} \end{NoHyper}\tabularnewline
+\textcolor{blue}{\hyperlink{groupdelay}{groupdelay()}}&
+...&
+ \begin{NoHyper} \nameref{par:groupdelay} \end{NoHyper}\tabularnewline
 \end{tabular}
 
 


### PR DESCRIPTION
In order to complement the recently added smooth() function, here it is a function for calculating the group delay from the S parameters.

_groupdelay(S)_ returns the delay group between ports 1 and 2, and _groupdelay(S, P2, P1)_
does the same but for ports P2 and P1.

[UPDATED Nov 26 2017]
Tests:
[Consistency with theoretical results](https://gist.github.com/andresmmera/2d1eaceaa3899e15835bfcf2098a7692) 
[P1 and P2 out of range](https://gist.github.com/andresmmera/5d6322e711430f55c04768e971cfcda8) 
[Handle P1=P2 case](https://gist.github.com/andresmmera/0626a8eb6c12f74ff57dc74d542c7848) 

Examples:
[Branch line coupler](https://gist.github.com/andresmmera/fba7ab9953ffed6c03b294ef0e9eb7ca)
[Wilkinson combiner](https://gist.github.com/andresmmera/d3c6b371a87c796cd877e6e02a2b7c66) 

![selection_024](https://user-images.githubusercontent.com/13180689/33219121-e9aedd5c-d140-11e7-8d51-2e50e0c34a6e.png)

