### PR TITLE
Fix Graph loading when Dataset names contain spaces (-> develop)

### DIFF
--- a/qucs/qucs/diagrams/graph.cpp
+++ b/qucs/qucs/diagrams/graph.cpp
@@ -139,6 +139,9 @@ bool Graph::load(const QString& _s)
   s = s.mid(1, s.length()-2);   // cut off start and end character
 
   Var = s.section('"',1,1);  // Var
+  // Var can include a Dataset name, which can contain spaces
+  // remove the Var string so subsequent parsing of the other fields does not fail in this case
+  s = s.section('"', 2); // keep everything after the closing quotes
 
   QString n;
   n  = s.section(' ',1,1);    // Color


### PR DESCRIPTION
Fix #929. Works for me. Please check.

If a Diagram contained a Graph which referenced a variable in a Dataset with a name containing spaces, the Graph loading failed as the simple parsing code was confused by the spaces in the Dataset name.

(supersedes #930)