### PR TITLE
Silence warning spam on clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,12 +191,14 @@ script:
       make qucscheck || travis_terminate 1;
     fi
 
-    if [[ $LINUX && $AUTOTOOLS && $CLANG ]]; then
-      ./configure --disable-dependency-tracking --with-gtest=/tmp/gtest --enable-doc || travis_terminate 1;
-      make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-gtest=/tmp/gtest --enable-doc" || travis_terminate 1;
+  # clang 5.0.0 complains a lot about unused command line arguments
+  # set CXXFLAGS also in 'make distcheck' as specifying DISTCHECK_CONFIGURE_FLAGS will retrigger configure
+  - if [[ $LINUX && $AUTOTOOLS && $CLANG ]]; then
+      ./configure CXXFLAGS="-Wno-unused-command-line-argument" --disable-dependency-tracking --with-gtest=/tmp/gtest --enable-doc || travis_terminate 1;
+      make distcheck DISTCHECK_CONFIGURE_FLAGS="CXXFLAGS=-Wno-unused-command-line-argument --with-gtest=/tmp/gtest --enable-doc" || travis_terminate 1;
     fi
 
-   if [[ $LINUX && $AUTOTOOLS && $GCC ]]; then
+  - if [[ $LINUX && $AUTOTOOLS && $GCC ]]; then
       ./configure --disable-dependency-tracking --with-gtest=/tmp/gtest --disable-doc || travis_terminate 1;
       make distcheck DISTCHECK_CONFIGURE_FLAGS="--with-gtest=/tmp/gtest --disable-dependency-tracking --disable-doc" || travis_terminate 1;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,10 @@ before_install:
 install:
   # Setup Linux
   # Set up for Coveralls for GCC (LINUX) only
-  - if [[ $GCC ]]; then pip install --user cpp-coveralls; fi
+  - if [[ $GCC ]]; then pip install --user cpp-coveralls --quiet; fi
 
   # Qucs-Test uses Numpy to compare results
-  - if [[ $LINUX ]]; then pip install --user --only-binary=numpy,matplotlib numpy matplotlib; fi
+  - if [[ $LINUX ]]; then pip install --user --only-binary=numpy,matplotlib numpy matplotlib --quiet; fi
 
   # Setup OSX
   # Installed already: autoconf automake libtool pkg-config
@@ -162,7 +162,7 @@ script:
     fi
 
   # fetch gtest...
-  - wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz -O /tmp/gtest.tar.gz
+  - wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz -O /tmp/gtest.tar.gz --quiet
   - mkdir /tmp/gtest
   - tar --strip-components=1 -C /tmp/gtest -xvf /tmp/gtest.tar.gz
 
@@ -170,7 +170,7 @@ script:
   # Build ADMS from release (avoid need of Perl and its modules)
   #   install locally to avoid using sudo, add local bin/ to PATH so the Qucs configure can find it
   - if [[ $LINUX ]]; then
-      wget http://sourceforge.net/projects/mot-adms/files/adms-source/2.3/adms-2.3.6.tar.gz -O /tmp/adms-2.3.6.tar.gz  || travis_terminate 1;
+      wget http://sourceforge.net/projects/mot-adms/files/adms-source/2.3/adms-2.3.6.tar.gz -O /tmp/adms-2.3.6.tar.gz --quiet || travis_terminate 1;
       tar -xzvf /tmp/adms-2.3.6.tar.gz;
       cd adms-2.3.6 && ./configure --prefix=$HOME && make && make install && cd .. || travis_terminate 1;
       export PATH=$HOME/bin:$PATH;


### PR DESCRIPTION
since this is probably due to the `clang` version used by Travis and maybe to the `ccache` usage, fix it only there for the moment