### PR TITLE
Correct marker misbehaviour when pointing to data outside the diagram limits

### DIFF
--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -74,10 +74,10 @@ void CurveDiagram::calcCoordinate(const double*, const double* yD, const double*
 }
 
 // --------------------------------------------------------------
-void CurveDiagram::finishMarkerCoordinates(float& fCX, float& fCY) const
+void CurveDiagram::finishMarkerCoordinates(Marker *m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-	  fCX = fCY = 0.0;
+  if(!insideDiagram(m->fCX, m->fCY)) {
+	  m->fCX = m->fCY = 0.0;
   }
 }
 

--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -76,7 +76,7 @@ void CurveDiagram::calcCoordinate(const double*, const double* yD, const double*
 // --------------------------------------------------------------
 bool CurveDiagram::clipCoordinates(float &fCX, float& fCY) const
 {
-  if(!insideDiagram(fCX, fCY)) {
+  if(insideDiagram(fCX, fCY)) {
     return false;
   }
 

--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -240,7 +240,7 @@ Frame:
 // ------------------------------------------------------------
 bool CurveDiagram::insideDiagram(float x, float y) const
 {
-  return (regionCode(x, y) == 0);
+  return (regionCode(x, y) == CS_INSIDE);
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -74,14 +74,11 @@ void CurveDiagram::calcCoordinate(const double*, const double* yD, const double*
 }
 
 // --------------------------------------------------------------
-bool CurveDiagram::clipCoordinates(float &fCX, float& fCY) const
+void CurveDiagram::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
-  if(insideDiagram(fCX, fCY)) {
-    return false;
+  if(!insideDiagram(fCX, fCY)) {
+    fCX = fCY = 0.0;
   }
-
-  fCX = fCY = 0.0;
-  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/curvediagram.cpp
+++ b/qucs/qucs/diagrams/curvediagram.cpp
@@ -74,11 +74,14 @@ void CurveDiagram::calcCoordinate(const double*, const double* yD, const double*
 }
 
 // --------------------------------------------------------------
-void CurveDiagram::finishMarkerCoordinates(Marker *m) const
+bool CurveDiagram::clipCoordinates(float &fCX, float& fCY) const
 {
-  if(!insideDiagram(m->fCX, m->fCY)) {
-	  m->fCX = m->fCY = 0.0;
+  if(!insideDiagram(fCX, fCY)) {
+    return false;
   }
+
+  fCX = fCY = 0.0;
+  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/curvediagram.h
+++ b/qucs/qucs/diagrams/curvediagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  bool clipCoordinates(float &fCX, float& fCY) const;
+  void finishMarkerCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/curvediagram.h
+++ b/qucs/qucs/diagrams/curvediagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(float&, float&) const;
+  void finishMarkerCoordinates(Marker*) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/curvediagram.h
+++ b/qucs/qucs/diagrams/curvediagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(Marker*) const;
+  bool clipCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -1320,11 +1320,11 @@ Diagram* Diagram::newOne()
 }
 
 // ------------------------------------------------------------
-void Diagram::finishMarkerCoordinates(float& fCX, float& fCY) const
+void Diagram::finishMarkerCoordinates(Marker *m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-      fCX = float(x2 >> 1);
-      fCY = float(y2 >> 1);
+  if(!insideDiagram(m->fCX, m->fCY)) {
+      m->fCX = float(x2 >> 1);
+      m->fCY = float(y2 >> 1);
   }
 }
 

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -1322,11 +1322,16 @@ Diagram* Diagram::newOne()
 // ------------------------------------------------------------
 void Diagram::finishMarkerCoordinates(Marker *m) const
 {
-  // for round diagrams: if marker is outside its coordinates
-  // are reset to the diagram center
+  // for round diagrams: if marker is outside it's placed
+  // on the diagram border, keeping its angle
   if(!insideDiagram(m->fCX, m->fCY)) {
-      m->fCX = float(x2 >> 1);
-      m->fCY = float(y2 >> 1);
+    float R = x2/2.0; // diagram radius and also coordinate of center
+    float ma = atan2(m->fCY-R, m->fCX-R);
+    m->fCX = R * (1 + cos(ma));
+    m->fCY = R * (1 + sin(ma));
+    m->outside_graph = true;
+  } else {
+     m->outside_graph = false;
   }
 }
 

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -1322,6 +1322,8 @@ Diagram* Diagram::newOne()
 // ------------------------------------------------------------
 void Diagram::finishMarkerCoordinates(Marker *m) const
 {
+  // for round diagrams: if marker is outside its coordinates
+  // are reset to the diagram center
   if(!insideDiagram(m->fCX, m->fCY)) {
       m->fCX = float(x2 >> 1);
       m->fCY = float(y2 >> 1);

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -1325,20 +1325,17 @@ Diagram* Diagram::newOne()
 }
 
 // ------------------------------------------------------------
-bool Diagram::clipCoordinates(float &fCX, float& fCY) const
+void Diagram::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
   // for round diagrams: if marker is outside it's placed
   // on the diagram border, keeping its angle
   // return true if coordinates were modified
-  if(insideDiagram(fCX, fCY)) {
-    return false;
+  if(!insideDiagram(fCX, fCY)) {
+    float R = x2/2.0; // diagram radius and also coordinate of center
+    float ma = atan2(fCY-R, fCX-R);
+    fCX = R * (1 + cos(ma));
+    fCY = R * (1 + sin(ma));
   }
-
-  float R = x2/2.0; // diagram radius and also coordinate of center
-  float ma = atan2(fCY-R, fCX-R);
-  fCX = R * (1 + cos(ma));
-  fCY = R * (1 + sin(ma));
-  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/diagram.cpp
+++ b/qucs/qucs/diagrams/diagram.cpp
@@ -363,6 +363,11 @@ void Diagram::createAxisLabels()
 }
 
 // ------------------------------------------------------------
+// compute outcodes for the Cohen-Sutherland algorithm
+//             left central right
+//        top  1001   1000   1010
+//    central  0001   0000   0010
+//     bottom  0101   0100   0110
 int Diagram::regionCode(float x, float y) const
 {
   int code=0;   // code for clipping
@@ -1320,19 +1325,20 @@ Diagram* Diagram::newOne()
 }
 
 // ------------------------------------------------------------
-void Diagram::finishMarkerCoordinates(Marker *m) const
+bool Diagram::clipCoordinates(float &fCX, float& fCY) const
 {
   // for round diagrams: if marker is outside it's placed
   // on the diagram border, keeping its angle
-  if(!insideDiagram(m->fCX, m->fCY)) {
-    float R = x2/2.0; // diagram radius and also coordinate of center
-    float ma = atan2(m->fCY-R, m->fCX-R);
-    m->fCX = R * (1 + cos(ma));
-    m->fCY = R * (1 + sin(ma));
-    m->outside_graph = true;
-  } else {
-     m->outside_graph = false;
+  // return true if coordinates were modified
+  if(insideDiagram(fCX, fCY)) {
+    return false;
   }
+
+  float R = x2/2.0; // diagram radius and also coordinate of center
+  float ma = atan2(fCY-R, fCX-R);
+  fCX = R * (1 + cos(ma));
+  fCY = R * (1 + sin(ma));
+  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -67,7 +67,7 @@ public:
                (const double*, const double*, const double*, float*, float*, Axis const*) const {};
   void calcCoordinateP (const double*x, const double*y, const double*z, Graph::iterator& p, Axis const* A) const;
   virtual void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const{};
-  virtual bool clipCoordinates(float &fCX, float& fCY) const;
+  virtual void finishMarkerCoordinates(float &fCX, float& fCY) const;
   virtual void calcLimits() {};
   virtual QString extraMarkerText(Marker const*) const {return "";}
   

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -67,7 +67,7 @@ public:
                (const double*, const double*, const double*, float*, float*, Axis const*) const {};
   void calcCoordinateP (const double*x, const double*y, const double*z, Graph::iterator& p, Axis const* A) const;
   virtual void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const{};
-  virtual void finishMarkerCoordinates(float&, float&) const;
+  virtual void finishMarkerCoordinates(Marker*) const;
   virtual void calcLimits() {};
   virtual QString extraMarkerText(Marker const*) const {return "";}
   

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -140,6 +140,15 @@ protected:
 
   virtual void calcData(Graph*);
 
+  // enums for the Cohen-Sutherland algorithm outcodes
+  enum CS_REGION : char {
+    CS_INSIDE = 0, // 0000
+    CS_LEFT = 1,   // 0001
+    CS_RIGHT = 2,  // 0010
+    CS_BOTTOM = 4, // 0100
+    CS_TOP = 8    // 1000
+  };
+
 private:
   int Bounding_x1, Bounding_x2, Bounding_y1, Bounding_y2;
 };

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -122,6 +122,7 @@ public:
 
   bool hideLines;       // for "Rect3D": hide invisible lines ?
   int rotX, rotY, rotZ; // for "Rect3D": rotation around x, y and z axis
+  int  regionCode(float, float) const;
 
 protected:
   void calcSmithAxisScale(Axis*, int&, int&);
@@ -134,7 +135,6 @@ protected:
   bool calcYAxis(Axis*, int);
   virtual void createAxisLabels();
 
-  int  regionCode(float, float) const;
   virtual void clip(Graph::iterator &) const;
   void rectClip(Graph::iterator &) const;
 

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -122,7 +122,6 @@ public:
 
   bool hideLines;       // for "Rect3D": hide invisible lines ?
   int rotX, rotY, rotZ; // for "Rect3D": rotation around x, y and z axis
-  int  regionCode(float, float) const;
 
 protected:
   void calcSmithAxisScale(Axis*, int&, int&);
@@ -135,6 +134,7 @@ protected:
   bool calcYAxis(Axis*, int);
   virtual void createAxisLabels();
 
+  int  regionCode(float, float) const;
   virtual void clip(Graph::iterator &) const;
   void rectClip(Graph::iterator &) const;
 

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -67,7 +67,7 @@ public:
                (const double*, const double*, const double*, float*, float*, Axis const*) const {};
   void calcCoordinateP (const double*x, const double*y, const double*z, Graph::iterator& p, Axis const* A) const;
   virtual void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const{};
-  virtual void finishMarkerCoordinates(Marker*) const;
+  virtual bool clipCoordinates(float &fCX, float& fCY) const;
   virtual void calcLimits() {};
   virtual QString extraMarkerText(Marker const*) const {return "";}
   

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -314,6 +314,8 @@ void Marker::createText()
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
   }
+  outside_diagram_boundaries = !diag()->insideDiagram(fCX, fCY);
+  diag()->finishMarkerCoordinates(fCX, fCY);
 
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
@@ -324,6 +326,9 @@ void Marker::createText()
 void Marker::makeInvalid()
 {
   fCX = fCY = -1e3; // invalid coordinates
+  assert(diag());
+  outside_diagram_boundaries = !diag()->insideDiagram(fCX, fCY);
+  diag()->finishMarkerCoordinates(fCX, fCY); // leave to diagram
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
 
@@ -499,11 +504,6 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
 
   int x1_, y1_;
   p->map(x0+x1, y0+y1, x1_, y1_);
-  // limit coordinates to diagram boundary
-  float tCX = fCX, tCY = fCY;
-  bool outside_diagram_boundaries = diag()->clipCoordinates(tCX, tCY);
-  cx = int(tCX+0.5);
-  cy = int(tCY+0.5);
   // which corner of rectangle should be connected to line ?
   if(cx < x1+(x2>>1)) {
     if(-cy >= y1+(y2>>1))
@@ -515,8 +515,8 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
       y1_ += y2_ - 1;
   }
   float fx2, fy2;
-  fx2 = (float(x0)+tCX)*p->Scale + p->DX;
-  fy2 = (float(y0)-tCY)*p->Scale + p->DY;
+  fx2 = (float(x0)+fCX)*p->Scale + p->DX;
+  fy2 = (float(y0)-fCY)*p->Scale + p->DY;
   p->Painter->drawLine(x1_, y1_, TO_INT(fx2), TO_INT(fy2));
 
   if (outside_diagram_boundaries)

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -314,7 +314,6 @@ void Marker::createText()
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
   }
-  diag()->finishMarkerCoordinates(this);
 
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
@@ -325,8 +324,6 @@ void Marker::createText()
 void Marker::makeInvalid()
 {
   fCX = fCY = -1e3; // invalid coordinates
-  assert(diag());
-  diag()->finishMarkerCoordinates(this); // leave to diagram
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
 
@@ -502,6 +499,11 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
 
   int x1_, y1_;
   p->map(x0+x1, y0+y1, x1_, y1_);
+  // limit coordinates to diagram boundary
+  float tCX = fCX, tCY = fCY;
+  bool outside_diagram_boundaries = diag()->clipCoordinates(tCX, tCY);
+  cx = int(tCX+0.5);
+  cy = int(tCY+0.5);
   // which corner of rectangle should be connected to line ?
   if(cx < x1+(x2>>1)) {
     if(-cy >= y1+(y2>>1))
@@ -513,11 +515,11 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
       y1_ += y2_ - 1;
   }
   float fx2, fy2;
-  fx2 = (float(x0)+fCX)*p->Scale + p->DX;
-  fy2 = (float(y0)-fCY)*p->Scale + p->DY;
+  fx2 = (float(x0)+tCX)*p->Scale + p->DX;
+  fy2 = (float(y0)-tCY)*p->Scale + p->DY;
   p->Painter->drawLine(x1_, y1_, TO_INT(fx2), TO_INT(fy2));
 
-  if (outside_graph) // set by Diagram::finishMarkerCoordinates()
+  if (outside_diagram_boundaries)
   {//Let's draw a symbol to emphasize the point is outside the graph
     QPen pen(QColor(Qt::red), 7);
     p->Painter->setPen(pen);

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -314,7 +314,7 @@ void Marker::createText()
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
   }
-  diag()->finishMarkerCoordinates(fCX, fCY);
+  diag()->finishMarkerCoordinates(this);
 
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
@@ -326,7 +326,7 @@ void Marker::makeInvalid()
 {
   fCX = fCY = -1e3; // invalid coordinates
   assert(diag());
-  diag()->finishMarkerCoordinates(fCX, fCY); // leave to diagram
+  diag()->finishMarkerCoordinates(this); // leave to diagram
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
 

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -314,8 +314,21 @@ void Marker::createText()
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
   }
-  diag()->finishMarkerCoordinates(fCX, fCY);
-
+  
+  if(diag()->Name=="Rect")
+  { //In the case of the Cartesian diagram, this code checks if the point the marker is pointing outside the diagram boundaries and, in
+    //such case "point_outside_graph" is set to "true" in order to paint a red square at paint().
+    float fx = fCX, fy = fCY;
+    point_outside_graph = false;
+    if (diag()->regionCode(fCX, fCY) == 8) point_outside_graph = true, fCY = diag()->y2;//The marker points above the upper limit
+    if (diag()->regionCode(fCX, fCY) == 4) point_outside_graph = true, fCY = 0;//The marker points below the lower limit
+    
+  }
+  else
+  {
+    diag()->finishMarkerCoordinates(fCX, fCY);
+  }
+  
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
   getTextSize();
@@ -516,6 +529,13 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
   fx2 = (float(x0)+fCX)*p->Scale + p->DX;
   fy2 = (float(y0)-fCY)*p->Scale + p->DY;
   p->Painter->drawLine(x1_, y1_, TO_INT(fx2), TO_INT(fy2));
+
+  if (point_outside_graph)
+  {//Let's draw a symbol to emphasize the point is outside the graph
+     QPen pen(QColor(Qt::red), 7);
+     p->Painter->setPen(pen);
+     p->Painter->drawPoint(fx2, fy2);
+  }
 
   if(isSelected) {
     p->Painter->setPen(QPen(Qt::darkGray,3));

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -314,21 +314,8 @@ void Marker::createText()
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
   }
-  
-  if(diag()->Name=="Rect")
-  { //In the case of the Cartesian diagram, this code checks if the point the marker is pointing outside the diagram boundaries and, in
-    //such case "point_outside_graph" is set to "true" in order to paint a red square at paint().
-    float fx = fCX, fy = fCY;
-    point_outside_graph = false;
-    if (diag()->regionCode(fCX, fCY) == 8) point_outside_graph = true, fCY = diag()->y2;//The marker points above the upper limit
-    if (diag()->regionCode(fCX, fCY) == 4) point_outside_graph = true, fCY = 0;//The marker points below the lower limit
-    
-  }
-  else
-  {
-    diag()->finishMarkerCoordinates(fCX, fCY);
-  }
-  
+  diag()->finishMarkerCoordinates(fCX, fCY);
+
   cx = int(fCX+0.5);
   cy = int(fCY+0.5);
   getTextSize();
@@ -529,13 +516,6 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
   fx2 = (float(x0)+fCX)*p->Scale + p->DX;
   fy2 = (float(y0)-fCY)*p->Scale + p->DY;
   p->Painter->drawLine(x1_, y1_, TO_INT(fx2), TO_INT(fy2));
-
-  if (point_outside_graph)
-  {//Let's draw a symbol to emphasize the point is outside the graph
-     QPen pen(QColor(Qt::red), 7);
-     p->Painter->setPen(pen);
-     p->Painter->drawPoint(fx2, fy2);
-  }
 
   if(isSelected) {
     p->Painter->setPen(QPen(Qt::darkGray,3));

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -517,6 +517,13 @@ void Marker::paint(ViewPainter *p, int x0, int y0)
   fy2 = (float(y0)-fCY)*p->Scale + p->DY;
   p->Painter->drawLine(x1_, y1_, TO_INT(fx2), TO_INT(fy2));
 
+  if (outside_graph) // set by Diagram::finishMarkerCoordinates()
+  {//Let's draw a symbol to emphasize the point is outside the graph
+    QPen pen(QColor(Qt::red), 7);
+    p->Painter->setPen(pen);
+    p->Painter->drawPoint(fx2, fy2);
+  }
+
   if(isSelected) {
     p->Painter->setPen(QPen(Qt::darkGray,3));
     p->drawRoundRect(x0+x1-3, y0+y1-3, x2+6, y2+6);

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -75,6 +75,7 @@ private:
   std::vector<double> VarPos;   // values the marker is pointing to
   double VarDep[2];   // dependent value
   float  fCX, fCY;  // coordinates for the line from graph to marker body
+  bool outside_diagram_boundaries; // marker coordinates (would) point outside diagram?
 
 public:
   QString Text;     // the string to be displayed in the marker text

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -77,6 +77,7 @@ private:
 
 public:
   float  fCX, fCY;  // coordinates for the line from graph to marker body
+  bool outside_graph = false;//Indicates whether the point is inside the graph or not
   QString Text;     // the string to be displayed in the marker text
   bool transparent; // background shines through marker body
   Axis const*xA,*yA,*zA;

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -74,10 +74,9 @@ public: // power matching stuff. some sort of VarPos (ab?)use
 private:
   std::vector<double> VarPos;   // values the marker is pointing to
   double VarDep[2];   // dependent value
+  float  fCX, fCY;  // coordinates for the line from graph to marker body
 
 public:
-  float  fCX, fCY;  // coordinates for the line from graph to marker body
-  bool outside_graph = false;//Indicates whether the point is inside the graph or not
   QString Text;     // the string to be displayed in the marker text
   bool transparent; // background shines through marker body
   Axis const*xA,*yA,*zA;

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -75,6 +75,7 @@ private:
   std::vector<double> VarPos;   // values the marker is pointing to
   double VarDep[2];   // dependent value
   float  fCX, fCY;  // coordinates for the line from graph to marker body
+  bool point_outside_graph;//Indicates whether the point is inside the graph or not
 
 public:
   QString Text;     // the string to be displayed in the marker text

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -74,9 +74,9 @@ public: // power matching stuff. some sort of VarPos (ab?)use
 private:
   std::vector<double> VarPos;   // values the marker is pointing to
   double VarDep[2];   // dependent value
-  float  fCX, fCY;  // coordinates for the line from graph to marker body
 
 public:
+  float  fCX, fCY;  // coordinates for the line from graph to marker body
   QString Text;     // the string to be displayed in the marker text
   bool transparent; // background shines through marker body
   Axis const*xA,*yA,*zA;

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -75,7 +75,6 @@ private:
   std::vector<double> VarPos;   // values the marker is pointing to
   double VarDep[2];   // dependent value
   float  fCX, fCY;  // coordinates for the line from graph to marker body
-  bool point_outside_graph;//Indicates whether the point is inside the graph or not
 
 public:
   QString Text;     // the string to be displayed in the marker text

--- a/qucs/qucs/diagrams/phasordiagram.cpp
+++ b/qucs/qucs/diagrams/phasordiagram.cpp
@@ -53,14 +53,11 @@ PhasorDiagram::~PhasorDiagram()
 {
 }
 // --------------------------------------------------------------
-bool PhasorDiagram::clipCoordinates(float &fCX, float& fCY) const
+void PhasorDiagram::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
-  if(insideDiagram(fCX, fCY)) {
-    return false;
+  if(!insideDiagram(fCX, fCY)) {
+    fCX = fCY = 0.0;
   }
-
-  fCX = fCY = 0.0;
-  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/phasordiagram.cpp
+++ b/qucs/qucs/diagrams/phasordiagram.cpp
@@ -53,11 +53,14 @@ PhasorDiagram::~PhasorDiagram()
 {
 }
 // --------------------------------------------------------------
-void PhasorDiagram::finishMarkerCoordinates(Marker *m) const
+bool PhasorDiagram::clipCoordinates(float &fCX, float& fCY) const
 {
-  if(!insideDiagram(m->fCX, m->fCY)) {
-	  m->fCX = m->fCY = 0.0;
+  if(insideDiagram(fCX, fCY)) {
+    return false;
   }
+
+  fCX = fCY = 0.0;
+  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/phasordiagram.cpp
+++ b/qucs/qucs/diagrams/phasordiagram.cpp
@@ -53,10 +53,10 @@ PhasorDiagram::~PhasorDiagram()
 {
 }
 // --------------------------------------------------------------
-void PhasorDiagram::finishMarkerCoordinates(float& fCX, float& fCY) const
+void PhasorDiagram::finishMarkerCoordinates(Marker *m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-	  fCX = fCY = 0.0;
+  if(!insideDiagram(m->fCX, m->fCY)) {
+	  m->fCX = m->fCY = 0.0;
   }
 }
 

--- a/qucs/qucs/diagrams/phasordiagram.h
+++ b/qucs/qucs/diagrams/phasordiagram.h
@@ -37,7 +37,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const;
-  void finishMarkerCoordinates(float&, float&) const;
+  void finishMarkerCoordinates(Marker*) const;
   void calcRestAxis(Axis* , Axis* , Axis*);
 
 protected:

--- a/qucs/qucs/diagrams/phasordiagram.h
+++ b/qucs/qucs/diagrams/phasordiagram.h
@@ -37,7 +37,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const;
-  bool clipCoordinates(float &fCX, float& fCY) const;
+  void finishMarkerCoordinates(float &fCX, float& fCY) const;
   void calcRestAxis(Axis* , Axis* , Axis*);
 
 protected:

--- a/qucs/qucs/diagrams/phasordiagram.h
+++ b/qucs/qucs/diagrams/phasordiagram.h
@@ -37,7 +37,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinatePh(const double*, float*, float*, Axis const*, Axis const*) const;
-  void finishMarkerCoordinates(Marker*) const;
+  bool clipCoordinates(float &fCX, float& fCY) const;
   void calcRestAxis(Axis* , Axis* , Axis*);
 
 protected:

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -188,11 +188,14 @@ void Rect3DDiagram::calcCoordinate(const double* xD, const double* zD, const dou
 }
 
 // --------------------------------------------------------------
-void Rect3DDiagram::finishMarkerCoordinates(Marker *m) const
+bool Rect3DDiagram::clipCoordinates(float &fCX, float& fCY) const
 {
-  if(!insideDiagram(m->fCX, m->fCY)) {
-	  m->fCX = m->fCY = 0.0;
+  if(insideDiagram(fCX, fCY)) {
+    return false;
   }
+
+  fCX = fCY = 0.0;
+  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -188,10 +188,10 @@ void Rect3DDiagram::calcCoordinate(const double* xD, const double* zD, const dou
 }
 
 // --------------------------------------------------------------
-void Rect3DDiagram::finishMarkerCoordinates(float& fCX, float& fCY) const
+void Rect3DDiagram::finishMarkerCoordinates(Marker *m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-	  fCX = fCY = 0.0;
+  if(!insideDiagram(m->fCX, m->fCY)) {
+	  m->fCX = m->fCY = 0.0;
   }
 }
 

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -1063,7 +1063,7 @@ void Rect3DDiagram::createAxisLabels()
 // ------------------------------------------------------------
 bool Rect3DDiagram::insideDiagram(float x, float y) const
 {
-  return (regionCode(x, y) == 0);
+  return (regionCode(x, y) == CS_INSIDE);
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/qucs/diagrams/rect3ddiagram.cpp
@@ -188,14 +188,11 @@ void Rect3DDiagram::calcCoordinate(const double* xD, const double* zD, const dou
 }
 
 // --------------------------------------------------------------
-bool Rect3DDiagram::clipCoordinates(float &fCX, float& fCY) const
+void Rect3DDiagram::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
-  if(insideDiagram(fCX, fCY)) {
-    return false;
+  if(!insideDiagram(fCX, fCY)) {
+    fCX = fCY = 0.0;
   }
-
-  fCX = fCY = 0.0;
-  return true;
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/rect3ddiagram.h
+++ b/qucs/qucs/diagrams/rect3ddiagram.h
@@ -47,7 +47,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(float&, float&) const;
+  void finishMarkerCoordinates(Marker*) const;
 
   void createAxisLabels();
   bool insideDiagram(float, float) const;

--- a/qucs/qucs/diagrams/rect3ddiagram.h
+++ b/qucs/qucs/diagrams/rect3ddiagram.h
@@ -47,7 +47,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  bool clipCoordinates(float &fCX, float& fCY) const;
+  void finishMarkerCoordinates(float &fCX, float& fCY) const;
 
   void createAxisLabels();
   bool insideDiagram(float, float) const;

--- a/qucs/qucs/diagrams/rect3ddiagram.h
+++ b/qucs/qucs/diagrams/rect3ddiagram.h
@@ -47,7 +47,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(Marker*) const;
+  bool clipCoordinates(float &fCX, float& fCY) const;
 
   void createAxisLabels();
   bool insideDiagram(float, float) const;

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -89,19 +89,19 @@ bool RectDiagram::clipCoordinates(float &fCX, float& fCY) const
   // the marker is pointing outside the diagram boundaries and, in
   // such case it clips the given coordinates to the diagram border
   // and returns true
-  if (regionCode(fCX, fCY) == 8) {
+  if (regionCode(fCX, fCY) == CS_TOP) {
     fCY = y2; // The marker points above the upper limit
     return true;
   }
-  if (regionCode(fCX, fCY) == 4) {
+  if (regionCode(fCX, fCY) == CS_BOTTOM) {
     fCY = 0;  // The marker points below the lower limit
     return true;
   }
-  if (regionCode(fCX, fCY) == 1) {
+  if (regionCode(fCX, fCY) == CS_LEFT) {
     fCX = 0;  // The marker points below the left limit
     return true;
   }
-  if (regionCode(fCX, fCY) == 2) {
+  if (regionCode(fCX, fCY) == CS_RIGHT) {
     fCX = x2;  // The marker points above the right limit
     return true;
   }
@@ -254,7 +254,7 @@ Frame:
 // ------------------------------------------------------------
 bool RectDiagram::insideDiagram(float x, float y) const
 {
-  return (regionCode(x, y) == 0);
+  return (regionCode(x, y) == CS_INSIDE);
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -85,9 +85,23 @@ void RectDiagram::calcCoordinate(const double* xD, const double* yD, const doubl
 // --------------------------------------------------------------
 void RectDiagram::finishMarkerCoordinates(Marker* m) const
 {
-  if(!insideDiagram(m->fCX, m->fCY)) {
-	  m->fCX = m->fCY = 0.0;
+  // In the case of the Cartesian diagram, this code checks if the point
+  // the marker is pointing outside the diagram boundaries and, in
+  // such case "point_outside_graph" is set to "true" in order to paint
+  // a red square at paint().
+  if (regionCode(m->fCX, m->fCY) == 8) {
+    m->fCY = y2; // The marker points above the upper limit
+    m->outside_graph = true;
+    return;
   }
+  
+  if (regionCode(m->fCX, m->fCY) == 4) {
+    m->fCY = 0;  // The marker points below the lower limit
+    m->outside_graph = true;
+    return;
+  }
+
+  m->outside_graph = false;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -83,17 +83,13 @@ void RectDiagram::calcCoordinate(const double* xD, const double* yD, const doubl
 }
 
 // --------------------------------------------------------------
-bool RectDiagram::clipCoordinates(float &fCX, float& fCY) const
+void RectDiagram::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
   // In the case of the Cartesian diagram, this code checks if the point
   // the marker is pointing outside the diagram boundaries and, in
   // such case it clips the given coordinates to the diagram border
   // and returns true
   int rc = regionCode(fCX, fCY);
-
-  if (rc == CS_INSIDE) {
-    return false;
-  }
 
   if (rc & CS_TOP) {
     fCY = y2; // The marker points above the upper limit
@@ -107,7 +103,6 @@ bool RectDiagram::clipCoordinates(float &fCX, float& fCY) const
   if (rc & CS_RIGHT) {
     fCX = x2;  // The marker points above the right limit
   }
-  return true;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -83,25 +83,30 @@ void RectDiagram::calcCoordinate(const double* xD, const double* yD, const doubl
 }
 
 // --------------------------------------------------------------
-void RectDiagram::finishMarkerCoordinates(Marker* m) const
+bool RectDiagram::clipCoordinates(float &fCX, float& fCY) const
 {
   // In the case of the Cartesian diagram, this code checks if the point
   // the marker is pointing outside the diagram boundaries and, in
-  // such case "point_outside_graph" is set to "true" in order to paint
-  // a red square at paint().
-  if (regionCode(m->fCX, m->fCY) == 8) {
-    m->fCY = y2; // The marker points above the upper limit
-    m->outside_graph = true;
-    return;
+  // such case it clips the given coordinates to the diagram border
+  // and returns true
+  if (regionCode(fCX, fCY) == 8) {
+    fCY = y2; // The marker points above the upper limit
+    return true;
   }
-  
-  if (regionCode(m->fCX, m->fCY) == 4) {
-    m->fCY = 0;  // The marker points below the lower limit
-    m->outside_graph = true;
-    return;
+  if (regionCode(fCX, fCY) == 4) {
+    fCY = 0;  // The marker points below the lower limit
+    return true;
+  }
+  if (regionCode(fCX, fCY) == 1) {
+    fCX = 0;  // The marker points below the left limit
+    return true;
+  }
+  if (regionCode(fCX, fCY) == 2) {
+    fCX = x2;  // The marker points above the right limit
+    return true;
   }
 
-  m->outside_graph = false;
+  return false;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -83,10 +83,10 @@ void RectDiagram::calcCoordinate(const double* xD, const double* yD, const doubl
 }
 
 // --------------------------------------------------------------
-void RectDiagram::finishMarkerCoordinates(float& fCX, float& fCY) const
+void RectDiagram::finishMarkerCoordinates(Marker* m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-	  fCX = fCY = 0.0;
+  if(!insideDiagram(m->fCX, m->fCY)) {
+	  m->fCX = m->fCY = 0.0;
   }
 }
 

--- a/qucs/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/qucs/diagrams/rectdiagram.cpp
@@ -89,24 +89,25 @@ bool RectDiagram::clipCoordinates(float &fCX, float& fCY) const
   // the marker is pointing outside the diagram boundaries and, in
   // such case it clips the given coordinates to the diagram border
   // and returns true
-  if (regionCode(fCX, fCY) == CS_TOP) {
-    fCY = y2; // The marker points above the upper limit
-    return true;
-  }
-  if (regionCode(fCX, fCY) == CS_BOTTOM) {
-    fCY = 0;  // The marker points below the lower limit
-    return true;
-  }
-  if (regionCode(fCX, fCY) == CS_LEFT) {
-    fCX = 0;  // The marker points below the left limit
-    return true;
-  }
-  if (regionCode(fCX, fCY) == CS_RIGHT) {
-    fCX = x2;  // The marker points above the right limit
-    return true;
+  int rc = regionCode(fCX, fCY);
+
+  if (rc == CS_INSIDE) {
+    return false;
   }
 
-  return false;
+  if (rc & CS_TOP) {
+    fCY = y2; // The marker points above the upper limit
+  }
+  if (rc & CS_BOTTOM) {
+    fCY = 0;  // The marker points below the lower limit
+  }
+  if (rc & CS_LEFT) {
+    fCX = 0;  // The marker points below the left limit
+  }
+  if (rc & CS_RIGHT) {
+    fCX = x2;  // The marker points above the right limit
+  }
+  return true;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/rectdiagram.h
+++ b/qucs/qucs/diagrams/rectdiagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  bool clipCoordinates(float &fCX, float& fCY) const;
+  void finishMarkerCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/rectdiagram.h
+++ b/qucs/qucs/diagrams/rectdiagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(float&, float&) const;
+  void finishMarkerCoordinates(Marker*) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/rectdiagram.h
+++ b/qucs/qucs/diagrams/rectdiagram.h
@@ -32,7 +32,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(Marker*) const;
+  bool clipCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/waveac.cpp
+++ b/qucs/qucs/diagrams/waveac.cpp
@@ -66,10 +66,10 @@ void Waveac::calcCoordinate(const double* xD, const double* yD, const double*,
 }
 
 // --------------------------------------------------------------
-void Waveac::finishMarkerCoordinates(float& fCX, float& fCY) const
+void Waveac::finishMarkerCoordinates(Marker *m) const
 {
-  if(!insideDiagram(fCX, fCY)) {
-	  fCX = fCY = 0.0;
+  if(!insideDiagram(m->fCX, m->fCY)) {
+	  m->fCX = m->fCY = 0.0;
   }
 }
 

--- a/qucs/qucs/diagrams/waveac.cpp
+++ b/qucs/qucs/diagrams/waveac.cpp
@@ -303,7 +303,7 @@ void Waveac::calcData(Graph *g)
 // ------------------------------------------------------------
 bool Waveac::insideDiagram(float x, float y) const
 {
-  return (regionCode(x, y) == 0);
+  return (regionCode(x, y) == CS_INSIDE);
 }
 
 // ------------------------------------------------------------

--- a/qucs/qucs/diagrams/waveac.cpp
+++ b/qucs/qucs/diagrams/waveac.cpp
@@ -66,14 +66,11 @@ void Waveac::calcCoordinate(const double* xD, const double* yD, const double*,
 }
 
 // --------------------------------------------------------------
-bool Waveac::clipCoordinates(float &fCX, float& fCY) const
+void Waveac::finishMarkerCoordinates(float &fCX, float& fCY) const
 {
-  if(insideDiagram(fCX, fCY)) {
-    return false;
+  if(!insideDiagram(fCX, fCY)) {
+    fCX = fCY = 0.0;
   }
-
-  fCX = fCY = 0.0;
-  return true;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/waveac.cpp
+++ b/qucs/qucs/diagrams/waveac.cpp
@@ -66,11 +66,14 @@ void Waveac::calcCoordinate(const double* xD, const double* yD, const double*,
 }
 
 // --------------------------------------------------------------
-void Waveac::finishMarkerCoordinates(Marker *m) const
+bool Waveac::clipCoordinates(float &fCX, float& fCY) const
 {
-  if(!insideDiagram(m->fCX, m->fCY)) {
-	  m->fCX = m->fCY = 0.0;
+  if(insideDiagram(fCX, fCY)) {
+    return false;
   }
+
+  fCX = fCY = 0.0;
+  return true;
 }
 
 // --------------------------------------------------------------

--- a/qucs/qucs/diagrams/waveac.h
+++ b/qucs/qucs/diagrams/waveac.h
@@ -38,7 +38,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(Marker*) const;
+  bool clipCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/waveac.h
+++ b/qucs/qucs/diagrams/waveac.h
@@ -38,7 +38,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  void finishMarkerCoordinates(float&, float&) const;
+  void finishMarkerCoordinates(Marker*) const;
   bool insideDiagram(float, float) const;
 
 protected:

--- a/qucs/qucs/diagrams/waveac.h
+++ b/qucs/qucs/diagrams/waveac.h
@@ -38,7 +38,7 @@ public:
   int  calcDiagram();
   void calcLimits();
   void calcCoordinate(const double*, const double*, const double*, float*, float*, Axis const*) const;
-  bool clipCoordinates(float &fCX, float& fCY) const;
+  void finishMarkerCoordinates(float &fCX, float& fCY) const;
   bool insideDiagram(float, float) const;
 
 protected:


### PR DESCRIPTION
When moving a marker back and forth, it points to (0,0) if the data the marker is pointing at lies outside the diagram limits. See [this](https://drive.google.com/open?id=1smNdsFWsCOArMRTy7Y7Rhlb55d376ks9)

This PR solves that issue by checking if that point is above the upper limit or below the lower limit of the y-axis and setting fCX and fCY according to such limits. For this purpose, [I've set Diagram::regioncode() to be public](https://github.com/Qucs/qucs/compare/develop...andresmmera:FixMarker_Bug_when_pointing_to_hidden_data?expand=1#diff-793f9ef8aa12236983a5432bbd58b798R125). I think this shouldn't have any side-effect...
In addition to this, [I defined a private boolean variable](https://github.com/Qucs/qucs/compare/develop...andresmmera:FixMarker_Bug_when_pointing_to_hidden_data?expand=1#diff-11755930ce8a7c8de63278c3bdb3f58fR78) in the Marker class which is set to true when the graph data is outside the limits and is used [here](https://github.com/Qucs/qucs/compare/develop...andresmmera:FixMarker_Bug_when_pointing_to_hidden_data?expand=1#diff-d6888ff24dbf42ac6c04ad6e983c02bcR533) to display a big red point to emphasize that the data is missing.

This is the marker behavior using this patch https://drive.google.com/open?id=1mhPCOiz5HuMX_rbZdYvBWq9irZh4aHve