### PR TITLE
Ignore swap files for vi/vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,12 @@ CMakeLists.txt.user
 # dot hash files (write locks)
 .\#*
 
+# vi/vim #
+##########
+# lock files (write locks)
+[._]*.swp
+[._]*.swo
+
 # Qucs user files #
 ###################
 # ignore schematics, data display and data


### PR DESCRIPTION
Just found that `vim` swap files are not ignored...