### PR TITLE
Fix optimization

### DIFF
--- a/qucs/qucs/components/opt_sim.cpp
+++ b/qucs/qucs/components/opt_sim.cpp
@@ -25,6 +25,13 @@
 #include "qucs.h"
 
 
+// ASCO uses OS-dependent script names
+#ifdef __MINGW32__
+const QString asco_script_filename="general.bat";
+#else
+const QString asco_script_filename="general.sh";
+#endif
+
 Optimize_Sim::Optimize_Sim()
 {
   Description = QObject::tr("Optimization");
@@ -81,22 +88,16 @@ bool Optimize_Sim::createASCOFiles()
   Property* pp;
 
   // create the script used by ASCO to invoke the simulator
-#ifdef __MINGW32__
-  QFile gfile(QucsSettings.QucsHomeDir.filePath("general.bat"));
-#else
-  QFile gfile(QucsSettings.QucsHomeDir.filePath("general.sh"));
-#endif
+  QFile gfile(QucsSettings.QucsHomeDir.filePath(asco_script_filename));
   if(gfile.open(QIODevice::WriteOnly)) {
     QTextStream stream(&gfile);
 #ifdef __MINGW32__
     stream << "@echo off\r\n";
-#else
-    stream << "nice -n 19 ";
-#endif
     stream << "\"" << QDir::toNativeSeparators(QucsSettings.Qucsator) << "\"";
-#ifdef __MINGW32__
     stream << " -i %1.txt -o %2.out > NUL";
 #else
+    stream << "nice -n 19 ";
+    stream << "\"" << QDir::toNativeSeparators(QucsSettings.Qucsator) << "\"";
     stream << " -i $1.txt -o $2.out > /dev/null";
 #endif
     gfile.close();

--- a/qucs/qucs/components/opt_sim.cpp
+++ b/qucs/qucs/components/opt_sim.cpp
@@ -74,11 +74,37 @@ QString Optimize_Sim::netlist()
   return s;
 }
 
- 
+
 // -----------------------------------------------------------
 bool Optimize_Sim::createASCOFiles()
 {
   Property* pp;
+
+  // create the script used by ASCO to invoke the simulator
+#ifdef __MINGW32__
+  QFile gfile(QucsSettings.QucsHomeDir.filePath("general.bat"));
+#else
+  QFile gfile(QucsSettings.QucsHomeDir.filePath("general.sh"));
+#endif
+  if(gfile.open(QIODevice::WriteOnly)) {
+    QTextStream stream(&gfile);
+#ifdef __MINGW32__
+    stream << "@echo off\r\n";
+#else
+    stream << "nice -n 19 ";
+#endif
+    stream << "\"" << QDir::toNativeSeparators(QucsSettings.Qucsator) << "\"";
+#ifdef __MINGW32__
+    stream << " -i %1.txt -o %2.out > NUL";
+#else
+    stream << " -i $1.txt -o $2.out > /dev/null";
+#endif
+    gfile.close();
+    gfile.setPermissions(gfile.permissions() | QFile::ExeUser);
+  } else {
+    return false;
+  }
+
   QFile afile(QucsSettings.QucsHomeDir.filePath("asco_netlist.cfg"));
   if(afile.open(QIODevice::WriteOnly)) {
     QTextStream stream(&afile);

--- a/qucs/qucs/dialogs/simmessage.cpp
+++ b/qucs/qucs/dialogs/simmessage.cpp
@@ -525,9 +525,11 @@ void SimMessage::startSimulator()
       if((SimOpt = findOptimization((Schematic*)DocWidget))) {
 	    ((Optimize_Sim*)SimOpt)->createASCOnetlist();
 
+        // use ASCO "general" mode so the full simulator path can be specified
+        // in the 'general.sh' that it will call
         Program = QucsSettings.AscoBinDir.canonicalPath();
         Program = QDir::toNativeSeparators(Program+"/"+"asco"+QString(executableSuffix));
-        Arguments << "-qucs" << QucsSettings.QucsHomeDir.filePath("asco_netlist.txt")
+        Arguments << "-general" << QucsSettings.QucsHomeDir.filePath("asco_netlist.txt")
                   << "-o" << "asco_out";
       }
       else {


### PR DESCRIPTION
Optimization was no longer working properly after #730, since ASCO expects to find `qucsator` in the path. Besides, optimization never honored the `QUCSATOR` environment variable and always called just `qucsator`.
To fix this, the ASCO "general" optimizer mode is now used, where it actually runs a `general.sh` script, which needs to do the actual simulator invocation. The script is created by Qucs with the correct simulator path and name before running ASCO.

All this works fine in Linux but not on Windows, since there ASCO does not use the right path separator and script extension. I've contacted the ASCO maintainer about this.
If needed, I'll add a patch for ASCO to fix the Windows behaviour in this PR later.
