### PR TITLE
Correct closeAllFiles() return value 

### DIFF
--- a/qucs/qucs/dialogs/qucssettingsdialog.cpp
+++ b/qucs/qucs/dialogs/qucssettingsdialog.cpp
@@ -656,8 +656,9 @@ void QucsSettingsDialog::slotApply()
     // if QucsHome is changed, refresh projects tree
     // do this after updating the other paths
     if (homeDirChanged) {;
-      // files were actuallt closed above, this will refresh the projects tree
+      // files were actually closed above, this will refresh the projects tree
       // and create an empty schematic
+      // (this could likely be simplified once the automatic Project Content Tab refresh is implemented)
       App->slotMenuProjClose();
       changed = true;
     }

--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1687,9 +1687,14 @@ void QucsApp::closeFile(int index)
 /**
  * @brief close all open documents - except a specified one, optionally
  * @param exceptTab tab to leave open, none if not specified
+ *
+ * @return true if all files were succesfully closed
  */
 bool QucsApp::closeAllFiles(int exceptTab)
 {
+  if (DocumentTab->count() == 0) // no open tabs
+    return true;
+
   return closeTabsRange(0, DocumentTab->count()-1, exceptTab);
 }
 
@@ -1698,6 +1703,8 @@ bool QucsApp::closeAllFiles(int exceptTab)
  * @param startTab first tab to be closed
  * @param stoptTab last tab to be closed
  * @param exceptTab tab to leave open, none if not specified
+ *
+ * @return true if all requested tabs were succesfully closed
  */
 bool QucsApp::closeTabsRange(int startTab, int stopTab, int exceptTab)
 {


### PR DESCRIPTION
Fixes #834

A bug was introduced in #708 (62ff9b0f417285a49f4c4dfb0913394d59b8216f) as the `closeAllFiles()` function return value when there were no tabs open was accidentally changed from `true` to `false`.