### PR TITLE
Fix PDF bounding box

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,6 @@ Qucs
 
 * [NEW] Wattmeter probe. [(PR#682)]
   -  Calculate apparent power, real power, reactive power and power factor.
-  -  Internal resistance can be set for the voltage and current ports.update news
 
 * [NEW] Add context menu to document tabs ([PR#708])
 
@@ -546,6 +545,7 @@ Bug fixes
 [PR#252]: https://github.com/Qucs/qucs/pull/252
 [PR#292]: https://github.com/Qucs/qucs/pull/292
 [PR#416]: https://github.com/Qucs/qucs/pull/416
+[PR#682]: https://github.com/Qucs/qucs/pull/682
 [PR#523]: https://github.com/Qucs/qucs/pull/523
 [PR#509]: https://github.com/Qucs/qucs/pull/509
 [PR#412]: https://github.com/Qucs/qucs/pull/412

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ Qucs
 
 * Fix "export as image" with non integer scale factor ([PR#715])
 
+* Fix PDF bounding box when using "File->Export as image..." ([#882])
+
 Qucsator
 --------
 
@@ -501,6 +503,7 @@ Bug fixes
 [#15]: https://github.com/Qucs/qucs/issues/15
 [#311]: https://github.com/Qucs/qucs/issues/311
 [#74]: https://github.com/Qucs/qucs/issues/74
+[#882]: https://github.com/Qucs/qucs/issues/882
 [#112]: https://github.com/Qucs/qucs/issues/112
 [#310]: https://github.com/Qucs/qucs/issues/310
 [#43]: https://github.com/Qucs/qucs/issues/43

--- a/qucs/qucs/imagewriter.cpp
+++ b/qucs/qucs/imagewriter.cpp
@@ -62,7 +62,8 @@ ImageWriter::noGuiPrint(QWidget *doc, QString printFile, QString color)
         svg1->setFileName(printFile);
     }
 
-    svg1->setSize(QSize(1.12*w, h));
+    svg1->setSize(QSize(w, h));
+    svg1->setViewBox(QRectF(0, 0, w,h));
     QPainter *p = new QPainter(svg1);
     p->fillRect(0, 0, svg1->size().width(), svg1->size().height(), Qt::white);
     ViewPainter *vp = new ViewPainter(p);
@@ -75,7 +76,7 @@ ImageWriter::noGuiPrint(QWidget *doc, QString printFile, QString color)
     delete svg1;
 
     if (!printFile.endsWith(".svg")) {
-        QString cmd = "inkscape -z -D --file=";
+        QString cmd = "inkscape -z --file=";
         cmd += tempfile + " ";
 
         if (printFile.endsWith(".eps")) {
@@ -225,8 +226,8 @@ int ImageWriter::print(QWidget *doc)
           svgwriter->setFileName(filename);
         }
 
-        //svgwriter->setSize(QSize(1.12*w,1.1*h));
-        svgwriter->setSize(QSize(1.12*w,h));
+        svgwriter->setSize(QSize(w,h));
+        svgwriter->setViewBox(QRectF(0, 0, w,h));
         QPainter *p = new QPainter(svgwriter);
         p->fillRect(0, 0, svgwriter->size().width(), svgwriter->size().height(), Qt::white);
 
@@ -239,7 +240,7 @@ int ImageWriter::print(QWidget *doc)
         delete svgwriter;
 
         if (dlg->needsInkscape()) {
-            QString cmd = "inkscape -z -D --file=";
+            QString cmd = "inkscape -z --file=";
             cmd += filename+".tmp.svg ";
 
             if (dlg->isPdf_Tex()) {


### PR DESCRIPTION
Fixes #882. 

When creating a PDF file using *File->Export as image...* the resulting PDF size was often not correct.
Now the bouding box is specified in the intermediate `svg` file and not left to `inkscape` to guess/compute.

I've tested it on a few examples and seems to work fine but please double check.