### PR TITLE
[Not yet finished] Fix wattmeter probe

### DIFF
--- a/qucs-core/src/components/wprobe.cpp
+++ b/qucs-core/src/components/wprobe.cpp
@@ -71,8 +71,6 @@ void wprobe::saveOperatingPoints (void) {
   nr_double_t Q = imag (Sw);
   setOperatingPoint ("P", P);
   setOperatingPoint ("Q", Q);
-//Power Factor calculation
-  setOperatingPoint ("PF", P/std::sqrt(P*P+Q*Q));
 }
 
 void wprobe::initTR (void) {

--- a/qucs-core/src/components/wprobe.cpp
+++ b/qucs-core/src/components/wprobe.cpp
@@ -39,14 +39,16 @@ wprobe::wprobe () : circuit (4) {
   setVoltageSources (1);
 }
 
-//NODE 1 --> I+
-//NODE 2 --> I-
-//NODE 3 --> V+
-//NODE 4 --> V-
+// voltmeter nodes must be at nodes 1 and 2 as so it's assumed
+//   in saveNoiseResults() for noise calculations
+//NODE 1 --> V+
+//NODE 2 --> V-
+//NODE 3 --> I+
+//NODE 4 --> I-
 
 void wprobe::initDC (void) {
   allocMatrixMNA ();
-  voltageSource (VSRC_1, NODE_1, NODE_2);
+  voltageSource (VSRC_1, NODE_3, NODE_4);
 }
 
 void wprobe::initAC (void) {
@@ -54,8 +56,9 @@ void wprobe::initAC (void) {
 }
 
 void wprobe::saveOperatingPoints (void) {
-  nr_double_t Vr = real (getV (NODE_3) - getV (NODE_4));
-  nr_double_t Vi = imag (getV (NODE_3) - getV (NODE_4));
+  nr_double_t Vr = real (getV (NODE_1) - getV (NODE_2));
+  nr_double_t Vi = imag (getV (NODE_1) - getV (NODE_2));
+  // operating points as for the vprobe
   setOperatingPoint ("Vr", Vr);
   setOperatingPoint ("Vi", Vi); //This section works just like a voltmeter
 }
@@ -65,7 +68,7 @@ void wprobe::saveOperatingPoints (void) {
 
 void wprobe::calcOperatingPoints (void) {
 //Reading the current and voltage values to calculate power values
-  nr_complex_t Vw = getV (NODE_3) - getV (NODE_4);
+  nr_complex_t Vw = getV (NODE_1) - getV (NODE_2);
   nr_complex_t Iw = getJ (VSRC_1);
   nr_complex_t Sw = Vw * conj (Iw);
   nr_double_t VAr = real (Sw);

--- a/qucs-core/src/components/wprobe.cpp
+++ b/qucs-core/src/components/wprobe.cpp
@@ -65,8 +65,11 @@ void wprobe::saveOperatingPoints (void) {
 
 void wprobe::calcOperatingPoints (void) {
 //Reading the current and voltage values to calculate power values
-  nr_double_t VAr = real  ((getV (NODE_3) - getV (NODE_4)) * getJ (NODE_1));
-  nr_double_t VAi = -imag ((getV (NODE_3) - getV (NODE_4)) * getJ (NODE_1));
+  nr_complex_t Vw = getV (NODE_3) - getV (NODE_4);
+  nr_complex_t Iw = getJ (VSRC_1);
+  nr_complex_t Sw = Vw * conj (Iw);
+  nr_double_t VAr = real (Sw);
+  nr_double_t VAi = imag (Sw);
   setOperatingPoint ("VAr", VAr);
   setOperatingPoint ("VAi", VAi);
 

--- a/qucs-core/src/components/wprobe.cpp
+++ b/qucs-core/src/components/wprobe.cpp
@@ -60,29 +60,19 @@ void wprobe::saveOperatingPoints (void) {
   nr_double_t Vi = imag (getV (NODE_1) - getV (NODE_2));
   // operating points as for the vprobe
   setOperatingPoint ("Vr", Vr);
-  setOperatingPoint ("Vi", Vi); //This section works just like a voltmeter
-}
+  setOperatingPoint ("Vi", Vi);
 
-//For specific information regarding The Power triangle and Power factor:
-//https://en.wikipedia.org/wiki/Power_factor#Definition_and_calculation
-
-void wprobe::calcOperatingPoints (void) {
-//Reading the current and voltage values to calculate power values
+  // read current and voltage values to calculate power values
   nr_complex_t Vw = getV (NODE_1) - getV (NODE_2);
   nr_complex_t Iw = getJ (VSRC_1);
   nr_complex_t Sw = Vw * conj (Iw);
-  nr_double_t VAr = real (Sw);
-  nr_double_t VAi = imag (Sw);
-  setOperatingPoint ("VAr", VAr);
-  setOperatingPoint ("VAi", VAi);
-
-  nr_double_t P = VAr;
+  // save P and Q instead of just S since operating points cannot hold complex values
+  nr_double_t P = real (Sw);
+  nr_double_t Q = imag (Sw);
   setOperatingPoint ("P", P);
-
-  nr_double_t Q = VAi;
   setOperatingPoint ("Q", Q);
 //Power Factor calculation
-  setOperatingPoint ("PF", P/std::sqrt(P*P+VAi*VAi));
+  setOperatingPoint ("PF", P/std::sqrt(P*P+Q*Q));
 }
 
 void wprobe::initTR (void) {

--- a/qucs-core/src/components/wprobe.h
+++ b/qucs-core/src/components/wprobe.h
@@ -34,7 +34,6 @@ class wprobe : public qucs::circuit
   void initAC (void);
   void initTR (void);
   void saveOperatingPoints (void);
-  void calcOperatingPoints (void);
 };
 
 #endif /* __WPROBE_H__ */

--- a/qucs-core/src/nasolver.cpp
+++ b/qucs-core/src/nasolver.cpp
@@ -1369,28 +1369,26 @@ void nasolver<nr_type_t>::saveResults (const std::string &volts, const std::stri
             saveVariable (n, nr_complex_t (c->getOperatingPoint ("Vr"),
             c->getOperatingPoint ("Vi")), f);
 
-	    //add watt probe data
+            // add watt probe data
             // this is a big hack due to (ab)using the operating points
-	    for (auto ops: c->getOperatingPoints ())
-            {
-		//It will only get values if none of the strings are 0
-		//Once again most of this is adapted from Vprobe and Iprobe
-                operatingpoint &p = ops.second;
-	        if (strcmp(p.getName(), "Vi") == 0) continue;
-                if (strcmp(p.getName(), "VAi") == 0) continue;
-	        if (strcmp(p.getName(), "Vr") == 0) continue;
-		if (strcmp(p.getName(), "VAr") == 0)
-		{
-              	    std::string n = createOP(c->getName(), "S");
-              	    saveVariable (n, nr_complex_t (c->getOperatingPoint ("VAr"),
-                    c->getOperatingPoint ("VAi")), f);
-		   continue;
-		}
-           	
-           	std::string n = createOP(c->getName(), p.getName());
-           	saveVariable(n, p.getValue(), f);
-       	    }	    
-	    	    
+            // for specific information regarding The Power triangle and Power factor:
+            //    https://en.wikipedia.org/wiki/Power_factor#Definition_and_calculation
+            if (c->hasOperatingPoint("P") && c->hasOperatingPoint("Q")) {
+                nr_double_t P = c->getOperatingPoint ("P");
+                nr_double_t Q = c->getOperatingPoint ("Q");
+                // save complex power
+                std::string n = createOP(c->getName(), "S");
+                saveVariable (n, nr_complex_t (P, Q), f);
+                // save active power
+                n = createOP(c->getName(), "P");
+                saveVariable(n, P, f);
+                // save reactive power
+                n = createOP(c->getName(), "Q");
+                saveVariable(n, Q, f);
+                // save power factor
+                n = createOP(c->getName(), "PF");
+                saveVariable(n, P / std::sqrt(P*P + Q*Q), f);
+            }
         }
     }
 

--- a/qucs-core/src/nasolver.cpp
+++ b/qucs-core/src/nasolver.cpp
@@ -1355,8 +1355,14 @@ void nasolver<nr_type_t>::saveResults (const std::string &volts, const std::stri
         circuit * root = subnet->getRoot ();
         for (circuit * c = root; c != NULL; c = (circuit *) c->getNext ())
         {
+            // FIXME: operating points are (ab)used in probes to hold probes data
+            //   should be handled differently
+            // skip if not a probe
             if (!c->isProbe ()) continue;
+            // skip if saving subcircuit components data is not requested
             if (!c->getSubcircuit().empty() && !(saveOPs & SAVE_ALL)) continue;
+            // update probe internal values, if it's not a noise simulation
+            //   values for noise simulation are in acsolver::saveNoiseResults()
             if (volts != "vn")
                 c->saveOperatingPoints ();
 	    std::string n = createOP (c->getName (), volts);
@@ -1364,7 +1370,7 @@ void nasolver<nr_type_t>::saveResults (const std::string &volts, const std::stri
             c->getOperatingPoint ("Vi")), f);
 
 	    //add watt probe data
-	    c->calcOperatingPoints ();
+            // this is a big hack due to (ab)using the operating points
 	    for (auto ops: c->getOperatingPoints ())
             {
 		//It will only get values if none of the strings are 0

--- a/qucs/qucs/components/wprobe.cpp
+++ b/qucs/qucs/components/wprobe.cpp
@@ -51,15 +51,15 @@ wProbe::wProbe()
   Lines.append(new Line(-15,  8, -9,  8,QPen(Qt::red,2)));
   Lines.append(new Line(  9,  8, 15,  8,QPen(Qt::darkBlue,2)));
 
-//Current Entries
-  Ports.append(new Port(-30,  0));
-  Ports.append(new Port( 30,  0));
-
 //Voltage Entries
   Lines.append(new Line(-10,  14,-10, 20,QPen(Qt::darkBlue,2)));
   Lines.append(new Line( 10,  14, 10, 20,QPen(Qt::darkBlue,2)));
   Ports.append(new Port(-10, 20));
   Ports.append(new Port( 10, 20));
+
+//Current Entries
+  Ports.append(new Port(-30,  0));
+  Ports.append(new Port( 30,  0));
 
 //Letter V
   Lines.append(new Line(-3,  7 ,0,  13,QPen(Qt::darkBlue,2)));


### PR DESCRIPTION
Fix Qucs/qucsator#47 .

There where two main issues:
- the formula used for computing the complex power was wrong:
  this was easy, just use the correct formula for the power
- the voltage noise values from were wrong:
  this required changing the nodes order for the component in the netlist: the probes are a bit of a hack and currently require the voltage sensing to be on the first two nodes, while the wattmeter had the current sensing there.

I also couldn't resist changing a little the probe values output handling to make it feel a little less "hackish" (IMHO).

This goes together with the `qucs-test` update at Qucs/qucs-test#35 .