### PR TITLE
Fix #949

### DIFF
--- a/qucs/qucs/textdoc.cpp
+++ b/qucs/qucs/textdoc.cpp
@@ -42,6 +42,7 @@ Copyright (C) 2014 by Guilherme Brondani Torri <guitorri@gmail.com>
  */
 TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDoc(App_, Name_)
 {
+  App = App_;
   TextFont = QFont("Courier New");
   TextFont.setPointSize(QucsSettings.font.pointSize()-1);
   TextFont.setStyleHint(QFont::Courier);
@@ -89,6 +90,11 @@ TextDoc::TextDoc(QucsApp *App_, const QString& Name_) : QPlainTextEdit(), QucsDo
  */
 TextDoc::~TextDoc()
 {
+  // closing the doc may trigger a signalFileChanged which in turn will run QucsApp::slotFileChanged(), which
+  // if text document Tab is removed first, DocumentTab->currentIndex() will point to the previous tab and
+  // setSaveIcon() (called by slotFileChanged() ) will wrongly change that tab icon
+
+  disconnect(this, SIGNAL(signalFileChanged(bool)), App, SLOT(slotFileChanged(bool)));
   delete syntaxHighlight;
 }
 

--- a/qucs/qucs/textdoc.h
+++ b/qucs/qucs/textdoc.h
@@ -99,6 +99,7 @@ public slots:
 
 private:
   SyntaxHighlighter * syntaxHighlight;
+  QucsApp *App;
 
 private slots:
   void highlightCurrentLine();


### PR DESCRIPTION
Fix #949.
For some reason, closing an unmodified text document may trigger a `signalFileChanged()` (via the syntax highlighter) which in turn will run `QucsApp::slotFileChanged()`, which,  if the text document Tab happened to be already removed, will cause `DocumentTab->currentIndex()` to point to the previous tab and `setSaveIcon()`, called by `slotFileChanged()` will wrongly change that tab icon instead of the (no longer present) text document tab icon.
So here I just disconnect `signalFileChanged()` before deleting the syntax highlighter of the text document.