### PR TITLE
Lay aside phasor and waveac diagrams

### DIFF
--- a/qucs/qucs/diagrams/CMakeLists.txt
+++ b/qucs/qucs/diagrams/CMakeLists.txt
@@ -13,7 +13,6 @@ diagrams.h
 graph.h
 marker.h
 markerdialog.h
-phasordiagram.h
 polardiagram.h
 psdiagram.h
 rect3ddiagram.h
@@ -22,14 +21,17 @@ smithdiagram.h
 tabdiagram.h
 timingdiagram.h
 truthdiagram.h
-waveac.h
+#phasordiagram.h
+#waveac.h
 )
 
 SET(DIAGRAMS_SRCS
 curvediagram.cpp	graph.cpp		polardiagram.cpp	smithdiagram.cpp
 diagram.cpp		marker.cpp		psdiagram.cpp		tabdiagram.cpp
 diagramdialog.cpp	markerdialog.cpp	rect3ddiagram.cpp	timingdiagram.cpp
-rectdiagram.cpp		phasordiagram.cpp		truthdiagram.cpp	waveac.cpp
+rectdiagram.cpp		truthdiagram.cpp
+#phasordiagram.cpp
+#waveac.cpp
 )
 
 SET(DIAGRAMS_MOC_HDRS

--- a/qucs/qucs/diagrams/Makefile.am
+++ b/qucs/qucs/diagrams/Makefile.am
@@ -30,13 +30,15 @@ MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 libdiagrams_la_SOURCES = tabdiagram.cpp smithdiagram.cpp rectdiagram.cpp \
   polardiagram.cpp graph.cpp diagramdialog.cpp diagram.cpp marker.cpp   \
   markerdialog.cpp psdiagram.cpp rect3ddiagram.cpp curvediagram.cpp     \
-  timingdiagram.cpp truthdiagram.cpp phasordiagram.cpp waveac.cpp
+  timingdiagram.cpp truthdiagram.cpp
+ # phasordiagram.cpp waveac.cpp
 
 nodist_libdiagrams_la_SOURCES = $(MOCFILES)
 
 noinst_HEADERS = $(MOCHEADERS) diagram.h graph.h polardiagram.h rectdiagram.h \
   smithdiagram.h tabdiagram.h diagrams.h marker.h psdiagram.h rect3ddiagram.h \
-  curvediagram.h timingdiagram.h truthdiagram.h phasordiagram.h waveac.h
+  curvediagram.h timingdiagram.h truthdiagram.h 
+#phasordiagram.h waveac.h
 
 AM_CPPFLAGS = $(X11_INCLUDES) $(QT_INCLUDES) -I$(top_srcdir)/qucs
 

--- a/qucs/qucs/diagrams/diagram.h
+++ b/qucs/qucs/diagrams/diagram.h
@@ -96,12 +96,13 @@ public:
 
   bool insideDiagramPh(Graph::iterator const& , float*, float*) const;
   bool newcoordinate(Graph::iterator const& , float*, float*) const;
+  /* PHASOR AND WAVEAC RELATED
   void phasorscale();
   void findaxisA(Graph*);
   bool findmatch(Graph* , int);
   void findfreq(Graph*);
   void setlimitsphasor(Axis* ,Axis*);
-  double wavevalX(int) const;
+  double wavevalX(int) const;*/
 
   QString Name; // identity of diagram type (e.g. Polar), used for saving etc.
   QPen    GridPen;
@@ -116,8 +117,10 @@ public:
   int nfreqt,nfreqa;
   int x3, y3, sc;
   Axis  xAxis, yAxis, zAxis;   // axes (x, y left, y right)
+
+  /* PHASOR DIAGRAM RELATED
   Axis  xAxisV, yAxisV, zAxisV, xAxisI, yAxisI, zAxisI, xAxisP, yAxisP, zAxisP, xAxisZ, yAxisZ,
- zAxisZ, *xAxisA, *yAxisA, *zAxisA;//for Phasor diagram
+ zAxisZ, *xAxisA, *yAxisA, *zAxisA;*/
   int State;  // to remember which resize area was touched
 
   bool hideLines;       // for "Rect3D": hide invisible lines ?

--- a/qucs/qucs/diagrams/diagramdialog.h
+++ b/qucs/qucs/diagrams/diagramdialog.h
@@ -79,13 +79,14 @@ private slots:
   void slotEditRotX(const QString&);
   void slotEditRotY(const QString&);
   void slotEditRotZ(const QString&);
+  /* RELATED TO WAVEAC AND PHASOR DIAGRAMS
   void PhasorvalV(int);
   void PhasorvalI(int);
   void PhasorvalP(int);
   void PhasorvalZ(int);
   void addvar(QString);
   void remvar(QString);
-  bool testvar(QString);
+  bool testvar(QString);*/
 
 protected slots:
     void reject();

--- a/qucs/qucs/diagrams/diagrams.h
+++ b/qucs/qucs/diagrams/diagrams.h
@@ -31,7 +31,7 @@
 #include "curvediagram.h"
 #include "timingdiagram.h"
 #include "truthdiagram.h"
-#include "phasordiagram.h"
-#include "waveac.h"
+//#include "phasordiagram.h"
+//#include "waveac.h"
 
 #endif

--- a/qucs/qucs/diagrams/marker.cpp
+++ b/qucs/qucs/diagrams/marker.cpp
@@ -75,7 +75,7 @@ Marker::Marker(Graph *pg_, int branchNo, int cx_, int cy_) :
     makeInvalid();
   }else{
     initText(branchNo);   // finally create marker
-    fix();
+    //fix();//RELATED TO THE PHASOR DIAGRAM CODE
     createText();
   }
 
@@ -134,9 +134,7 @@ void Marker::initText(int n)
   // find exact marker position
   m  = nnn - 1;
   pz = pGraph->cPointsY + 2*n;
-  if(diag()->Name=="Phasor") m = phasormk(pz,px,nnn);
-  else
-  {
+
     for(nn=0; nn<nnn; nn++) {
       diag()->calcCoordinate(px, pz, py, &fCX, &fCY, pa);
       ++px;
@@ -155,9 +153,7 @@ void Marker::initText(int n)
 	m = nn;
       }
     }
-  }
-  //inittext for waveac is only to find values for VarPos except for VarPos[0]
-  if(diag()->Name=="Waveac") m=0;
+
   if(isCross) m *= pD->count;
   n += m;
 
@@ -178,8 +174,9 @@ void Marker::initText(int n)
 
   // createText();
 }
-// ---------------------------------------------------------------------
-/*this function finds the VarPos[0] of waveac*/
+
+/* RELATED TO THE PHASOR DIAGRAM CODE
+//this function finds the VarPos[0] of waveac
 void Marker::fix()
 {
   if(!(pGraph->cPointsY)) {
@@ -210,6 +207,8 @@ void Marker::fix()
   VarPos[0] = diag()->wavevalX(m);
   
 }
+*/
+
 // ---------------------------------------------------------------------
 /*!
  * (should)
@@ -288,32 +287,13 @@ void Marker::createText()
   Text += diag()->extraMarkerText(this);
 
     Axis const *pa,*pt;
-  if(diag()->Name=="Phasor")
-  {
-    int z;
-    findaxismk();
-    pt=xA;
-    if(pGraph->yAxisNo == 0)  pa = yA;
-    else  pa = zA;
-    for(z=0;z<diag()->nfreqt;z++)
-    {
-      if(diag()->freq[z]<=VarPos[0]) v=diag()->freq[z];
-      if(diag()->freq[z]==VarPos[0]) break;
 
-    }
-    VarPos[0]=v;
-    pp = &(VarPos[0]);
-
-    diag()->calcCoordinatePh(pz, &fCX, &fCY, pa, pt);
-  }
-  else
-  {
     if(pGraph->yAxisNo == 0)  pa = &(diag()->yAxis);
     else  pa = &(diag()->zAxis);
     pp = &(VarPos[0]);
 
     diag()->calcCoordinate(pp, pz, py, &fCX, &fCY, pa);
-  }
+
   diag()->finishMarkerCoordinates(fCX, fCY);
 
   cx = int(fCX+0.5);
@@ -354,8 +334,7 @@ bool Marker::moveLeftRight(bool left)
   DataX const *pD = pGraph->axis(0);
   px = pD->Points;
   if(!px) return false;
-  if(diag()->Name != "Waveac" &&diag()->Name != "Phasor")
-  {
+
     for(n=0; n<pD->count; n++) {
       if(VarPos[0] <= *px) break;
       px++;
@@ -371,43 +350,7 @@ bool Marker::moveLeftRight(bool left)
       px++;  // one position to the right
     }
     VarPos[0] = *px;
-  }
-  if(diag()->Name == "Waveac")
-  {
-    for(n=0; n < 50*diag()->sc; n++) {
-      x=diag()->wavevalX(n);
-      if(VarPos[0] <= x) break;
-    }
-    if(n == 50*diag()->sc) n--;
 
-    if(left) {
-      if(n <= 0) return false;
-      n--;  // one position to the left
-    }
-    else {
-      if(n >= 50*diag()->sc) return false;
-      n++;  // one position to the right
-    }
-    VarPos[0] = diag()->wavevalX(n);
-  }
-  if(diag()->Name == "Phasor")
-  {
-    for(n=0; n < diag()->nfreqt; n++) {
-      x=diag()->freq[n];
-      if(VarPos[0] == x) break;
-    }
-    if(n == diag()->nfreqt) n = diag()->nfreqt-1;
-
-    if(left) {
-      if(n == 0) return false;
-      n--;  // one position to the left
-    }
-    else {
-      if(n == diag()->nfreqt-1) return false;
-      n++;  // one position to the right
-    }
-    VarPos[0] = diag()->freq[n];
-  }
   createText();
 
   return true;
@@ -751,6 +694,8 @@ QString Marker::unit(double n)
   return value;
 
 }
+
+/* RELATED TO THE PHASOR DIAGRAM CODE
 int Marker::phasormk(double *pz,double *px,int max)
 {
   int m,n,nn,x,y,d,dmin = INT_MAX;
@@ -815,4 +760,4 @@ void Marker::findaxismk()
     }
 
 }
-// vim:ts=8:sw=2:noet
+*/

--- a/qucs/qucs/diagrams/marker.h
+++ b/qucs/qucs/diagrams/marker.h
@@ -41,7 +41,10 @@ public:
 private:
   void    initText(int);
 public:
+  /* RELATED TO THE PHASOR DIAGRAM CODE
   void    fix();
+  int phasormk(double*,double*,int);
+  void findaxismk();*/
   QString unit(double);
   void    createText();
   void    makeInvalid();
@@ -61,8 +64,7 @@ public:
   int precision() const {return Precision;}
   std::vector<double> const& varPos() const {return VarPos;}
   const Diagram *diag() const;
-  int phasormk(double*,double*,int);
-  void findaxismk();
+
 public: // power matching stuff. some sort of VarPos (ab?)use
   double  powFreq() const {return VarPos[0];}
   double  powReal() const {return VarDep[0];}

--- a/qucs/qucs/module.cpp
+++ b/qucs/qucs/module.cpp
@@ -417,8 +417,8 @@ void Module::registerModules (void) {
   REGISTER_DIAGRAM_1 (CurveDiagram);
   REGISTER_DIAGRAM_1 (TimingDiagram);
   REGISTER_DIAGRAM_1 (TruthDiagram);
-  REGISTER_DIAGRAM_1 (PhasorDiagram);
-  REGISTER_DIAGRAM_1 (Waveac);
+//  REGISTER_DIAGRAM_1 (PhasorDiagram);
+//  REGISTER_DIAGRAM_1 (Waveac);
 
   // external simulation
   REGISTER_EXTERNAL_1 (ETR_Sim);

--- a/qucs/qucs/mouseactions.cpp
+++ b/qucs/qucs/mouseactions.cpp
@@ -969,8 +969,8 @@ void MouseActions::MPressSelect(Schematic *Doc, QMouseEvent *Event, float fX, fl
       if(((Diagram*)focusElement)->Name.left(4) != "Rect")
         if(((Diagram*)focusElement)->Name.at(0) != 'T')
           if(((Diagram*)focusElement)->Name != "Curve")
-            if(((Diagram*)focusElement)->Name != "Waveac")
-	      if(((Diagram*)focusElement)->Name != "Phasor")
+           /* if(((Diagram*)focusElement)->Name != "Waveac")
+          if(((Diagram*)focusElement)->Name != "Phasor")*/
             isMoveEqual = true;  // diagram must be square
 
       focusElement->Type = isDiagram;

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -777,8 +777,8 @@ bool Schematic::loadDiagrams(QTextStream *stream, Q3PtrList<Diagram> *List)
     else if(cstr == "<Curve") d = new CurveDiagram();
     else if(cstr == "<Time") d = new TimingDiagram();
     else if(cstr == "<Truth") d = new TruthDiagram();
-    else if(cstr == "<Phasor") d = new PhasorDiagram();
-    else if(cstr == "<Waveac") d = new Waveac();
+    /*else if(cstr == "<Phasor") d = new PhasorDiagram();
+    else if(cstr == "<Waveac") d = new Waveac();*/
     else {
       QMessageBox::critical(0, QObject::tr("Error"),
 		   QObject::tr("Format Error:\nUnknown diagram!"));


### PR DESCRIPTION
The aim of this commit is to lay aside the waveac and phasor diagrams since their current implementation makes much more difficult to merge older PR (specifically #370) and entangles the Qucs code. 

In this sense, "phasordiagram.h/.cpp" and "waveac.h/.cpp" were removed from "CMakeLists.txt" and "Makefile.am". The most relevant code spread over "diagram.cpp/h", "marker.cpp/h", etc. was
commented whereas those portions of code that intrude existing functions were removed.
IMHO, an alternative non-intrusive way will be needed to implement these features in the future.