### PR TITLE
Inhibit Simulation Messages Window

### DIFF
--- a/qucs/qucs/dialogs/settingsdialog.cpp
+++ b/qucs/qucs/dialogs/settingsdialog.cpp
@@ -88,6 +88,9 @@ SettingsDialog::SettingsDialog(Schematic *Doc_)
                                     Tab1);
     gp->addWidget(Check_RunScript,4,0,1,2);
 
+    Check_SimInhibitWindow = new QCheckBox(tr("inhibit sim window"), Tab1);
+    gp->addWidget(Check_SimInhibitWindow,5,0,1,2);
+
     t->addTab(Tab1, tr("Simulation"));
 
     // ...........................................................
@@ -168,6 +171,7 @@ SettingsDialog::SettingsDialog(Schematic *Doc_)
     Input_Script->setText(Doc->Script);
     Check_OpenDpl->setChecked(Doc->SimOpenDpl);
     Check_RunScript->setChecked(Doc->SimRunScript);
+    Check_SimInhibitWindow->setChecked(Doc->SimInhibitWindow);
     Check_GridOn->setChecked(Doc->GridOn);
     Input_GridX->setText(QString::number(Doc->GridX));
     Input_GridY->setText(QString::number(Doc->GridY));
@@ -254,6 +258,12 @@ void SettingsDialog::slotApply()
     if(Doc->SimRunScript != Check_RunScript->isChecked())
     {
         Doc->SimRunScript = Check_RunScript->isChecked();
+        changed = true;
+    }
+
+    if(Doc->SimInhibitWindow != Check_SimInhibitWindow->isChecked())
+    {
+        Doc->SimInhibitWindow = Check_SimInhibitWindow->isChecked();
         changed = true;
     }
 

--- a/qucs/qucs/dialogs/settingsdialog.h
+++ b/qucs/qucs/dialogs/settingsdialog.h
@@ -53,7 +53,7 @@ public:
   QLineEdit *Input_Frame1, *Input_Frame2, *Input_Frame3;
   QLineEdit *Input_DataSet, *Input_DataDisplay, *Input_Script;
   QLineEdit *Input_GridX, *Input_GridY;
-  QCheckBox *Check_OpenDpl, *Check_GridOn, *Check_RunScript;
+  QCheckBox *Check_OpenDpl, *Check_GridOn, *Check_RunScript, *Check_SimInhibitWindow;
 
   QVBoxLayout *all;
   QRegExpValidator *valExpr;

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -2115,8 +2115,8 @@ void QucsApp::slotSimulate()
   connect(sim, SIGNAL(displayDataPage(QString&, QString&)),
 		this, SLOT(slotChangePage(QString&, QString&)));
 
-  sim->show();
-  if(!sim->startProcess()) return;
+  if(!Doc->SimInhibitWindow) sim->show();
+  if(!sim->startProcess()) return;  
 
   // to kill it before qucs ends
   connect(this, SIGNAL(signalKillEmAll()), sim, SLOT(slotClose()));

--- a/qucs/qucs/qucsdoc.cpp
+++ b/qucs/qucs/qucsdoc.cpp
@@ -47,6 +47,7 @@ QucsDoc::QucsDoc(QucsApp *App_, const QString& Name_)
   }
   SimOpenDpl = true;
   SimRunScript = false;
+  SimInhibitWindow = false;
 
   DocChanged = false;
   showBias = -1;  // don't show DC bias (currently for "Schematic" only)

--- a/qucs/qucs/qucsdoc.h
+++ b/qucs/qucs/qucsdoc.h
@@ -56,6 +56,7 @@ public:
   bool DocChanged;
   bool SimOpenDpl;   // open data display after simulation ?
   bool SimRunScript; // run script after simulation ?
+  bool SimInhibitWindow; // inhibit sim window ( a warning msg still appears on status bar if warnings )
   int  showBias;     // -1=no, 0=calculation running, >0=show DC bias points
   bool GridOn;
   int  tmpPosX, tmpPosY;

--- a/qucs/qucs/schematic_file.cpp
+++ b/qucs/qucs/schematic_file.cpp
@@ -375,6 +375,7 @@ int Schematic::saveDocument()
   stream << "  <OpenDisplay=" << SimOpenDpl << ">\n";
   stream << "  <Script=" << Script << ">\n";
   stream << "  <RunScript=" << SimRunScript << ">\n";
+  stream << "  <SimInhibitWindow=" << SimInhibitWindow << ">\n";
   stream << "  <showFrame=" << showFrame << ">\n";
 
   QString t;
@@ -585,6 +586,9 @@ bool Schematic::loadProperties(QTextStream *stream)
     else if(cstr == "RunScript")
 		if(nstr.toInt(&ok) == 0) SimRunScript = false;
 		else SimRunScript = true;
+    else if (cstr == "SimInhibitWindow")
+    if(nstr.toInt(&ok) == 0) SimInhibitWindow = false;
+    else SimInhibitWindow = true;
     else if(cstr == "showFrame")
 		showFrame = nstr.at(0).toLatin1() - '0';
     else if(cstr == "FrameText0") misc::convert2Unicode(Frame_Text0 = nstr);


### PR DESCRIPTION
- per document settings
- a warning message still appears in statusbar if some warnings detected