### PR TITLE
Add manpage for qucspowercombining

### DIFF
--- a/qucs-core/CMakeLists.txt
+++ b/qucs-core/CMakeLists.txt
@@ -97,6 +97,12 @@ SET(PROJECT_COPYRIGHT_YEAR "2013")
 SET(PROJECT_DOMAIN_FIRST "qucs")
 SET(PROJECT_DOMAIN_SECOND "org")
 
+SET(QUCS_URL "https://sf.net/p/qucs")
+SET(QUCS_BUGREPORT "qucs-bugs@lists.sourceforge.net")
+
+configure_file(./doc/qucsconv.1.cmake.in ./doc/qucsconv.1)
+configure_file(./doc/qucsator.1.cmake.in ./doc/qucsator.1)
+
 # use last git commit hash along the version
 set(GIT unknown)
 IF(EXISTS ${CMAKE_SOURCE_DIR}/../.git )

--- a/qucs-core/CMakeLists.txt
+++ b/qucs-core/CMakeLists.txt
@@ -100,8 +100,8 @@ SET(PROJECT_DOMAIN_SECOND "org")
 SET(QUCS_URL "https://sf.net/p/qucs")
 SET(QUCS_BUGREPORT "qucs-bugs@lists.sourceforge.net")
 
-configure_file(./doc/qucsconv.1.cmake.in ./doc/qucsconv.1)
-configure_file(./doc/qucsator.1.cmake.in ./doc/qucsator.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/qucsconv.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/doc/qucsconv.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc/qucsator.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/doc/qucsator.1)
 
 # use last git commit hash along the version
 set(GIT unknown)

--- a/qucs-core/configure.ac
+++ b/qucs-core/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ(2.64)
 dnl Read version from file
 m4_define([QUCS_VERSION], m4_esyscmd([tr -d '\n' < VERSION]))
 
-AC_INIT([qucs-core],[QUCS_VERSION],[qucs-bugs@lists.sourceforge.net])
+AC_INIT([qucsator], [QUCS_VERSION], [qucs-bugs@lists.sourceforge.net], [], [https://sf.net/p/qucs])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([build-aux])
 LT_PREREQ([2.2.2])
@@ -899,6 +899,8 @@ AH_TOP([
 #endif
 ])
 
+
+
 dnl Add here all your Makefiles. These are created by configure.
 AC_CONFIG_FILES([Makefile
 		 qucs_typedefs.h
@@ -913,6 +915,8 @@ AC_CONFIG_FILES([Makefile
 		 src/components/digital/Makefile
 		 src/components/verilog/Makefile
 		 tests/Makefile
+                 doc/qucsator.1
+                 doc/qucsconv.1
 		 ])
 
 

--- a/qucs-core/doc/qucsator.1.cmake.in
+++ b/qucs-core/doc/qucsator.1.cmake.in
@@ -1,0 +1,72 @@
+.TH Qucsator "1" "September 2004" "Debian/GNU Linux" "User Commands"
+.SH NAME
+Qucsator \- An integrated electronic circuit simulator.
+.SH SYNOPSIS
+.B qucsator
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsator\fR, the simulation backend, is a command line circuit
+simulator.  It takes a network list in a certain format as input and
+outputs a Qucs dataset.  It has been programmed for usage in the Qucs
+project but may also be used by other applications.
+
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+display this help and exit
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+display version information and exit
+.TP
+\fB\-i\fR FILENAME
+use file as input netlist (default stdin)
+.TP
+\fB\-o\fR FILENAME
+use file as output dataset (default stdout)
+.TP
+\fB\-b\fR, \fB\-\-bar\fR
+enable textual progress bar
+.TP
+\fB\-g\fR, \fB\-\-gui\fR
+special progress bar used by gui
+.TP
+\fB\-c\fR, \fB\-\-check\fR
+check the input netlist and exit
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2003, 2004, 2005, 2006, 2007 Stefan Jahn <stefan@lkcc.org>
+.br
+Copyright \(co 2006 Helene Parruitte <parruit@enseirb.fr>
+.br
+Copyright \(co 2006 Bastien Roucaries <roucaries.bastien@gmail.com>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH "SEE ALSO"
+The technical documentation for
+.B Qucsator
+is maintained as a LaTeX manual.  The precompiled postscript (or pdf)
+file comes with every new release of the application.  This
+documentation is also online available (as HTML) at
+<http://qucs.sourceforge.net/>.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de>,
+Vincent Habchi, F5RCS <10.50@free.fr>, Helene Parruitte
+<parruit@enseirb.fr>, Bastien Roucaries <roucaries.bastien@gmail.com>
+and Stefan Jahn <stefan@lkcc.org>.

--- a/qucs-core/doc/qucsator.1.in
+++ b/qucs-core/doc/qucsator.1.in
@@ -45,10 +45,10 @@ special progress bar used by gui
 check the input netlist and exit
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2003, 2004, 2005, 2006, 2007 Stefan Jahn <stefan@lkcc.org>
 .br

--- a/qucs-core/doc/qucsconv.1.cmake.in
+++ b/qucs-core/doc/qucsconv.1.cmake.in
@@ -1,0 +1,62 @@
+.TH QucsConverter "1" "June 2006" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsConverter \- Command line tool for data conversion.
+.SH SYNOPSIS
+.B qucsconv
+[\fIOPTION\fR]...
+.SH DESCRIPTION
+
+The \fBQucsConverter\fR is a command line tool for converting
+netlists, data files and schematics from other software into data
+formats used by \fBQucs\fR and its simulation backend.
+
+The software aims to support a variety of data formats and currently
+supports Qucs datasets, SPICE netlists, CITIfiles, Touchstone, ZVR,
+VCD and IC-CAP model files as input data format and CSV files, Qucs
+netlists, libraries and datasets as output data format.
+
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+display this help and exit
+.TP
+\fB\-v\fR, \fB\-\-version\fR
+display version information and exit
+.TP
+\fB\-i\fR FILENAME
+use file as input file (default stdin)
+.TP
+\fB\-o\fR FILENAME
+use file as output file (default stdout)
+.TP
+\fB\-if\fR FORMAT
+input data specification (e.g. \fBtouchstone\fR, \fBciti\fR, \fBqucsdata\fR, \fBspice\fR, \fBzvr\fR, \fBvcd\fR, \fBcsv\fR or \fBmdl\fR)
+.TP
+\fB\-of\fR FORMAT
+output data specification (e.g. \fBmatlab\fR, \fBtouchstone\fR, \fBcsv\fR, \fBqucs\fR, \fBqucsdata\fR or \fBqucslib\fR)
+.TP
+\fB\-a\fR, \fB\-\-noaction\fR
+do not include netlist actions in the output
+.TP
+\fB\-g\fR GNDNODE
+replace ground node
+.TP
+\fB\-d\fR DATANAME
+data variable specification
+.TP
+\fB\-c\fR, \fB\-\-correct\fR
+enable node correction
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2004, 2005, 2006, 2007, 2009 Stefan Jahn <stefan@lkcc.org>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de>,
+Raimund Jacob <raimi@lkcc.org> and Stefan Jahn <stefan@lkcc.org>.

--- a/qucs-core/doc/qucsconv.1.in
+++ b/qucs-core/doc/qucsconv.1.in
@@ -48,10 +48,10 @@ data variable specification
 enable node correction
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2004, 2005, 2006, 2007, 2009 Stefan Jahn <stefan@lkcc.org>
 .PP

--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -6,6 +6,9 @@ cmake_policy(VERSION 2.8)
 file (STRINGS "${qucs-suite_SOURCE_DIR}/VERSION" QUCS_VERSION)
 message(STATUS "Configuring Qucs: VERSION ${QUCS_VERSION}")
 
+SET(QUCS_URL "https://sf.net/p/qucs")
+SET(QUCS_BUGREPORT "qucs-bugs@lists.sourceforge.net")
+
 set(GIT unknown)
 IF(EXISTS ${CMAKE_SOURCE_DIR}/../.git )
   FIND_PACKAGE(Git)
@@ -38,6 +41,22 @@ INCLUDE( ${QT_USE_FILE} )
 
 ADD_DEFINITIONS(${QT_DEFINITIONS} -DQT_DEPRECATED_WARNINGS)
 
+
+
+
+configure_file(./man/qucs.1.cmake.in ./man/qucs.1)
+configure_file(./man/qucsdigi.1.cmake.in ./man/qucsdigi.1)
+configure_file(./man/qucsdigilib.1.cmake.in ./man/qucsdigilib.1)
+configure_file(./man/qucsveri.1.cmake.in ./man/qucsveri.1)
+
+#Tools
+configure_file(./qucs-activefilter/qucsactivefilter.1.cmake.in ./qucs-activefilter/qucsactivefilter.1)
+configure_file(./qucs-filter/qucsfilter.1.cmake.in ./qucs-filter/qucsfilter.1)
+configure_file(./qucs-attenuator/qucsattenuator.1.cmake.in ./qucs-attenuator/qucsattenuator.1)
+configure_file(./qucs-lib/qucslib.1.cmake.in ./qucs-lib/qucslib.1)
+configure_file(./qucs-powercombining/qucspowercombining.1.cmake.in ./qucs-powercombining/qucspowercombining.1)
+configure_file(./qucs-rescodes/qucsrescodes.1.cmake.in ./qucs-rescodes/qucsrescodes.1)
+configure_file(./qucs-transcalc/qucstrans.1.cmake.in ./qucs-transcalc/qucstrans.1)
 
 ADD_SUBDIRECTORY( man )
 ADD_SUBDIRECTORY( qucs )

--- a/qucs/CMakeLists.txt
+++ b/qucs/CMakeLists.txt
@@ -44,19 +44,19 @@ ADD_DEFINITIONS(${QT_DEFINITIONS} -DQT_DEPRECATED_WARNINGS)
 
 
 
-configure_file(./man/qucs.1.cmake.in ./man/qucs.1)
-configure_file(./man/qucsdigi.1.cmake.in ./man/qucsdigi.1)
-configure_file(./man/qucsdigilib.1.cmake.in ./man/qucsdigilib.1)
-configure_file(./man/qucsveri.1.cmake.in ./man/qucsveri.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/man/qucs.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/man/qucs.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/man/qucsdigi.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/man/qucsdigi.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/man/qucsdigilib.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/man/qucsdigilib.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/man/qucsveri.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/man/qucsveri.1)
 
 #Tools
-configure_file(./qucs-activefilter/qucsactivefilter.1.cmake.in ./qucs-activefilter/qucsactivefilter.1)
-configure_file(./qucs-filter/qucsfilter.1.cmake.in ./qucs-filter/qucsfilter.1)
-configure_file(./qucs-attenuator/qucsattenuator.1.cmake.in ./qucs-attenuator/qucsattenuator.1)
-configure_file(./qucs-lib/qucslib.1.cmake.in ./qucs-lib/qucslib.1)
-configure_file(./qucs-powercombining/qucspowercombining.1.cmake.in ./qucs-powercombining/qucspowercombining.1)
-configure_file(./qucs-rescodes/qucsrescodes.1.cmake.in ./qucs-rescodes/qucsrescodes.1)
-configure_file(./qucs-transcalc/qucstrans.1.cmake.in ./qucs-transcalc/qucstrans.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-activefilter/qucsactivefilter.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-activefilter/qucsactivefilter.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-filter/qucsfilter.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-filter/qucsfilter.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-attenuator/qucsattenuator.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-attenuator/qucsattenuator.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-lib/qucslib.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-lib/qucslib.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-powercombining/qucspowercombining.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-powercombining/qucspowercombining.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-rescodes/qucsrescodes.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-rescodes/qucsrescodes.1)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qucs-transcalc/qucstrans.1.cmake.in ${CMAKE_CURRENT_SOURCE_DIR}/qucs-transcalc/qucstrans.1)
 
 ADD_SUBDIRECTORY( man )
 ADD_SUBDIRECTORY( qucs )

--- a/qucs/configure.ac
+++ b/qucs/configure.ac
@@ -6,7 +6,7 @@ AC_PREREQ(2.57)
 dnl Read version from file
 m4_define([QUCS_VERSION], m4_esyscmd([tr -d '\n' < VERSION]))
 
-AC_INIT([qucs], [QUCS_VERSION], [qucs-bugs@lists.sourceforge.net])
+AC_INIT([qucs], [QUCS_VERSION], [qucs-bugs@lists.sourceforge.net], [], [https://sf.net/p/qucs])
 AC_CONFIG_SRCDIR([qucs/qucs.cpp])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_HEADERS([qt_version])
@@ -802,6 +802,9 @@ AH_TOP([
 #endif
 ])
 
+
+
+
 dnl Add here all your Makefiles. These are created by configure.
 AC_CONFIG_FILES([Makefile
     contrib/Makefile
@@ -827,7 +830,18 @@ AC_CONFIG_FILES([Makefile
     qucs/dialogs/Makefile
     qucs/tests/Makefile
     tests/Makefile
-    translations/Makefile])
+    translations/Makefile
+    man/qucs.1
+    man/qucsdigi.1
+    man/qucsdigilib.1
+    man/qucsveri.1
+    qucs-activefilter/qucsactivefilter.1
+    qucs-attenuator/qucsattenuator.1
+    qucs-filter/qucsfilter.1
+    qucs-lib/qucslib.1
+    qucs-rescodes/qucsrescodes.1
+    qucs-transcalc/qucstrans.1
+    qucs-powercombining/qucspowercombining.1])
 
 AC_CONFIG_FILES([qucs/qucs], [chmod +x qucs/qucs])
 

--- a/qucs/man/qucs.1.cmake.in
+++ b/qucs/man/qucs.1.cmake.in
@@ -1,0 +1,37 @@
+.TH Qucs "1" "September 2004" "Debian/GNU Linux" "User Commands"
+.SH NAME
+Qucs \- An integrated electronic circuit simulator.
+.SH SYNOPSIS
+.B qucs
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsator\fR, the simulation backend, is a command line circuit
+simulator.  It takes a network list in a certain format as input and
+outputs a Qucs dataset.  It has been programmed for usage in the Qucs
+project but may also be used by other applications.
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2003, 2004, 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/man/qucs.1.in
+++ b/qucs/man/qucs.1.in
@@ -23,10 +23,10 @@ project but may also be used by other applications.
 
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2003, 2004, 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/man/qucsdigi.1.cmake.in
+++ b/qucs/man/qucsdigi.1.cmake.in
@@ -1,0 +1,58 @@
+.TH QucsDigi "1" "December 2005" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsDigi \- A wrapper script for digital simulations.
+.SH SYNOPSIS
+.B qucsdigi
+[\fIOPTION\fR] \fIinfile\fR \fIoutfile\fR \fItime\fR \fIdir\fR \fIbindir\fR \fIvlibs\fR
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsDigi\fR is a wrapper script for digital simulations performed
+by Qucs.  The program utilizes the \fBFreeHDL\fR compiler in order to
+convert the VHDL output of Qucs into a C++ program.  Thereafter this
+C++ source is compiled and linked to a binary.  This binary is then
+executed and its VCD output file is converted to a Qucs dataset.
+.SH OPTIONS
+.TP
+\fR INFILE
+the filename of the VHDL file to be simulated located in the
+directory specified in \fIDIR\fR
+.TP
+\fR OUTFILE
+the filename of the Qucs dataset file to be produced
+.TP
+\fR TIME
+duration of the digital simulation
+.TP
+\fR DIR
+the name of the directory where the simulation is going to be performed
+.TP
+\fR BINDIR
+the location where the \fIqucsconv\fR program is installed
+.TP
+\fR VLIBS
+a -Wl linker option passing extraneous libraries against which 
+resulting simulation binary is linked
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/man/qucsdigi.1.in
+++ b/qucs/man/qucsdigi.1.in
@@ -44,10 +44,10 @@ a -Wl linker option passing extraneous libraries against which
 resulting simulation binary is linked
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/man/qucsdigilib.1.cmake.in
+++ b/qucs/man/qucsdigilib.1.cmake.in
@@ -1,0 +1,52 @@
+.TH QucsDigiLib "1" "October 2009" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsDigiLib \- A wrapper script for digital modules and libraries.
+.SH SYNOPSIS
+.B qucsdigilib
+[\fIOPTION\fR] \fIinfile\fR \fIdir\fR \fIentity\fR \fIlibrary\fR
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsDigiLib\fR is a wrapper script for digital modules and
+libraries created by Qucs.  The program utilizes the \fBFreeHDL\fR
+compiler in order to convert the VHDL output of Qucs into a C++ file.
+Thereafter this C++ source is compiled to a binary.  The binary is
+then copied into the VHDL directory.
+
+.SH OPTIONS
+.TP
+\fR INFILE
+the filename of the VHDL file to be simulated located in the
+directory specified in \fIDIR\fR
+.TP
+\fR DIR
+the name of the directory where the compilation is going to be performed
+.TP
+\fR ENTITY
+the entity name implemented in the VHDL file
+.TP
+\fR LIBRARY
+library name into which the module will reside
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/man/qucsdigilib.1.in
+++ b/qucs/man/qucsdigilib.1.in
@@ -38,10 +38,10 @@ the entity name implemented in the VHDL file
 library name into which the module will reside
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/man/qucsveri.1.cmake.in
+++ b/qucs/man/qucsveri.1.cmake.in
@@ -1,0 +1,54 @@
+.TH QucsVeri "1" "March 2007" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsVeri \- A wrapper script for digital simulations.
+.SH SYNOPSIS
+.B qucsveri
+[\fIOPTION\fR] \fIinfile\fR \fIoutfile\fR \fItime\fR \fIdir\fR \fIbindir\fR
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsVeri\fR is a wrapper script for digital simulations performed
+by Qucs.  The program utilizes the \fBIcarus Verilog\fR compiler in
+order to convert the Verilog output of Qucs into a \fBiverilog\fR
+program.  This file is then executed using \fBvvp\fR and its VCD
+output file is converted to a Qucs dataset.
+.SH OPTIONS
+.TP
+\fR INFILE
+the filename of the Verilog file to be simulated located in the
+directory specified in \fIDIR\fR
+.TP
+\fR OUTFILE
+the filename of the Qucs dataset file to be produced
+.TP
+\fR TIME
+duration of the digital simulation
+.TP
+\fR DIR
+the name of the directory where the simulation is going to be performed
+.TP
+\fR BINDIR
+the location where the \fIqucsconv\fR program is installed
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2007 Stefan Jahn <stefan@lkcc.org>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/man/qucsveri.1.in
+++ b/qucs/man/qucsveri.1.in
@@ -40,10 +40,10 @@ the name of the directory where the simulation is going to be performed
 the location where the \fIqucsconv\fR program is installed
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2007 Stefan Jahn <stefan@lkcc.org>
 .PP

--- a/qucs/qucs-activefilter/qucsactivefilter.1.cmake.in
+++ b/qucs/qucs-activefilter/qucsactivefilter.1.cmake.in
@@ -1,0 +1,41 @@
+.TH QucsFilter "1" "April 2005" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsFilter \- A filter synthesis application.
+.SH SYNOPSIS
+.B qucsfilter
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you will be
+able to setup a circuit with a graphical user interface (GUI) and
+simulate the large-signal, small-signal and noise behaviour of the
+circuit.  After that simulation has finished you will be able to
+present the simulation results on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsActiveFilter\fR is the active filter synthesis tool used by Qucs.  
+By use of an input dialog the user can create a filter which is then 
+copied into the system-wide clipboard.  In \fBQucs\fR the user opens 
+an empty schematic and presses CTRL-V (paste from clipboard). The filter
+schematic is now inserted and can be simulated.
+
+Available filter types are: Butterworth, Bessel, Chebyshev, Cauer.
+
+Available topologies are: Sallen-Key, Multifeedback and Cauer.
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Vadim Kuznetsov (RA3XDH) <ra3xdh@gmail.com>.

--- a/qucs/qucs-activefilter/qucsactivefilter.1.in
+++ b/qucs/qucs-activefilter/qucsactivefilter.1.in
@@ -28,10 +28,10 @@ Available topologies are: Sallen-Key, Multifeedback and Cauer.
 
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/qucs-attenuator/qucsattenuator.1.cmake.in
+++ b/qucs/qucs-attenuator/qucsattenuator.1.cmake.in
@@ -1,0 +1,41 @@
+.TH QucsAttenuator "1" "July 2006" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsAttenuator \- An attenuator synthesis application.
+.SH SYNOPSIS
+.B qucsattenuator
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you will be
+able to setup a circuit with a graphical user interface (GUI) and
+simulate the large-signal, small-signal and noise behaviour of the
+circuit.  After that simulation has finished you will be able to
+present the simulation results on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsAttenuator\fR is the attenuator synthesis tool used by Qucs.
+By use of an input dialog the user can create an attenuator which is
+then copied into the system-wide clipboard.  In \fBQucs\fR the user
+opens an empty schematic and presses CTRL-V (paste from
+clipboard). The attenuator schematic is now inserted and can be
+simulated.
+
+Available attenuator topologies types are: Tee, Pi and Bridged-Tee.
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2006 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Toyoyuki Ishikawa <toyoishi@gmail.com> and Michael
+Margraf <michael.margraf@alumni.tu-berlin.de>.

--- a/qucs/qucs-attenuator/qucsattenuator.1.in
+++ b/qucs/qucs-attenuator/qucsattenuator.1.in
@@ -27,10 +27,10 @@ Available attenuator topologies types are: Tee, Pi and Bridged-Tee.
 
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2006 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/qucs-filter/qucsfilter.1.cmake.in
+++ b/qucs/qucs-filter/qucsfilter.1.cmake.in
@@ -1,0 +1,40 @@
+.TH QucsFilter "1" "April 2005" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsFilter \- A filter synthesis application.
+.SH SYNOPSIS
+.B qucsfilter
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you will be
+able to setup a circuit with a graphical user interface (GUI) and
+simulate the large-signal, small-signal and noise behaviour of the
+circuit.  After that simulation has finished you will be able to
+present the simulation results on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsFilter\fR is the filter synthesis tool used by Qucs.  By use of
+an input dialog the user can create a filter which is then copied into
+the system-wide clipboard.  In \fBQucs\fR the user opens an empty
+schematic and presses CTRL-V (paste from clipboard). The filter
+schematic is now inserted and can be simulated.
+
+Available filter types are: Butterworth, Bessel, Chebyshev, Cauer.
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Toyoyuki Ishikawa <toyoishi@gmail.com> and Michael
+Margraf <michael.margraf@alumni.tu-berlin.de>.

--- a/qucs/qucs-filter/qucsfilter.1.in
+++ b/qucs/qucs-filter/qucsfilter.1.in
@@ -26,10 +26,10 @@ Available filter types are: Butterworth, Bessel, Chebyshev, Cauer.
 
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP

--- a/qucs/qucs-lib/qucslib.1.cmake.in
+++ b/qucs/qucs-lib/qucslib.1.cmake.in
@@ -1,0 +1,40 @@
+.TH QucsLib "1" "July 2005" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsLib \- A component library manager for Qucs.
+.SH SYNOPSIS
+.B qucslib
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsLib\fR is a program to manage Qucs component libraries. On the
+left side of the application window the available libraries can be
+browsed to find the wanted component.  By clicking on the component
+name its description can be seen on the right side. The selected
+component is transported to the Qucs application by clicking on the
+button "Copy to Clipboard".  Being back in the schematic window the
+component can be inserted by pressing CTRL-V (paste from clipboard).
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/qucs-lib/qucslib.1.in
+++ b/qucs/qucs-lib/qucslib.1.in
@@ -1,8 +1,8 @@
-.TH QucsResCodes "" "April 2012" "Debian/GNU Linux" "User Commands"
+.TH QucsLib "1" "July 2005" "Debian/GNU Linux" "User Commands"
 .SH NAME
-QucsResCodes \- A Standard resistor color code generator for Qucs.
+QucsLib \- A component library manager for Qucs.
 .SH SYNOPSIS
-.B qucsrescodes
+.B qucslib
 [\fIOPTION\fR] ...
 .SH DESCRIPTION
 
@@ -24,27 +24,17 @@ component is transported to the Qucs application by clicking on the
 button "Copy to Clipboard".  Being back in the schematic window the
 component can be inserted by pressing CTRL-V (paste from clipboard).
 
-\fBQucsResCodes\fR is a program to compute color codes for resistors
-and resistance values for color codes. 
-To obtain the color codes, simply enter the 
-resistance and tolerance values and press the "To Colors" button.
-Alternatively to obtain the resistance, 
-select the appropriate color bands and press the "To Resistance" button. 
-The program computes the closest standard 
-resistor value. You can paste the computed resistor 
-in the schematic (by pressing ctrl+v). Have fun! ;)
-
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
-Copyright \(co 2012 M. K. Sudhakar <sudhakar.m.kumar@gmail.com>
+Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
 .PP
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 .SH AUTHORS
-Written by Arun I <theroarofthedragon@gmail.com> and 
-M. K. Sudhakar <sudhakar.m.kumar@gmail.com>
+Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
+Stefan Jahn <stefan@lkcc.org>.

--- a/qucs/qucs-powercombining/CMakeLists.txt
+++ b/qucs/qucs-powercombining/CMakeLists.txt
@@ -100,4 +100,4 @@ INSTALL(TARGETS qucspowercombining
     )
 
 # man pages
-#INSTALL( FILES qucspowercombining.1 DESTINATION share/man/man1 )
+INSTALL( FILES qucspowercombining.1 DESTINATION share/man/man1 )

--- a/qucs/qucs-powercombining/Makefile.am
+++ b/qucs/qucs-powercombining/Makefile.am
@@ -26,6 +26,8 @@ bin_PROGRAMS = qucspowercombining
 MOCHEADERS = qucspowercombiningtool.h
 MOCFILES = $(MOCHEADERS:.h=.moc.cpp)
 
+dist_man_MANS = qucspowercombining.1
+
 include ../common.mk
 
 qucspowercombining_SOURCES = main.cpp qucspowercombiningtool.cpp qrc_qucspowercombining.cpp

--- a/qucs/qucs-powercombining/qucspowercombining.1.cmake.in
+++ b/qucs/qucs-powercombining/qucspowercombining.1.cmake.in
@@ -1,0 +1,51 @@
+.TH QucsPowerCombiningTool "1" "September 2018" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsPowerCombiningTool \- A power combiner synthesis tool.
+.SH SYNOPSIS
+.B qucspowercombining
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsPowerCombiningTool\fR is a synthesis tool focused on the design of power
+combiners/dividers which is integrated into the \fBQucs\fR environment.
+The GUI consists of a dialog which includes the design parameters of the combiner and
+a graphical description of the combiner type in the dialog. After the synthesis is done,
+the schematic is copied into the system-wide clipboard. In order to run a simulation, please create
+a new schematic in \fBQucs\fR and then press CTRL-V (paste from clipboard). The schematic will be
+inserted in \fBQucs\fR and ready for simulation.
+
+The available power combiner types are: 
+Wilkinson,
+Multistage Wilkinson,
+T-junction,
+Branchline,
+Double-box Branchline,
+Bagley,
+Gysel,
+Travelling wave combiner
+and Tree combiner
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+
+.SH COPYRIGHT
+Copyright \(co 2018 Qucs Team
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+

--- a/qucs/qucs-powercombining/qucspowercombining.1.in
+++ b/qucs/qucs-powercombining/qucspowercombining.1.in
@@ -1,0 +1,51 @@
+.TH QucsPowerCombiningTool "1" "September 2018" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsPowerCombiningTool \- A power combiner synthesis tool.
+.SH SYNOPSIS
+.B qucspowercombining
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsPowerCombiningTool\fR is a synthesis tool focused on the design of power
+combiners/dividers which is integrated into the \fBQucs\fR environment.
+The GUI consists of a dialog which includes the design parameters of the combiner and
+a graphical description of the combiner type in the dialog. After the synthesis is done,
+the schematic is copied into the system-wide clipboard. In order to run a simulation, please create
+a new schematic in \fBQucs\fR and then press CTRL-V (paste from clipboard). The schematic will be
+inserted in \fBQucs\fR and ready for simulation.
+
+The available power combiner types are: 
+Wilkinson,
+Multistage Wilkinson,
+T-junction,
+Branchline,
+Double-box Branchline,
+Bagley,
+Gysel,
+Travelling wave combiner
+and Tree combiner
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB@PACKAGE_URL@\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB@PACKAGE_BUGREPORT@\fR
+
+.SH COPYRIGHT
+Copyright \(co 2018 Qucs Team
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+

--- a/qucs/qucs-rescodes/qucsrescodes.1.cmake.in
+++ b/qucs/qucs-rescodes/qucsrescodes.1.cmake.in
@@ -1,0 +1,50 @@
+.TH QucsResCodes "" "April 2012" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsResCodes \- A Standard resistor color code generator for Qucs.
+.SH SYNOPSIS
+.B qucsrescodes
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsLib\fR is a program to manage Qucs component libraries. On the
+left side of the application window the available libraries can be
+browsed to find the wanted component.  By clicking on the component
+name its description can be seen on the right side. The selected
+component is transported to the Qucs application by clicking on the
+button "Copy to Clipboard".  Being back in the schematic window the
+component can be inserted by pressing CTRL-V (paste from clipboard).
+
+\fBQucsResCodes\fR is a program to compute color codes for resistors
+and resistance values for color codes. 
+To obtain the color codes, simply enter the 
+resistance and tolerance values and press the "To Colors" button.
+Alternatively to obtain the resistance, 
+select the appropriate color bands and press the "To Resistance" button. 
+The program computes the closest standard 
+resistor value. You can paste the computed resistor 
+in the schematic (by pressing ctrl+v). Have fun! ;)
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2012 M. K. Sudhakar <sudhakar.m.kumar@gmail.com>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Arun I <theroarofthedragon@gmail.com> and 
+M. K. Sudhakar <sudhakar.m.kumar@gmail.com>

--- a/qucs/qucs-rescodes/qucsrescodes.1.in
+++ b/qucs/qucs-rescodes/qucsrescodes.1.in
@@ -1,8 +1,8 @@
-.TH QucsLib "1" "July 2005" "Debian/GNU Linux" "User Commands"
+.TH QucsResCodes "" "April 2012" "Debian/GNU Linux" "User Commands"
 .SH NAME
-QucsLib \- A component library manager for Qucs.
+QucsResCodes \- A Standard resistor color code generator for Qucs.
 .SH SYNOPSIS
-.B qucslib
+.B qucsrescodes
 [\fIOPTION\fR] ...
 .SH DESCRIPTION
 
@@ -24,17 +24,27 @@ component is transported to the Qucs application by clicking on the
 button "Copy to Clipboard".  Being back in the schematic window the
 component can be inserted by pressing CTRL-V (paste from clipboard).
 
+\fBQucsResCodes\fR is a program to compute color codes for resistors
+and resistance values for color codes. 
+To obtain the color codes, simply enter the 
+resistance and tolerance values and press the "To Colors" button.
+Alternatively to obtain the resistance, 
+select the appropriate color bands and press the "To Resistance" button. 
+The program computes the closest standard 
+resistor value. You can paste the computed resistor 
+in the schematic (by pressing ctrl+v). Have fun! ;)
+
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
-Copyright \(co 2005 Michael Margraf <michael.margraf@alumni.tu-berlin.de>
+Copyright \(co 2012 M. K. Sudhakar <sudhakar.m.kumar@gmail.com>
 .PP
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 .SH AUTHORS
-Written by Michael Margraf <michael.margraf@alumni.tu-berlin.de> and
-Stefan Jahn <stefan@lkcc.org>.
+Written by Arun I <theroarofthedragon@gmail.com> and 
+M. K. Sudhakar <sudhakar.m.kumar@gmail.com>

--- a/qucs/qucs-transcalc/qucstrans.1.cmake.in
+++ b/qucs/qucs-transcalc/qucstrans.1.cmake.in
@@ -1,0 +1,52 @@
+.TH QucsTranscalc "1" "April 2005" "Debian/GNU Linux" "User Commands"
+.SH NAME
+QucsTranscalc \- A transmission line calculator.
+.SH SYNOPSIS
+.B qucstrans
+[\fIOPTION\fR] ...
+.SH DESCRIPTION
+
+\fBQucs\fR is an integrated circuit simulator which means you are able
+to setup a circuit with a graphical user interface (GUI) and simulate
+the large-signal, small-signal and noise behaviour of the circuit.
+After that simulation has finished you can view the simulation results
+on a presentation page or window.
+
+The software aims to support all kinds of circuit simulation types,
+e.g. DC, AC, S-parameter, harmonic balance analysis, noise analysis,
+etc.
+
+\fBQucsTranscalc\fR is the transmission line tool used by Qucs.  The
+application was somewhat inspired by \fBtranscalc\fR by Claudio
+Girardi and Gopal Narayanan.  It is based on transcalc's latest CVS
+version with some minor fixes incorporated.  The GUI has been ported
+from the GIMP toolkit (GTK) to Qt.
+
+It is an analysis and synthesis tool for calculating the electrical
+and physical properties of different kinds of RF and microwave
+transmission lines.
+
+For each type of transmission line, using dialog boxes, the user can
+enter values for the various parameters, and either calculate its
+electrical properties, or use the given electrical requirements to
+synthesize physical parameters of the required transmission line.
+
+Available transmission lines are: Microstrip, Rectangular Waveguide,
+Coaxial Line, Coplanar and Coupled Microstrips.
+
+.SH AVAILABILITY
+The latest version of Qucs can always be obtained from
+\fB${QUCS_URL}\fR
+.SH "REPORTING BUGS"
+Known bugs are documented within the BUGS file.  Report bugs to
+\fB${QUCS_BUGREPORT}\fR
+.SH COPYRIGHT
+Copyright \(co 2005 Stefan Jahn <stefan@lkcc.org>
+.PP
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+.SH AUTHORS
+Written by Gopal Narayanan <gopal@astro.umass.edu>, Claudio Girardi
+<claudio.girardi@ieee.org>, Michael Margraf
+<michael.margraf@alumni.tu-berlin.de> and Stefan Jahn
+<stefan@lkcc.org>.

--- a/qucs/qucs-transcalc/qucstrans.1.in
+++ b/qucs/qucs-transcalc/qucstrans.1.in
@@ -36,10 +36,10 @@ Coaxial Line, Coplanar and Coupled Microstrips.
 
 .SH AVAILABILITY
 The latest version of Qucs can always be obtained from
-\fBwww.sourceforge.net\fR or \fBwww.freshmeat.net\fR
+\fB@PACKAGE_URL@\fR
 .SH "REPORTING BUGS"
 Known bugs are documented within the BUGS file.  Report bugs to
-<qucs-bugs@lists.sourceforge.net>.
+\fB@PACKAGE_BUGREPORT@\fR
 .SH COPYRIGHT
 Copyright \(co 2005 Stefan Jahn <stefan@lkcc.org>
 .PP


### PR DESCRIPTION
As mentioned in #860, the recently added qucspowercombining tool was
missing the man page file. This caused the cmake installation to crash.

Additionally, the content of the "Availabilty" and "Reporting bugs"
sections was put in the following file: /qucs/man/qucs_availability_bugs.1 
