### PR TITLE
Fix S11 equation in the attenuator block

### DIFF
--- a/qucs-core/src/components/attenuator.cpp
+++ b/qucs-core/src/components/attenuator.cpp
@@ -40,7 +40,7 @@ void attenuator::initSP (void) {
   nr_double_t a = getPropertyDouble ("L");
   nr_double_t z = getPropertyDouble ("Zref");
   nr_double_t r = (z - z0) / (z + z0);
-  nr_double_t s11 = r * (1 - a) / (a - r * r);
+  nr_double_t s11 = r * (a - 1) / (a - r * r);
   nr_double_t s21 = std::sqrt (a) * (1 - r * r) / (a - r * r);
   setS (NODE_1, NODE_1, s11);
   setS (NODE_2, NODE_2, s11);


### PR DESCRIPTION
As pointed out by @in3otd [1], there was a bug in the S11 equation of the attenuator component. It didn't match the docs. See [2] Eq. 9.76. This caused that the attenuator didn't work as expected if Z0 != 50Ohm

I think this fix should be included in the new release, so I targeted this to hotfix-0.0.20.

Before:
![Selection_010](https://user-images.githubusercontent.com/13180689/58042269-828b5600-7b3a-11e9-9d83-b4ce5608363d.png)

After:
![Selection_011](https://user-images.githubusercontent.com/13180689/58042292-93d46280-7b3a-11e9-8886-f4375c39edf7.png)

https://gist.github.com/andresmmera/a4dacd0f3a698b7c75dcac15e6296b03

[1] https://sourceforge.net/p/qucs/mailman/message/36663139/
[2] http://qucs.sourceforge.net/tech/node51.html