### PR TITLE
Fix qucsconv matlab file generation

### DIFF
--- a/qucs-core/src/converter/matlab_producer.cpp
+++ b/qucs-core/src/converter/matlab_producer.cpp
@@ -80,17 +80,18 @@ static void matlab_header (int32_t rows, int32_t cols, const char * name) {
   int32_t len = strlen (name) + 1;
   fwrite (&len, sizeof (int32_t), 1, matlab_out);
 
-  char * p = strdup(name);
+  char * ns = strdup(name);
+  char * p = ns;
   // data name
   if (matlab_symbols) {
     // convert to valid Matlab identifiers
-    for (unsigned int i = 0; i < strlen (name); i++, p++) {
+    for (unsigned int i = 0; i < strlen (ns); i++, p++) {
       if (!isalnum (*p) && *p != '_')
 	*p = '_';
     }
   }
-  fwrite (p, 1, len, matlab_out);
-  free(p);
+  fwrite (ns, 1, len, matlab_out);
+  free(ns);
 }
 
 // Writes a Matlab v4 vector.


### PR DESCRIPTION
Fixes a bug introduced [here](https://github.com/Qucs/qucs/commit/85e658588bed1ff88fda328d4cb07cd1bb40b57f#diff-10505be9f9b84a5b48cae5a915a76b88) in the variable name sanitization which caused `qucsconv` to crash when writing a matlab file.

Found while testing #693 ; in practice I think `qucsconv` currently segfaults on any conversion to a matlab file.