### PR TITLE
Fix wrong calculation of power probes

### DIFF
--- a/qucs-core/src/components/wprobe.cpp
+++ b/qucs-core/src/components/wprobe.cpp
@@ -65,8 +65,8 @@ void wprobe::saveOperatingPoints (void) {
 
 void wprobe::calcOperatingPoints (void) {
 //Reading the current and voltage values to calculate power values
-  nr_double_t VAr = real (getV (NODE_3) * getJ (NODE_1));
-  nr_double_t VAi = -imag (getV (NODE_3) * getJ (NODE_1));
+  nr_double_t VAr = real  ((getV (NODE_3) - getV (NODE_4)) * getJ (NODE_1));
+  nr_double_t VAi = -imag ((getV (NODE_3) - getV (NODE_4)) * getJ (NODE_1));
   setOperatingPoint ("VAr", VAr);
   setOperatingPoint ("VAi", VAi);
 


### PR DESCRIPTION
The power probes implicitely had one of the voltage terminals
connected to ground.