### PR TITLE
Show schematic description while hovering the mouser pointer over the file name

### DIFF
--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -153,6 +153,13 @@ QucsSettingsDialog::QucsSettingsDialog(QucsApp *parent)
     appSettingsGrid->addWidget(checkTextAntiAliasing,9,1);
     checkTextAntiAliasing->setChecked(QucsSettings.TextAntiAliasing);
 
+    appSettingsGrid->addWidget(new QLabel(tr("Show schematic description in the project tree")),10,0);
+    checkShowSchematicDescription = new QCheckBox(appSettingsTab);
+    checkShowSchematicDescription->setToolTip(tr("Show schematic description when hovering the mouse over the file"));
+    appSettingsGrid->addWidget(checkShowSchematicDescription,10,1);
+    checkShowSchematicDescription->setChecked(QucsSettings.ShowDescriptionProjectTree);
+
+
     t->addTab(appSettingsTab, tr("Settings"));
 
     // ...........................................................
@@ -631,6 +638,12 @@ void QucsSettingsDialog::slotApply()
       changed = true;
     }
 
+    if (QucsSettings.ShowDescriptionProjectTree != checkShowSchematicDescription->isChecked())
+    {
+      QucsSettings.ShowDescriptionProjectTree = checkShowSchematicDescription->isChecked();
+      changed = true;
+    }
+
     // use toDouble() as it can interpret the string according to the current locale
     if (QucsSettings.largeFontSize != LargeFontSizeEdit->text().toDouble(&ok))
     {
@@ -723,6 +736,7 @@ void QucsSettingsDialog::slotDefaultValues()
     checkLoadFromFutureVersions->setChecked(false);
     checkAntiAliasing->setChecked(false);
     checkTextAntiAliasing->setChecked(true);
+    checkShowSchematicDescription->setChecked(false);
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/dialogs/qucssettingsdialog.h
+++ b/qucs/qucs/dialogs/qucssettingsdialog.h
@@ -79,7 +79,8 @@ public:
 
     QFont Font;
     QCheckBox *checkWiring, *checkLoadFromFutureVersions,
-              *checkAntiAliasing, *checkTextAntiAliasing;
+              *checkAntiAliasing, *checkTextAntiAliasing,
+              *checkShowSchematicDescription;
     QComboBox *LanguageCombo;
     QPushButton *FontButton, *BGColorButton;
     QLineEdit *LargeFontSizeEdit, *undoNumEdit, *editorEdit, *Input_Suffix,

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -184,5 +184,6 @@ QString ProjectView::ReadDescription(QString file)
     } while (!line.isNull());
 
     QucsDocument.close();
+    if (description == "Title") description = "";//Prevent schematics without description from showing "Title" in the tooltip
     return description;
 }

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -107,7 +107,10 @@ ProjectView::refresh()
     extName = QFileInfo(workPath.filePath(fileName)).suffix();
 
     columnData.clear();
-    columnData.append(new QStandardItem(fileName));
+    QStandardItem * d = new QStandardItem(fileName);
+    QString description = ReadDescription(workPath.absoluteFilePath(fileName));
+    d->setToolTip(description);
+    columnData.append(d);
 
     if(extName == "dat") {
       APPEND_CHILD(0, columnData);
@@ -156,4 +159,27 @@ ProjectView::exportSchematic()
     }
   }
   return list;
+}
+
+// This function reads the text inside the <description></description> tags from the given file location
+QString ProjectView::ReadDescription(QString file)
+{
+    QFile QucsDocument(file);
+    if (!QucsDocument.open(QIODevice::ReadOnly)) return "";
+    QTextStream in (&QucsDocument);
+    QString line, description;
+    int index, index2;
+    do {
+        line = in.readLine();
+        index = line.indexOf("FrameText0=");
+        if (index != -1) {
+            index2 = line.indexOf(">", index);
+            index+=11;//Skip FrameText0=
+            description = line.mid(index, index2-index);
+            break;
+        }
+    } while (!line.isNull());
+
+    QucsDocument.close();
+    return description;
 }

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -183,6 +183,7 @@ QString ProjectView::ReadDescription(QString file)
         }
     } while (!line.isNull());
 
+    description.replace("\\n", "<br>");
     QucsDocument.close();
     if (description == "Title") description = "";//Prevent schematics without description from showing "Title" in the tooltip
     return description;

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -108,8 +108,11 @@ ProjectView::refresh()
 
     columnData.clear();
     QStandardItem * d = new QStandardItem(fileName);
-    QString description = ReadDescription(workPath.absoluteFilePath(fileName));
-    d->setToolTip(description);
+    if (QucsSettings.ShowDescriptionProjectTree)
+    {
+       QString description = ReadDescription(workPath.absoluteFilePath(fileName));
+       d->setToolTip(description);
+    }
     columnData.append(d);
 
     if(extName == "dat") {

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -55,6 +55,7 @@ private:
   bool m_valid;
   QString m_projPath;
   QString m_projName;
+  QString ReadDescription(QString);
 };
 
 #endif /* PROJECTVIEW_H_ */

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -26,6 +26,7 @@
 
 #include <QTreeView>
 #include <QString>
+#include "qucs.h"
 
 #define APPEND_ROW(parent, data) \
 ({ \

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2876,6 +2876,8 @@ bool loadSettings()
 
     if(settings.contains("Editor")) QucsSettings.Editor = settings.value("Editor").toString();
 
+    if(settings.contains("ShowDescription")) QucsSettings.ShowDescriptionProjectTree = settings.value("ShowDescription").toBool();
+
     QucsSettings.RecentDocs = settings.value("RecentDocs").toString().split("*",QString::SkipEmptyParts);
     QucsSettings.numRecentDocs = QucsSettings.RecentDocs.count();
 
@@ -2942,6 +2944,7 @@ bool saveApplSettings()
     settings.setValue("GraphAntiAliasing", QucsSettings.GraphAntiAliasing);
     settings.setValue("TextAntiAliasing", QucsSettings.TextAntiAliasing);
     settings.setValue("Editor", QucsSettings.Editor);
+    settings.setValue("ShowDescription", QucsSettings.ShowDescriptionProjectTree);
 
     // Copy the list of directory paths in which Qucs should
     // search for subcircuit schematics from qucsPathList

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -108,6 +108,7 @@ struct tQucsSettings {
   bool IgnoreFutureVersion;
   bool GraphAntiAliasing;
   bool TextAntiAliasing;
+  bool ShowDescriptionProjectTree;
 };
 
 // extern because nearly everywhere used


### PR DESCRIPTION
The aim of this PR is to show a schematic description when the user hovers the mouse pointer over the project tree. In this sense, it was written a function for reading the schematic title from its frame.

Please refer to #763 for context
![screenshot from 2018-01-01 09-41-57](https://user-images.githubusercontent.com/13180689/34466654-7eac3866-eedb-11e7-959b-6737ebff0dc9.png)
