### PR TITLE
Fix the previous Project navigation modification merge

### DIFF
--- a/qucs/qucs/qucs.cpp
+++ b/qucs/qucs/qucs.cpp
@@ -1226,8 +1226,7 @@ void QucsApp::slotListProjOpen(const QModelIndex &idx)
     // change projects directory to the selected one
     QucsSettings.projsDir = QucsSettings.projsDir.filePath(dName);
     readProjects();
-    slotUpdateTreeview();
-    repaint();
+    //repaint();
   }
 }
 


### PR DESCRIPTION
the call to slotUpdateTreeview() is actually not needed and
this function was removed in commit adcacee97bcebbeba38203555a75bb549a75f9e1.