### PR TITLE
Allow navigating directories in the Projects tab

### DIFF
--- a/qucs/qucs/dialogs/packagedialog.cpp
+++ b/qucs/qucs/dialogs/packagedialog.cpp
@@ -99,8 +99,8 @@ PackageDialog::PackageDialog(QWidget *parent_, bool create_)
     connect(ButtCancel, SIGNAL(clicked()), SLOT(reject()));
 
     // ...........................................................
-    // insert all projects
-    QStringList PrDirs = QucsSettings.QucsHomeDir.entryList(QStringList("*"), QDir::Dirs, QDir::Name);
+    // insert all projects in the current directory
+    QStringList PrDirs = QucsSettings.projsDir.entryList(QStringList("*"), QDir::Dirs, QDir::Name);
     QStringList::iterator it;
     for(it = PrDirs.begin(); it != PrDirs.end(); it++)
        if((*it).right(4) == "_prj"){   // project directories end with "_prj"
@@ -292,7 +292,7 @@ void PackageDialog::slotCreate()
     if(p->isChecked()) {
       s = p->text() + "_prj";
       Stream << Q_UINT32(CODE_DIR) << s.toLatin1();
-      s = QucsSettings.QucsHomeDir.absolutePath() + QDir::separator() + s;
+      s = QucsSettings.projsDir.absolutePath() + QDir::separator() + s;
       if(insertDirectory(s, Stream) < 0) {
         PkgFile.close();
         PkgFile.remove();
@@ -358,7 +358,7 @@ void PackageDialog::extractPackage()
   }
   QDataStream Stream(&PkgFile);
 
-  QDir currDir = QucsSettings.QucsHomeDir;
+  QDir currDir = QucsSettings.projsDir;
   QString Version;
   VersionTriplet PackageVersion;
   Q_UINT16 Checksum;

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -23,6 +23,7 @@
 #include <QHash>
 #include <QStack>
 #include <QDir>
+#include <QFileSystemModel>
 
 /**
  * @file qucs.h
@@ -59,7 +60,6 @@ class QTreeWidgetItem;
 class QListWidget;
 class QShortcut;
 class QListView;
-class QFileSystemModel;
 class QModelIndex;
 class QPushButton;
 
@@ -95,8 +95,8 @@ struct tQucsSettings {
   QString DocDir;
 
   unsigned int NodeWiring;
-  QDir QucsWorkDir;
-  QDir QucsHomeDir;
+  QDir QucsWorkDir; // Qucs user directory where user currently works (usually QucsHomeDir or subdir)
+  QDir QucsHomeDir; // Qucs user directory where all projects are located
   QDir AdmsXmlBinDir;  // dir of admsXml executable
   QDir AscoBinDir;     // dir of asco executable
   // QDir OctaveBinDir;   // dir of octave executable
@@ -133,6 +133,13 @@ bool saveApplSettings();
 typedef bool (Schematic::*pToggleFunc) ();
 typedef void (MouseActions::*pMouseFunc) (Schematic*, QMouseEvent*);
 typedef void (MouseActions::*pMouseFunc2) (Schematic*, QMouseEvent*, float, float);
+
+class QucsFileSystemModel : public QFileSystemModel {
+  Q_OBJECT
+public:
+  QucsFileSystemModel(QObject* parent = 0) : QFileSystemModel(parent) {};
+  QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+};
 
 class QucsApp : public QMainWindow {
   Q_OBJECT
@@ -282,7 +289,7 @@ private:
 // ********** Properties ************************************************
   QStack<QString> HierarchyHistory; // keeps track of "go into subcircuit"
   QString  QucsFileFilter;
-  QFileSystemModel *m_homeDirModel;
+  QucsFileSystemModel *m_homeDirModel;
   QFileSystemModel *m_projModel;
   int ccCurIdx; // CompChooser current index (used during search)
 

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -24,6 +24,7 @@
 #include <QStack>
 #include <QDir>
 #include <QFileSystemModel>
+#include <QSortFilterProxyModel>
 
 /**
  * @file qucs.h
@@ -140,6 +141,15 @@ class QucsFileSystemModel : public QFileSystemModel {
 public:
   QucsFileSystemModel(QObject* parent = 0) : QFileSystemModel(parent) {};
   QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
+};
+
+class QucsSortFilterProxyModel : public QSortFilterProxyModel {
+  Q_OBJECT
+
+public:
+  QucsSortFilterProxyModel(QObject *parent = 0) : QSortFilterProxyModel(parent) {};
+protected:
+  bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
 };
 
 class QucsApp : public QMainWindow {
@@ -291,6 +301,7 @@ private:
   QStack<QString> HierarchyHistory; // keeps track of "go into subcircuit"
   QString  QucsFileFilter;
   QucsFileSystemModel *m_homeDirModel;
+  QucsSortFilterProxyModel *m_proxyModel;
   QFileSystemModel *m_projModel;
   int ccCurIdx; // CompChooser current index (used during search)
 

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -96,7 +96,8 @@ struct tQucsSettings {
 
   unsigned int NodeWiring;
   QDir QucsWorkDir; // Qucs user directory where user currently works (usually QucsHomeDir or subdir)
-  QDir QucsHomeDir; // Qucs user directory where all projects are located
+  QDir QucsHomeDir; // Qucs initial user projects directory
+  QDir projsDir; // current user directory where projects are located
   QDir AdmsXmlBinDir;  // dir of admsXml executable
   QDir AscoBinDir;     // dir of asco executable
   // QDir OctaveBinDir;   // dir of octave executable

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -463,6 +463,7 @@ int Schematic::saveDocument()
       qDebug() << "App path : " << qApp->applicationDirPath();
       qDebug() << "workdir"  << workDir;
       qDebug() << "homedir"  << QucsSettings.QucsHomeDir.absolutePath();
+      qDebug() << "projsdir"  << QucsSettings.projsDir.absolutePath();
 
       vaFile = QucsSettings.QucsWorkDir.filePath(fileBase()+".va");
 


### PR DESCRIPTION
As mentioned in #763, I did some small change to allow navigating thru directories in the Projects tab.

![image](https://user-images.githubusercontent.com/9018179/34650243-07740110-f3be-11e7-9f98-82fce634704a.png)

Code seems to be working but is not yet finished:
- currently the QucsHome setting is changed to the current working directory, it will be better to keep it fixed (sort of "Qucs start-up home") and use another variable to keep the current working directory
- in the Projects Tab maybe the normal directories and the projects should be grouped together and not simply mixed in alphabetical order
- etc.
