### PR TITLE
fix pkg include dir on qucsator verilog makefiles.

### DIFF
--- a/qucs-core/src/components/verilog/cpp2lib.makefile
+++ b/qucs-core/src/components/verilog/cpp2lib.makefile
@@ -22,7 +22,7 @@ PROJDIR=
 PREFIX=
 
 # Installed headers path
-INC=$(PREFIX)/include/qucs-core
+INC=$(PREFIX)/include/qucsator
 
 # Link to Qucs library
 LIBS=-lqucsator

--- a/qucs-core/src/components/verilog/va2cpp.makefile
+++ b/qucs-core/src/components/verilog/va2cpp.makefile
@@ -14,7 +14,7 @@ MODEL=
 PREFIX=
 
 # Location of installed Qucs XML files
-INC=$(PREFIX)/include/qucs-core
+INC=$(PREFIX)/include/qucsator
 
 # Locate admsXml, typicaly on the same prefix as Qucs
 ADMSXML=$(PREFIX)/bin/admsXml


### PR DESCRIPTION
The package was renamed from qucs-core to qucsator.
The right thing to go is to configure the makefiles.
For that 2 template files need to be created for CMake.
Maybe another day.

Close #901