### PR TITLE
Update the Project Content view automatically

### DIFF
--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -666,7 +666,6 @@ void QucsSettingsDialog::slotApply()
     if(changed)
     {
         App->readProjects();
-        App->slotUpdateTreeview();
         App->repaint();
     }
 

--- a/qucs/qucs/projectView.cpp
+++ b/qucs/qucs/projectView.cpp
@@ -28,17 +28,20 @@
 #include <QStringList>
 #include <QDir>
 #include <QStandardItemModel>
+#include <QFileSystemWatcher>
 #include <QDebug>
 
 ProjectView::ProjectView(QWidget *parent)
   : QTreeView(parent)
 {
   m_projPath = QString();
-  m_projPath = QString();
+  m_projName = QString();
   m_valid = false;
   m_model = new QStandardItemModel(8, 2, this);
+  watcher = new QFileSystemWatcher(this);
+  connect(watcher, SIGNAL(directoryChanged(const QString&)), SLOT(dirChanged(const QString&)));
 
-  refresh();
+  init();
 
   this->setModel(m_model);
   this->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -47,6 +50,7 @@ ProjectView::ProjectView(QWidget *parent)
 ProjectView::~ProjectView()
 {
   delete m_model;
+  delete watcher;
 }
 
 void
@@ -56,7 +60,11 @@ ProjectView::setProjPath(const QString &path)
   m_valid = !path.isEmpty() && QDir(path).exists();
 
   if (m_valid) {
+    if (!m_projPath.isEmpty()) {
+      watcher->removePath(m_projPath); // stop watching the previous directry
+    }
     m_projPath = path; // full path
+    watcher->addPath(path); // start watching the current directory
     m_projName = QDir(m_projPath).dirName(); // only project directory name
     if (m_projName.endsWith("_prj")) {
       m_projName.chop(4);// remove "_prj" from name
@@ -65,11 +73,17 @@ ProjectView::setProjPath(const QString &path)
     }
   }
   refresh();
+  // expand only the Schematics section, to show all the schematic files
+  for (int i=0; i<m_model->rowCount(); i++) {
+    setExpanded(m_model->index(i, 0), i==6);
+  }
+  // make sure the whole schematics name are shown
+  resizeColumnToContents(0);
 }
 
-// refresh using projectPath
+// initialize the view
 void
-ProjectView::refresh()
+ProjectView::init()
 {
   m_model->clear();
 
@@ -86,18 +100,26 @@ ProjectView::refresh()
   APPEND_ROW(m_model, tr("Schematics")   );
   APPEND_ROW(m_model, tr("Others")       );
 
-  setExpanded(m_model->index(6, 0), true);
-
   if (!m_valid) {
     return;
   }
+}
 
+// refresh the view using the current projectPath
+void
+ProjectView::refresh()
+{
   // put all files into "Content"-ListView
   QDir workPath(m_projPath);
   QStringList files = workPath.entryList(QStringList() << "*", QDir::Files, QDir::Name);
   QStringList::iterator it;
   QString extName, fileName;
   QList<QStandardItem *> columnData;
+
+  for (int i=0; i<m_model->rowCount(); i++) {
+    // delete_childrens
+    m_model->item(i, 0)->removeRows(0, m_model->item(i, 0)->rowCount());
+  }
 
 #define APPEND_CHILD(category, data) \
   m_model->item(category, 0)->appendRow(data);
@@ -162,6 +184,13 @@ ProjectView::exportSchematic()
     }
   }
   return list;
+}
+
+void ProjectView::dirChanged(const QString &path)
+{
+  Q_UNUSED(path);
+  //qDebug() << "watcher:" << path;
+  refresh();
 }
 
 // This function reads the text inside the <description></description> tags from the given file location

--- a/qucs/qucs/projectView.h
+++ b/qucs/qucs/projectView.h
@@ -36,6 +36,7 @@
 })
 
 class QStandardItemModel;
+class QFileSystemWatcher;
 
 class ProjectView : public QTreeView
 {
@@ -48,15 +49,21 @@ public:
 
   //data related
   void setProjPath(const QString &);
+  void init();
   void refresh();
   QStringList exportSchematic();
 private:
   QStandardItemModel *m_model;
+  QFileSystemWatcher *watcher;
 
   bool m_valid;
   QString m_projPath;
   QString m_projName;
+
   QString ReadDescription(QString);
+
+public slots:
+  void dirChanged(const QString&);
 };
 
 #endif /* PROJECTVIEW_H_ */

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1004,8 +1004,6 @@ void QucsApp::slotCMenuCopy()
     // refresh the schematic file path
     this->updateSchNameHash();
     this->updateSpiceNameHash();
-
-    slotUpdateTreeview();
   }
 }
 
@@ -1044,8 +1042,6 @@ void QucsApp::slotCMenuRename()
       QMessageBox::critical(this, tr("Error"), tr("Cannot rename file: %1").arg(filename));
       return;
     }
-
-    slotUpdateTreeview();
   }
 }
 
@@ -1075,8 +1071,6 @@ void QucsApp::slotCMenuDelete()
       return;
     }
   }
-
-  slotUpdateTreeview();
 }
 
 void QucsApp::slotCMenuInsert()
@@ -1439,7 +1433,6 @@ bool QucsApp::saveFile(QucsDoc *Doc)
   if(Result < 0)  return false;
 
   updatePortNumber(Doc, Result);
-  slotUpdateTreeview();
   return true;
 }
 
@@ -1459,9 +1452,6 @@ void QucsApp::slotFileSave()
 
   DocumentTab->blockSignals(false);
   statusBar()->showMessage(tr("Ready."));
-
-  if(!ProjName.isEmpty())
-    slotUpdateTreeview();
 }
 
 // --------------------------------------------------------------
@@ -1544,7 +1534,6 @@ bool QucsApp::saveAs()
   if(n < 0)  return false;
 
   updatePortNumber(Doc, n);
-  slotUpdateTreeview();
   updateRecentFilesList(s);
   return true;
 }
@@ -1568,9 +1557,6 @@ void QucsApp::slotFileSaveAs()
 
   // refresh the schematic file path
   slotRefreshSchPath();
-
-  if(!ProjName.isEmpty())
-    slotUpdateTreeview();
 }
 
 
@@ -1604,7 +1590,6 @@ void QucsApp::slotFileSaveAll()
 
   // refresh the schematic file path
   slotRefreshSchPath();
-  slotUpdateTreeview();
 }
 
 // --------------------------------------------------------------
@@ -2226,7 +2211,6 @@ void QucsApp::slotChangePage(QString& DocName, QString& DataDisplay)
     else {
       if(file.open(QIODevice::ReadWrite)) {  // if document doesn't exist, create
         d->DataDisplay = Info.fileName();
-        slotUpdateTreeview();
       }
       else {
         QMessageBox::critical(this, tr("Error"), tr("Cannot create ")+Name);
@@ -2727,14 +2711,6 @@ void QucsApp::slotHideEdit()
 void QucsApp::slotFileChanged(bool changed)
 {
   DocumentTab->setSaveIcon(changed);
-}
-
-// -----------------------------------------------------------
-// Update project view by call refresh function
-// looses the focus.
-void QucsApp::slotUpdateTreeview()
-{
-  Content->refresh();
 }
 
 // -----------------------------------------------------------

--- a/qucs/qucs/qucs.h
+++ b/qucs/qucs/qucs.h
@@ -216,8 +216,6 @@ public slots:
   void slotCMenuDelete();
   void slotCMenuInsert();
 
-  void slotUpdateTreeview();
-
   void slotMenuProjClose();
 
 private slots:

--- a/qucs/qucs/qucs_actions.cpp
+++ b/qucs/qucs/qucs_actions.cpp
@@ -969,7 +969,6 @@ void QucsApp::slotAddToProject()
   }
 
   free(Buffer);
-  slotUpdateTreeview();
   statusBar()->showMessage(tr("Ready."));
 }
 
@@ -1226,8 +1225,7 @@ void QucsApp::slotImportData()
   }
 
   ImportDialog *d = new ImportDialog(this);
-  if(d->exec() == QDialog::Accepted)
-    slotUpdateTreeview();
+  d->exec();
 }
 
 // -----------------------------------------------------------


### PR DESCRIPTION
The Project Content Tab should always show the actual directory content but this was not always the case since its update was manually triggered.
There were some actions that changed the directory content but did not update the view, e.g.:
- run a simulation
- change the destination Dataset name
- rerun the simulation
- note that the new Dataset does not show up in the Project content

also the view was not updated when copying something into the Project directory outside of Qucs (like a schematic or other files).
Moreover the manual update reinitialized the view completely, forcing to show only the Schematics content even if some other rows were manually expanded previously.

This PR solves the above issues.
