### PR TITLE
Initial condition label updates

### DIFF
--- a/qucs-core/src/components/capacitor.cpp
+++ b/qucs-core/src/components/capacitor.cpp
@@ -25,7 +25,7 @@
 /*!\file capacitor.cpp
    \brief capacitor class implementation
 
-   A capacitor is a passive device that strore electric energy
+   A capacitor is a passive device that stores electric energy
 */
 
 

--- a/qucs/qucs/components/capacitor.cpp
+++ b/qucs/qucs/components/capacitor.cpp
@@ -24,7 +24,7 @@ Capacitor::Capacitor()
 
   Props.append(new Property("C", "1 pF", true,
 		QObject::tr("capacitance in Farad")));
-  Props.append(new Property("V", "", false,
+  Props.append(new Property("Vinit", "", false,
 		QObject::tr("initial voltage for transient simulation")));
   Props.append(new Property("Symbol", "neutral", false,
 	QObject::tr("schematic symbol")+" [neutral, polar]"));

--- a/qucs/qucs/components/inductor.cpp
+++ b/qucs/qucs/components/inductor.cpp
@@ -41,7 +41,7 @@ Inductor::Inductor()
 
   Props.append(new Property("L", "1 nH", true,
 		QObject::tr("inductance in Henry")));
-  Props.append(new Property("I", "", false,
+  Props.append(new Property("Iinit", "", false,
 		QObject::tr("initial current for transient simulation")));
 }
 


### PR DESCRIPTION
This patch appends "init" to the labels of the initial conditions for the capacitor
and inductor.  Also fixed a typo in capacitor class implementation.