### PR TITLE
Read-only feature

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1436,7 +1436,7 @@ bool QucsApp::saveFile(QucsDoc *Doc)
     return saveAs();
 
   int Result = Doc->save();
-  if(Result < 0)  return false;
+  if(Result < 0)  return saveAs();
 
   updatePortNumber(Doc, Result);
   slotUpdateTreeview();
@@ -3016,8 +3016,14 @@ Schematic *ContextMenuTabWidget::createEmptySchematic(const QString &name)
 {
   // create a schematic
   QFileInfo Info(name);
+  QString filename = Info.fileName();
   Schematic *d = new Schematic(App, name);
-  int i = addTab(d, QPixmap(":/bitmaps/empty.xpm"), name.isEmpty() ? QObject::tr("untitled") : Info.fileName());
+  if (d->isreadonly())
+   {// If the file is not writable, then add [READ-ONLY] to the tab title.
+    // The document can be edited but not saved.
+       filename += " [READ-ONLY]";
+   }
+  int i = addTab(d, QPixmap(":/bitmaps/empty.xpm"), name.isEmpty() ? QObject::tr("untitled") : filename);
   setCurrentIndex(i);
   return d;
 }
@@ -3026,8 +3032,14 @@ TextDoc *ContextMenuTabWidget::createEmptyTextDoc(const QString &name)
 {
   // create a text document
   QFileInfo Info(name);
+  QString filename = Info.fileName();
   TextDoc *d = new TextDoc(App, name);
-  int i = addTab(d, QPixmap(":/bitmaps/empty.xpm"), name.isEmpty() ? QObject::tr("untitled") : Info.fileName());
+  if (d->isreadonly())
+   {// If the file is not writable, then add [READ-ONLY] to the tab title.
+    // The document can be edited but not saved.
+       filename += " [READ-ONLY]";
+   }
+  int i = addTab(d, QPixmap(":/bitmaps/empty.xpm"), name.isEmpty() ? QObject::tr("untitled") : filename);
   setCurrentIndex(i);
   return d;
 }

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1810,8 +1810,10 @@ void QucsApp::slotChangeView(QWidget *w)
   }
   // for schematic documents
   else {
+    assert(w);
     Schematic *d = (Schematic*)w;
     Doc = (QucsDoc*)d;
+    assert(Doc);
     magAll->setDisabled(false);
     // already in schematic?
     if(cursorLeft->isEnabled()) {
@@ -1910,7 +1912,9 @@ void QucsApp::updatePortNumber(QucsDoc *currDoc, int No)
     if(isTextDocument (w))  continue;
 
     // start from the last to omit re-appended components
+    assert(w);
     Schematic *Doc = (Schematic*)w;
+    assert(Doc);
     for(Component *pc=Doc->Components->last(); pc!=0; ) {
       if(pc->Model == Model) {
         File = pc->Props.getFirst()->Value;
@@ -2005,7 +2009,11 @@ void QucsApp::slotIntoHierarchy()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   Component *pc = Doc->searchSelSubcircuit();
   if(pc == 0) { return; }
 
@@ -2070,7 +2078,9 @@ void QucsApp::slotSimulate()
   QucsDoc *Doc;
   QWidget *w = DocumentTab->currentWidget();
   if(isTextDocument (w)) {
+    assert(w);
     Doc = (QucsDoc*)((TextDoc*)w);
+    assert(Doc);
     if(Doc->SimTime.isEmpty() && ((TextDoc*)Doc)->simulation) {
       DigiSettingsDialog *d = new DigiSettingsDialog((TextDoc*)Doc);
       if(d->exec() == QDialog::Rejected)
@@ -2409,7 +2419,10 @@ void QucsApp::slotSelectSubcircuit(const QModelIndex &idx)
 void QucsApp::slotSelectLibComponent(QTreeWidgetItem *item)
 {
     // get the current document
-    Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+    assert(DocumentTab);
+    QWidget *w = DocumentTab->currentWidget();
+    Schematic *Doc = dynamic_cast<Schematic*>(w);
+    assert(Doc);
 
     // if the current document is a schematic activate the paste
     if(!isTextDocument(Doc))
@@ -2541,6 +2554,7 @@ bool QucsApp::isTextDocument(QWidget *w) {
 // symbol.
 void QucsApp::slotSymbolEdit()
 {
+  assert(DocumentTab);
   QWidget *w = DocumentTab->currentWidget();
 
   // in a text document (e.g. VHDL)
@@ -2560,7 +2574,8 @@ void QucsApp::slotSymbolEdit()
     slotChangePage(TDoc->DocName,TDoc->DataDisplay);
 
     // set 'DataDisplay' document of symbol file to original text file
-    Schematic *SDoc = (Schematic*)DocumentTab->currentWidget();
+    Schematic *SDoc = dynamic_cast<Schematic*>(w);
+    assert(SDoc);
     SDoc->DataDisplay = Info.fileName();
 
     // change into symbol mode
@@ -2574,7 +2589,8 @@ void QucsApp::slotSymbolEdit()
   }
   // in a normal schematic, data display or symbol file
   else {
-    Schematic *SDoc = (Schematic*)w;
+     Schematic *SDoc = dynamic_cast<Schematic*>(w);
+     assert(SDoc);
     // in a symbol file
     if(SDoc->DocName.right(4) == ".sym") {
       slotChangePage(SDoc->DocName, SDoc->DataDisplay);
@@ -2623,7 +2639,12 @@ void QucsApp::slot2PortMatching()
   Marker *pm = (Marker*)view->focusElement;
 
   QString DataSet;
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   int z = pm->pGraph->Var.indexOf(':');
   if(z <= 0)  DataSet = Doc->DataSet;
   else  DataSet = pm->pGraph->Var.mid(z+1);
@@ -2703,7 +2724,13 @@ void QucsApp::slot2PortMatching()
 void QucsApp::slotEditElement()
 {
   if(view->focusMEvent)
-    view->editElement((Schematic*)DocumentTab->currentWidget(), view->focusMEvent);
+  {
+     assert(DocumentTab);
+     QWidget *w = DocumentTab->currentWidget();
+     Schematic * sch = dynamic_cast<Schematic*>(w);
+     assert(sch);
+     view->editElement(sch, view->focusMEvent);
+   }
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -82,7 +82,11 @@ bool QucsApp::performToggleAction(bool on, QAction *Action,
     return false;
   }
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  Schematic * Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   do {
     if(Function) if((Doc->*Function)()) {
       Action->blockSignals(true);
@@ -217,7 +221,11 @@ void QucsApp::slotMoveText(bool on)
 // Is called, when "Zoom in" action is triggered.
 void QucsApp::slotZoomIn(bool on)
 {
-  TextDoc *Doc = (TextDoc*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  TextDoc *Doc = dynamic_cast<TextDoc*>(w);
+  assert(Doc);
+
   if(isTextDocument(Doc)) {
     Doc->zoomBy(1.5f);
     magPlus->blockSignals(true);
@@ -240,6 +248,7 @@ void QucsApp::slotEscape()
 // Is called when the select toolbar button is pressed.
 void QucsApp::slotSelect(bool on)
 {
+  assert(DocumentTab);
   QWidget *w = DocumentTab->currentWidget();
   if(isTextDocument(w)) {
     ((TextDoc*)w)->viewport()->setFocus();
@@ -250,7 +259,9 @@ void QucsApp::slotSelect(bool on)
   }
 
   // goto to insertWire mode if ESC pressed during wiring
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  Schematic * Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(MouseMoveAction == &MouseActions::MMoveWire2) {
     MouseMoveAction = &MouseActions::MMoveWire1;
     MousePressAction = &MouseActions::MPressWire1;
@@ -363,7 +374,11 @@ void QucsApp::slotEditPaste(bool on)
 // -----------------------------------------------------------------------
 void QucsApp::slotInsertEntity ()
 {
-  TextDoc * Doc = (TextDoc *) DocumentTab->currentWidget ();
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  TextDoc * Doc = dynamic_cast<TextDoc*>(w);
+  assert(Doc);
+
   Doc->viewport()->setFocus ();
   //TODO Doc->clearParagraphBackground (Doc->tmpPosX);
   Doc->insertSkeleton ();
@@ -401,7 +416,11 @@ void QucsApp::slotInsertEquation(bool on)
 
   view->selElem = new Equation();
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget *w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(view->drawn) Doc->viewport()->update();
   view->drawn = false;
   MouseMoveAction = &MouseActions::MMoveElement;
@@ -434,7 +453,11 @@ void QucsApp::slotInsertGround(bool on)
 
   view->selElem = new Ground();
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(view->drawn) Doc->viewport()->update();
   view->drawn = false;
   MouseMoveAction = &MouseActions::MMoveElement;
@@ -467,7 +490,11 @@ void QucsApp::slotInsertPort(bool on)
 
   view->selElem = new SubCirPort();
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(view->drawn) Doc->viewport()->update();
   view->drawn = false;
   MouseMoveAction = &MouseActions::MMoveElement;
@@ -478,7 +505,11 @@ void QucsApp::slotInsertPort(bool on)
 // Is called, when "Undo"-Button is pressed.
 void QucsApp::slotEditUndo()
 {
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(isTextDocument(Doc)) {
     ((TextDoc*)Doc)->viewport()->setFocus();
     ((TextDoc*)Doc)->undo();
@@ -496,12 +527,17 @@ void QucsApp::slotEditUndo()
 // Is called, when "Undo"-Button is pressed.
 void QucsApp::slotEditRedo()
 {
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
-  if(isTextDocument(Doc)) {
-    ((TextDoc*)Doc)->viewport()->setFocus();
-    ((TextDoc*)Doc)->redo();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+
+  if(isTextDocument(w)) {
+      ((TextDoc*)w)->viewport()->setFocus();
+      ((TextDoc*)w)->redo();
     return;
   }
+
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
 
   slotHideEdit(); // disable text edit of component property
 
@@ -516,7 +552,11 @@ void QucsApp::slotAlignTop()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(0))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -530,7 +570,11 @@ void QucsApp::slotAlignBottom()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(1))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -544,7 +588,11 @@ void QucsApp::slotAlignLeft()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(2))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -558,7 +606,11 @@ void QucsApp::slotAlignRight()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(3))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -572,7 +624,11 @@ void QucsApp::slotDistribHoriz()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   Doc->distributeHorizontal();
   Doc->viewport()->update();
   view->drawn = false;
@@ -584,7 +640,11 @@ void QucsApp::slotDistribVert()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   Doc->distributeVertical();
   Doc->viewport()->update();
   view->drawn = false;
@@ -596,7 +656,11 @@ void QucsApp::slotCenterHorizontal()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(4))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -610,7 +674,11 @@ void QucsApp::slotCenterVertical()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(!Doc->aligning(5))
     QMessageBox::information(this, tr("Info"),
 		      tr("At least two elements must be selected !"));
@@ -624,7 +692,11 @@ void QucsApp::slotSelectAll()
 {
   slotHideEdit(); // disable text edit of component property
 
-  QWidget *Doc = DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  QWidget *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   if(isTextDocument(Doc)) {
     ((TextDoc*)Doc)->viewport()->setFocus();
     //((TextDoc*)Doc)->selectAll(true);
@@ -643,7 +715,11 @@ void QucsApp::slotSelectMarker()
 {
   slotHideEdit(); // disable text edit of component property
 
-  Schematic *Doc = (Schematic*)DocumentTab->currentWidget();
+  assert(DocumentTab);
+  QWidget* w = DocumentTab->currentWidget();
+  Schematic *Doc = dynamic_cast<Schematic*>(w);
+  assert(Doc);
+
   Doc->selectMarkers();
   Doc->viewport()->update();
   view->drawn = false;

--- a/qucs/qucs/qucsdoc.cpp
+++ b/qucs/qucs/qucsdoc.cpp
@@ -71,3 +71,17 @@ QString QucsDoc::fileBase (void) {
   return fileBase (DocName);
 }
 
+// Returns a boolean flag indicating if the document has write permissions
+bool QucsDoc::isreadonly()
+{
+    if (DocName.isEmpty())
+    {//The file wasn't created yet
+     return false;
+    }
+    else
+    {
+      QFileInfo Info(DocName);
+      if (!Info.exists()) return false;//In case the file doesn't exist, we cannot say that's read-only.
+      return !Info.isWritable();//Unfortunately, !Info.isWritable() is true in that case, so we need to check Info.exists() first
+    }
+}

--- a/qucs/qucs/qucsdoc.h
+++ b/qucs/qucs/qucsdoc.h
@@ -43,6 +43,7 @@ public:
   QString fileSuffix (void);
   static QString fileBase (const QString&);
   QString fileBase (void);
+  bool isreadonly();
 
   QString DocName;
   QString DataSet;     // name of the default dataset


### PR DESCRIPTION
See #763 for more context...

This is a new feature for locking schematics. [Screencast here](https://drive.google.com/open?id=1Lf0BKoLL91MLX2KDdQE2KAxb1aqazTlq)

In the qucsdoc class, it was set two boolean flags: readonly and locked.
The first indicates if the file has read-only permissions whereas the latter is a parameter set by the user from the Qucs GUI. In both cases, the user input should be disabled and I think that the proper way to do that is by locking the viewport() and blocking the editDelete signal.

The lock feature only supports schematic files. The reason for that is that we need to modify (somehow) the document to make the lock property permanent. In this sense, I added a <locked> tag in the <Properties> field schematic file format, but this is **only** included when the schematic is locked. Since the most common case is to work with unlocked schematics, the <locked> tag is not added for them in favor of (some) backwards compatibility.
Obviously, we cannot proceed this way with other type of documents...

![selection_035](https://user-images.githubusercontent.com/13180689/34905457-36702b5c-f859-11e7-8a86-465b525faacd.png)
(I posted a screenshot of my text editor since github seems to have trouble with the tag format...)

Finally, a new button was added to the panel so as to let the user to lock/unlock the schematic.

Hope this helps