### PR TITLE
Copy examples to home dir

### DIFF
--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -179,6 +179,7 @@ public slots:
   void slotFileCloseAllRight(); // close all documents to the right of the current one
   void slotFileCloseAll();      //  close all documents
   void slotFileExamples();   // show the examples in a file browser
+  void slotCopyExamples(); //copy Examples in the user workspace
   void slotHelpTutorial();   // Open a pdf tutorial
   void slotHelpReport();   // Open a pdf report
   void slotHelpTechnical();   // Open a pdf technical document
@@ -255,7 +256,7 @@ public:
 
   QAction *fileNew, *fileNewNoDD, *textNew, *fileNewDpl, *fileOpen, *fileSave, *fileSaveAs,
           *fileSaveAll, *fileClose, *fileCloseOthers, *fileCloseAllLeft, *fileCloseAllRight,
-          *fileCloseAll, *fileExamples, *fileSettings, *filePrint, *fileQuit,
+          *fileCloseAll, *fileExamples, *fileSettings, *filePrint, *fileQuit, *copyExamples,
           *projNew, *projOpen, *projDel, *projClose, *applSettings, *refreshSchPath,
           *editCut, *editCopy, *magAll, *magOne, *magMinus, *filePrintFit,
           *symEdit, *intoH, *popH, *simulate, *dpl_sch, *undo, *redo, *dcbias;
@@ -306,6 +307,10 @@ private:
   void updateRecentFilesList(QString s);
   void successExportMessages(bool ok);
   void fillLibrariesTreeView (void);
+
+  int cpDir(const QString &, const QString &);
+  bool rmDir(const QString &);
+
 
 public:
 
@@ -489,3 +494,4 @@ private slots:
 };
 
 #endif /* QUCS_H */
+

--- a/qucs/qucs/qucs_init.cpp
+++ b/qucs/qucs/qucs_init.cpp
@@ -132,6 +132,13 @@ void QucsApp::initActions()
   connect(fileExamples, SIGNAL(triggered()), SLOT(slotFileExamples()));
 
 
+  copyExamples = new QAction(tr("&Copy the examples in the user workspace"), this);
+  copyExamples->setStatusTip(tr("Copy the whole Examples folder in the user workspace"));
+  copyExamples->setWhatsThis(
+            tr("Examples\n\nCopy the whole Examples folder in the user workspace"));
+  connect(copyExamples, SIGNAL(triggered()), SLOT(slotCopyExamples()));
+
+
   symEdit = new QAction(tr("&Edit Circuit Symbol"), this);
   symEdit->setShortcut(Qt::Key_F9);
   symEdit->setStatusTip(tr("Edits the symbol for this schematic"));
@@ -728,6 +735,7 @@ void QucsApp::initMenuBar()
   fileMenu->addAction(filePrintFit);
   fileMenu->addSeparator();
   fileMenu->addAction(fileExamples);
+  fileMenu->addAction(copyExamples);
   fileMenu->addSeparator();
   fileMenu->addAction(fileSettings);
   fileMenu->addAction(symEdit);

--- a/qucs/qucs/schematic.cpp
+++ b/qucs/qucs/schematic.cpp
@@ -2183,4 +2183,3 @@ void Schematic::contentsDragMoveEvent(QDragMoveEvent *Event)
 
   Event->accept();
 }
-

--- a/qucs/qucs/schematic.h
+++ b/qucs/qucs/schematic.h
@@ -40,6 +40,7 @@
 #include <QVector>
 #include <QStringList>
 #include <QFileInfo>
+#include <QMessageBox>
 
 class QTextStream;
 class QTextEdit;

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -347,9 +347,10 @@ int Schematic::saveSymbolJSON()
 int Schematic::saveDocument()
 {
   QFile file(DocName);
+
   if(!file.open(QIODevice::WriteOnly)) {
-    QMessageBox::critical(0, QObject::tr("Error"),
-				QObject::tr("Cannot save document!"));
+    QMessageBox::critical(this, QObject::tr("Error"),
+                                   QObject::tr("Cannot save document!"));
     return -1;
   }
 


### PR DESCRIPTION
Hello,

In this PR it was added a new option ("Copy examples in the user workspace") under the file menu. The reason for this new feature is that the examples are located at /usr/share, which is a read-only directory (so the user cannot run simulations nor save changes).

In addition to this, it was added an extra field to the schematic file format in order to provide a short description while hovering the mouser pointer over the file name in the project tree
![screenshot from 2017-12-31 08-12-40](https://user-images.githubusercontent.com/13180689/34460126-94332bf2-ee06-11e7-9445-63b4383def35.png)

Finally, it was added another file menu option (right-click on the file name) so as to let the user to edit such description
![screenshot from 2017-12-31 08-46-30](https://user-images.githubusercontent.com/13180689/34460148-217887aa-ee07-11e7-8d96-4c8dd7f22960.png)

