### PR TITLE
qucs#992 corrections in NMOSFETs PMOSFETs Transistors Z-Diodes libs

### DIFF
--- a/qucs/qucs-lib/library/NMOSFETs.lib
+++ b/qucs/qucs-lib/library/NMOSFETs.lib
@@ -4053,73 +4053,75 @@
   </Model>
 </Component>
 
-<Component IRF3709ZCS_L>
-  <Description>
-   Enhancement n-channel power MOSFET
-   30 V, 87 A, 6.3 mOhm, package: D2-Pak
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:NMOSFETs_IRF3709ZCS_L _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.31318" Lambda="0" Kp="226.971" Cgso="1.95329e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.31318 LAMBDA=0 KP=226.971 CGSO=1.95329E-05 CGDO=1E-11) 
-    R:RS _net8 _net3 R="0.00411316"
-    Diode:D1 _net1 _net3 Is="1.99276e-10" Rs="0.0029252" N="1.17266" Bv="30" Ibv="0.00025" Eg="1.2" Xti="3.10172" Tt="1e-07" Cj0="9.86355e-10" Vj="0.5" M="0.403132" Fc="0.5"
-    # .MODEL:MD  D (IS=1.99276E-10 RS=0.0029252 N=1.17266 BV=30 IBV=0.00025 EG=1.2 XTI=3.10172 TT=1E-07 CJO=9.86355E-10 VJ=0.5 M=0.403132 FC=0.5) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="1.48797"
-    Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="2.98433e-10" Vj="20.8385" M="0.560566" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.98433E-10 VJ=20.8385 M=0.560566 FC=1E-08) 
-    Diode:D3 _net5 gnd Is="1e-10" N="0.401511" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=0.401511 RS=3E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="1.03807e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 _net6 gnd Is="1e-10" N="0.401511" M="0.5" Cj0="1e-14" Vj="0.7"
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (20.8385) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF3709ZCS_L>
+#   <Description>
+#    Enhancement n-channel power MOSFET
+#    30 V, 87 A, 6.3 mOhm, package: D2-Pak
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:NMOSFETs_IRF3709ZCS_L _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.31318" Lambda="0" Kp="226.971" Cgso="1.95329e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.31318 LAMBDA=0 KP=226.971 CGSO=1.95329E-05 CGDO=1E-11) 
+#     R:RS _net8 _net3 R="0.00411316"
+#     Diode:D1 _net1 _net3 Is="1.99276e-10" Rs="0.0029252" N="1.17266" Bv="30" Ibv="0.00025" Eg="1.2" Xti="3.10172" Tt="1e-07" Cj0="9.86355e-10" Vj="0.5" M="0.403132" Fc="0.5"
+#     # .MODEL:MD  D (IS=1.99276E-10 RS=0.0029252 N=1.17266 BV=30 IBV=0.00025 EG=1.2 XTI=3.10172 TT=1E-07 CJO=9.86355E-10 VJ=0.5 M=0.403132 FC=0.5) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="1.48797"
+#     Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="2.98433e-10" Vj="20.8385" M="0.560566" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.98433E-10 VJ=20.8385 M=0.560566 FC=1E-08) 
+#     Diode:D3 _net5 gnd Is="1e-10" N="0.401511" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=0.401511 RS=3E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="1.03807e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 _net6 gnd Is="1e-10" N="0.401511" M="0.5" Cj0="1e-14" Vj="0.7"
+#   .Def:End
+#   </Model>
+# </Component>
 
-<Component IRF3709Z_S_L>
-  <Description>
-   Enhancement n-channel power MOSFET
-   30 V, 87 A, 6.3 mOhm, package: TO-220AB
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:NMOSFETs_IRF3709Z_S_L _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.31318" Lambda="0" Kp="226.971" Cgso="1.95329e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.31318 LAMBDA=0 KP=226.971 CGSO=1.95329E-05 CGDO=1E-11) 
-    R:RS _net8 _net3 R="0.00411316"
-    Diode:D1 _net1 _net3 Is="1.99276e-10" Rs="0.0029252" N="1.17266" Bv="30" Ibv="0.00025" Eg="1.2" Xti="3.10172" Tt="1e-07" Cj0="9.86355e-10" Vj="0.5" M="0.403132" Fc="0.5"
-    # .MODEL:MD  D (IS=1.99276E-10 RS=0.0029252 N=1.17266 BV=30 IBV=0.00025 EG=1.2 XTI=3.10172 TT=1E-07 CJO=9.86355E-10 VJ=0.5 M=0.403132 FC=0.5) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="1.48797"
-    Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="2.98433e-10" Vj="20.8385" M="0.560566" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.98433E-10 VJ=20.8385 M=0.560566 FC=1E-08) 
-    Diode:D3 _net5 gnd Is="1e-10" N="0.401511" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=0.401511 RS=3E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="1.03807e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 _net6 gnd Is="1e-10" N="0.401511" M="0.5" Cj0="1e-14" Vj="0.7"
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (20.8385) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF3709Z_S_L>
+#   <Description>
+#    Enhancement n-channel power MOSFET
+#    30 V, 87 A, 6.3 mOhm, package: TO-220AB
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:NMOSFETs_IRF3709Z_S_L _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.31318" Lambda="0" Kp="226.971" Cgso="1.95329e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.31318 LAMBDA=0 KP=226.971 CGSO=1.95329E-05 CGDO=1E-11) 
+#     R:RS _net8 _net3 R="0.00411316"
+#     Diode:D1 _net1 _net3 Is="1.99276e-10" Rs="0.0029252" N="1.17266" Bv="30" Ibv="0.00025" Eg="1.2" Xti="3.10172" Tt="1e-07" Cj0="9.86355e-10" Vj="0.5" M="0.403132" Fc="0.5"
+#     # .MODEL:MD  D (IS=1.99276E-10 RS=0.0029252 N=1.17266 BV=30 IBV=0.00025 EG=1.2 XTI=3.10172 TT=1E-07 CJO=9.86355E-10 VJ=0.5 M=0.403132 FC=0.5) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="1.48797"
+#     Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="2.98433e-10" Vj="20.8385" M="0.560566" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.98433E-10 VJ=20.8385 M=0.560566 FC=1E-08) 
+#     Diode:D3 _net5 gnd Is="1e-10" N="0.401511" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=0.401511 RS=3E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="1.03807e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 _net6 gnd Is="1e-10" N="0.401511" M="0.5" Cj0="1e-14" Vj="0.7"
+#   .Def:End
+#   </Model>
+# </Component>
 
 <Component IRF3710>
   <Description>
@@ -4292,39 +4294,40 @@
   </Model>
 </Component>
 
-<Component IRF3805S-7P>
-  <Description>
-   Enhancement n-channel power MOSFET
-   55 V, 240 A, 2.6 mOhm, package: D2-Pak 7-Lead
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:NMOSFETs_IRF3805S_7P _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="4.70867" Lambda="0.00392471" Kp="395.548" Cgso="7.19597e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=4.70867 LAMBDA=0.00392471 KP=395.548 CGSO=7.19597E-05 CGDO=1E-11) 
-    R:RS _net8 _net3 R="0.00141032"
-    Diode:D1 _net1 _net3 Is="1.24924e-12" Rs="0.000669634" N="0.934129" Bv="55" Ibv="0.00025" Eg="1" Xti="1" Tt="1e-07" Cj0="2.67174e-09" Vj="3.68287" M="0.695013" Fc="0.404527"
-    # .MODEL:MD  D (IS=1.24924E-12 RS=0.000669634 N=0.934129 BV=55 IBV=0.00025 EG=1 XTI=1 TT=1E-07 CJO=2.67174E-09 VJ=3.68287 M=0.695013 FC=0.404527) 
-    R:RDS _net3 _net1 R="1e+07"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="6"
-    Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="1.42784e-09" Vj="17.0358" M="0.9" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=1.42784E-09 VJ=17.0358 M=0.9 FC=1E-08) 
-    Diode:D3 _net5 gnd Is="1e-10" N="1" Rs="2.99893e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=1 RS=2.99893E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="1.68725e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 _net6 gnd Is="1e-10" N="1" M="0.5" Cj0="1e-14" Vj="0.7"
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (17.0358) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF3805S-7P>
+#   <Description>
+#    Enhancement n-channel power MOSFET
+#    55 V, 240 A, 2.6 mOhm, package: D2-Pak 7-Lead
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:NMOSFETs_IRF3805S_7P _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="4.70867" Lambda="0.00392471" Kp="395.548" Cgso="7.19597e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=4.70867 LAMBDA=0.00392471 KP=395.548 CGSO=7.19597E-05 CGDO=1E-11) 
+#     R:RS _net8 _net3 R="0.00141032"
+#     Diode:D1 _net1 _net3 Is="1.24924e-12" Rs="0.000669634" N="0.934129" Bv="55" Ibv="0.00025" Eg="1" Xti="1" Tt="1e-07" Cj0="2.67174e-09" Vj="3.68287" M="0.695013" Fc="0.404527"
+#     # .MODEL:MD  D (IS=1.24924E-12 RS=0.000669634 N=0.934129 BV=55 IBV=0.00025 EG=1 XTI=1 TT=1E-07 CJO=2.67174E-09 VJ=3.68287 M=0.695013 FC=0.404527) 
+#     R:RDS _net3 _net1 R="1e+07"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="6"
+#     Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="1.42784e-09" Vj="17.0358" M="0.9" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=1.42784E-09 VJ=17.0358 M=0.9 FC=1E-08) 
+#     Diode:D3 _net5 gnd Is="1e-10" N="1" Rs="2.99893e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=1 RS=2.99893E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="1.68725e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 _net6 gnd Is="1e-10" N="1" M="0.5" Cj0="1e-14" Vj="0.7"
+#   .Def:End
+#   </Model>
+# </Component>
 
 <Component IRF3805SL>
   <Description>
@@ -6892,6 +6895,7 @@
    Manufacturer: International Rectifier
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
+  <Model>
   .Def:NMOSFETs_IRF7465 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="5.52173" Lambda="0.107939" Kp="4.31953" Cgso="3e-06" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=5.52173 LAMBDA=0.107939 KP=4.31953 CGSO=3E-06 CGDO=1E-11) 
@@ -7647,40 +7651,41 @@
   </Model>
 </Component>
 
-<Component IRF7821>
-  <Description>
-   Enhancement n-channel power MOSFET
-   30 V, 13.6 A, 9.1 mOhm, package: SO-8
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:NMOSFETs_IRF7821 _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.43231" Lambda="0.0408792" Kp="83.7121" Cgso="9.21271e-06" Cgdo="7.38435e-07" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.43231 LAMBDA=0.0408792 KP=83.7121 CGSO=9.21271E-06 CGDO=7.38435E-07) 
-    R:RS _net8 _net3 R="0.00490342"
-    Diode:D1 _net1 _net3 Is="1.83992e-10" Rs="0.000992418" N="1.19801" Bv="30" Ibv="0.00025" Eg="1.2" Xti="4" Tt="1e-07" Cj0="9.51763e-10" Vj="0.5" M="0.394028" Fc="0.5"
-    # .MODEL:MD  D (IS=1.83992E-10 RS=0.000992418 N=1.19801 BV=30 IBV=0.00025 EG=1.2 XTI=4 TT=1E-07 CJO=9.51763E-10 VJ=0.5 M=0.394028 FC=0.5) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="3.40755"
-    Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="7.3672e-11" Vj="11.8882" M="0.9" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=7.3672E-11 VJ=11.8882 M=0.9 FC=1E-08) 
-    Diode:D3 _net5 gnd Is="1e-10" N="0.4" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=0.4 RS=3E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="5.51506e-10"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 _net6 gnd Is="1e-10" N="0.4" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD3  D (IS=1E-10 N=0.4) 
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (11.8882) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF7821>
+#   <Description>
+#    Enhancement n-channel power MOSFET
+#    30 V, 13.6 A, 9.1 mOhm, package: SO-8
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:NMOSFETs_IRF7821 _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="2.43231" Lambda="0.0408792" Kp="83.7121" Cgso="9.21271e-06" Cgdo="7.38435e-07" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=2.43231 LAMBDA=0.0408792 KP=83.7121 CGSO=9.21271E-06 CGDO=7.38435E-07) 
+#     R:RS _net8 _net3 R="0.00490342"
+#     Diode:D1 _net1 _net3 Is="1.83992e-10" Rs="0.000992418" N="1.19801" Bv="30" Ibv="0.00025" Eg="1.2" Xti="4" Tt="1e-07" Cj0="9.51763e-10" Vj="0.5" M="0.394028" Fc="0.5"
+#     # .MODEL:MD  D (IS=1.83992E-10 RS=0.000992418 N=1.19801 BV=30 IBV=0.00025 EG=1.2 XTI=4 TT=1E-07 CJO=9.51763E-10 VJ=0.5 M=0.394028 FC=0.5) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="3.40755"
+#     Diode:D2 _net5 _net4 Is="1e-32" N="50" Cj0="7.3672e-11" Vj="11.8882" M="0.9" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=7.3672E-11 VJ=11.8882 M=0.9 FC=1E-08) 
+#     Diode:D3 _net5 gnd Is="1e-10" N="0.4" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=0.4 RS=3E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="5.51506e-10"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 _net6 gnd Is="1e-10" N="0.4" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD3  D (IS=1E-10 N=0.4) 
+#   .Def:End
+#   </Model>
+# </Component>
 
 <Component IRF7822>
   <Description>
@@ -8347,7 +8352,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFS4229PBF _net2 _net1 _net3
+  .Def:NMOSFETs_IRFB4229PBF _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="5.34354" Lambda="0.171916" Kp="177.722" Cgso="4.31703e-05" Cgdo="2.13612e-07" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=5.34354 LAMBDA=0.171916 KP=177.722 CGSO=4.31703E-05 CGDO=2.13612E-07) 
     R:RS _net8 _net3 R="0.00978397"
@@ -10323,7 +10328,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU024N _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR024N _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.6319" Lambda="0" Kp="8.99346" Cgso="3.09714e-06" Cgdo="1.6185e-07" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.6319 LAMBDA=0 KP=8.99346 CGSO=3.09714E-06 CGDO=1.6185E-07) 
     R:RS _net8 _net3 R="0.0409355"
@@ -10358,7 +10363,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU110 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR110 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.7131" Lambda="0.00619193" Kp="4.20182" Cgso="1.70114e-06" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.7131 LAMBDA=0.00619193 KP=4.20182 CGSO=1.70114E-06 CGDO=1E-11) 
     R:RS _net8 _net3 R="0.242987"
@@ -10393,7 +10398,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU1205 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR1205 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.73139" Lambda="0" Kp="36.7046" Cgso="1.18612e-05" Cgdo="1.00005e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.73139 LAMBDA=0 KP=36.7046 CGSO=1.18612E-05 CGDO=1.00005E-11) 
     R:RS _net8 _net3 R="0.0184182"
@@ -10428,7 +10433,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU120N _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR120N _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.69404" Lambda="0.0155415" Kp="12.7625" Cgso="2.79242e-06" Cgdo="2.00936e-07" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.69404 LAMBDA=0.0155415 KP=12.7625 CGSO=2.79242E-06 CGDO=2.00936E-07) 
     R:RS _net8 _net3 R="0.139622"
@@ -10568,7 +10573,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU220 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR220 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.826" Lambda="0.00513436" Kp="1.18365" Cgso="2.19697e-06" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.826 LAMBDA=0.00513436 KP=1.18365 CGSO=2.19697E-06 CGDO=1E-11) 
     R:RS _net8 _net3 R="0.151373"
@@ -10673,7 +10678,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU320 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR320 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="4.15933" Lambda="0.000873656" Kp="1.20958" Cgso="3.69055e-06" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=4.15933 LAMBDA=0.000873656 KP=1.20958 CGSO=3.69055E-06 CGDO=1E-11) 
     R:RS _net8 _net3 R="0.0001"
@@ -10777,7 +10782,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU3910 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR3910 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.64652" Lambda="0.00294905" Kp="18.7905" Cgso="5.59783e-06" Cgdo="3.74853e-07" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.64652 LAMBDA=0.00294905 KP=18.7905 CGSO=5.59783E-06 CGDO=3.74853E-07) 
     R:RS _net8 _net3 R="0.0602588"
@@ -10846,7 +10851,7 @@
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>
   <Model>
-  .Def:NMOSFETs_IRFRU4105 _net2 _net1 _net3
+  .Def:NMOSFETs_IRFR4105 _net2 _net1 _net3
     MOSFET:M1 _net7 _net9 _net8 _net8 Type="nfet" L="100u" W="100u" Is="1e-32" Vt0="3.63895" Lambda="0" Kp="15.6814" Cgso="6.12732e-06" Cgdo="1.00004e-11" N="1" Gamma="0" Phi="0.6"
     # .MODEL:MM  NMOS (LEVEL=1 IS=1E-32 VTO=3.63895 LAMBDA=0 KP=15.6814 CGSO=6.12732E-06 CGDO=1.00004E-11) 
     R:RS _net8 _net3 R="0.0312085"

--- a/qucs/qucs-lib/library/PMOSFETs.lib
+++ b/qucs/qucs-lib/library/PMOSFETs.lib
@@ -833,75 +833,77 @@
   </Model>
 </Component>
 
-<Component IRF7220>
-  <Description>
-   Enhancement p-channel power MOSFET
-   -12 V, -11.0 A, 12 mOhm, package: SO-8
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:PMOSFETs_IRF7220 _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1" Lambda="2.04993" Kp="32.9291" Cgso="4.051e-05" Cgdo="4.69064e-08" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1 LAMBDA=2.04993 KP=32.9291 CGSO=4.051E-05 CGDO=4.69064E-08) 
-    R:RS _net8 _net3 R="0.004788"
-    Diode:D1 _net3 _net1 Is="6.82467e-09" Rs="0.0188446" N="1.5" Bv="300" Ibv="10" Eg="1" Xti="1" Tt="1.99996e-05" Cj0="7.23948e-10" Vj="5" M="0.860432" Fc="0.1"
-    # .MODEL:MD  D (IS=6.82467E-09 RS=0.0188446 N=1.5 BV=300 IBV=10 EG=1 XTI=1 TT=1.99996E-05 CJO=7.23948E-10 VJ=5 M=0.860432 FC=0.1) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="6"
-    Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="4.52727e-09" Vj="50" M="0.44818" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=4.52727E-09 VJ=50 M=0.44818 FC=1E-08) 
-    Diode:D3 gnd _net5 Is="1e-10" N="0.420941" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=0.420941 RS=3E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="4.52727e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 gnd _net6 Is="1e-10" N="0.420941" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD3  D (IS=1E-10 N=0.420941) 
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (50) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF7220>
+#   <Description>
+#    Enhancement p-channel power MOSFET
+#    -12 V, -11.0 A, 12 mOhm, package: SO-8
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:PMOSFETs_IRF7220 _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1" Lambda="2.04993" Kp="32.9291" Cgso="4.051e-05" Cgdo="4.69064e-08" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1 LAMBDA=2.04993 KP=32.9291 CGSO=4.051E-05 CGDO=4.69064E-08) 
+#     R:RS _net8 _net3 R="0.004788"
+#     Diode:D1 _net3 _net1 Is="6.82467e-09" Rs="0.0188446" N="1.5" Bv="300" Ibv="10" Eg="1" Xti="1" Tt="1.99996e-05" Cj0="7.23948e-10" Vj="5" M="0.860432" Fc="0.1"
+#     # .MODEL:MD  D (IS=6.82467E-09 RS=0.0188446 N=1.5 BV=300 IBV=10 EG=1 XTI=1 TT=1.99996E-05 CJO=7.23948E-10 VJ=5 M=0.860432 FC=0.1) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="6"
+#     Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="4.52727e-09" Vj="50" M="0.44818" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=4.52727E-09 VJ=50 M=0.44818 FC=1E-08) 
+#     Diode:D3 gnd _net5 Is="1e-10" N="0.420941" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=0.420941 RS=3E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="4.52727e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 gnd _net6 Is="1e-10" N="0.420941" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD3  D (IS=1E-10 N=0.420941) 
+#   .Def:End
+#   </Model>
+# </Component>
 
-<Component IRF7233>
-  <Description>
-   Enhancement p-channel power MOSFET
-   -12 V, -9.5 A, 20 mOhm, package: SO-8
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:PMOSFETs_IRF7233 _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1" Lambda="0.0856235" Kp="29.6299" Cgso="2.09443e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1 LAMBDA=0.0856235 KP=29.6299 CGSO=2.09443E-05 CGDO=1E-11) 
-    R:RS _net8 _net3 R="0.0101683"
-    Diode:D1 _net3 _net1 Is="7.72366e-09" Rs="0.0136195" N="1.5" Bv="300" Ibv="10" Eg="1.2" Xti="1" Tt="0.0001" Cj0="4.20139e-11" Vj="0.5" M="0.9" Fc="0.5"
-    # .MODEL:MD  D (IS=7.72366E-09 RS=0.0136195 N=1.5 BV=300 IBV=10 EG=1.2 XTI=1 TT=0.0001 CJO=4.20139E-11 VJ=0.5 M=0.9 FC=0.5) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.0001"
-    R:RG _net2 _net7 R="8.36907"
-    Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="2.80782e-09" Vj="49.8304" M="0.9" Fc="1e-08"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.80782E-09 VJ=49.8304 M=0.9 FC=1E-08) 
-    Diode:D3 gnd _net5 Is="1e-10" N="0.418403" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=0.418403 RS=3E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="3.36627e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 gnd _net6 Is="1e-10" N="0.418403" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD3  D (IS=1E-10 N=0.418403) 
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (49.8304) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF7233>
+#   <Description>
+#    Enhancement p-channel power MOSFET
+#    -12 V, -9.5 A, 20 mOhm, package: SO-8
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:PMOSFETs_IRF7233 _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1" Lambda="0.0856235" Kp="29.6299" Cgso="2.09443e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1 LAMBDA=0.0856235 KP=29.6299 CGSO=2.09443E-05 CGDO=1E-11) 
+#     R:RS _net8 _net3 R="0.0101683"
+#     Diode:D1 _net3 _net1 Is="7.72366e-09" Rs="0.0136195" N="1.5" Bv="300" Ibv="10" Eg="1.2" Xti="1" Tt="0.0001" Cj0="4.20139e-11" Vj="0.5" M="0.9" Fc="0.5"
+#     # .MODEL:MD  D (IS=7.72366E-09 RS=0.0136195 N=1.5 BV=300 IBV=10 EG=1.2 XTI=1 TT=0.0001 CJO=4.20139E-11 VJ=0.5 M=0.9 FC=0.5) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.0001"
+#     R:RG _net2 _net7 R="8.36907"
+#     Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="2.80782e-09" Vj="49.8304" M="0.9" Fc="1e-08"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.80782E-09 VJ=49.8304 M=0.9 FC=1E-08) 
+#     Diode:D3 gnd _net5 Is="1e-10" N="0.418403" Rs="3e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=0.418403 RS=3E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="3.36627e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 gnd _net6 Is="1e-10" N="0.418403" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD3  D (IS=1E-10 N=0.418403) 
+#   .Def:End
+#   </Model>
+# </Component>
 
 <Component IRF7404>
   <Description>
@@ -973,40 +975,41 @@
   </Model>
 </Component>
 
-<Component IRF7410>
-  <Description>
-   Enhancement p-channel power MOSFET
-   -12 V, -16.0 A, 7 mOhm, package: SO-8
-   Manufacturer: International Rectifier
-   added by Gunther Kraut <gn.kraut@online.de>
-  </Description>
-  <Model>
-  .Def:PMOSFETs_IRF7410 _net2 _net1 _net3
-    MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1.01518" Lambda="0.0900284" Kp="292.265" Cgso="7.50961e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
-    # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1.01518 LAMBDA=0.0900284 KP=292.265 CGSO=7.50961E-05 CGDO=1E-11) 
-    R:RS _net8 _net3 R="0.00316136"
-    Diode:D1 _net3 _net1 Is="8.57202e-07" Rs="0.00306658" N="1.5" Bv="12" Ibv="0.00025" Eg="1" Xti="1" Tt="0" Cj0="2.81771e-09" Vj="2.83395" M="0.9" Fc="0.1"
-    # .MODEL:MD  D (IS=8.57202E-07 RS=0.00306658 N=1.5 BV=12 IBV=0.00025 EG=1 XTI=1 TT=0 CJO=2.81771E-09 VJ=2.83395 M=0.9 FC=0.1) 
-    R:RDS _net3 _net1 R="1e+06"
-    R:RD _net9 _net1 R="0.000690837"
-    R:RG _net2 _net7 R="2.18034"
-    Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="2.27096e-09" Vj="20.7117" M="0.9" Fc="9.99997e-09"
-    # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.27096E-09 VJ=20.7117 M=0.9 FC=9.99997E-09) 
-    Diode:D3 gnd _net5 Is="1e-10" N="1" Rs="2.93769e-06" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD2  D (IS=1E-10 N=1 RS=2.93769E-06) 
-    R:RL _net5 _net10 R="1"
-    CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
-    Vdc:VFI2 _cnet0 gnd U="0"
-    VCVS:EV16 _net9 _net10 gnd _net7 G="1"
-    C:CAP _net11 _net10 C="7.27788e-09"
-    CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
-    Vdc:VFI1 _cnet1 _net6 U="0"
-    R:RCAP _net6 _net10 R="1"
-    Diode:D4 gnd _net6 Is="1e-10" N="1" M="0.5" Cj0="1e-14" Vj="0.7"
-    # .MODEL:MD3  D (IS=1E-10 N=1) 
-  .Def:End
-  </Model>
-</Component>
+# checker error, value of `Vj' (20.7117) is out of range `]0,10]' in `Diode:D2'
+# <Component IRF7410>
+#   <Description>
+#    Enhancement p-channel power MOSFET
+#    -12 V, -16.0 A, 7 mOhm, package: SO-8
+#    Manufacturer: International Rectifier
+#    added by Gunther Kraut <gn.kraut@online.de>
+#   </Description>
+#   <Model>
+#   .Def:PMOSFETs_IRF7410 _net2 _net1 _net3
+#     MOSFET:M1 _net7 _net9 _net8 _net8 Type="pfet" L="100u" W="100u" Is="1e-32" Vt0="-1.01518" Lambda="0.0900284" Kp="292.265" Cgso="7.50961e-05" Cgdo="1e-11" N="1" Gamma="0" Phi="0.6"
+#     # .MODEL:MM  PMOS (LEVEL=1 IS=1E-32 VTO=-1.01518 LAMBDA=0.0900284 KP=292.265 CGSO=7.50961E-05 CGDO=1E-11) 
+#     R:RS _net8 _net3 R="0.00316136"
+#     Diode:D1 _net3 _net1 Is="8.57202e-07" Rs="0.00306658" N="1.5" Bv="12" Ibv="0.00025" Eg="1" Xti="1" Tt="0" Cj0="2.81771e-09" Vj="2.83395" M="0.9" Fc="0.1"
+#     # .MODEL:MD  D (IS=8.57202E-07 RS=0.00306658 N=1.5 BV=12 IBV=0.00025 EG=1 XTI=1 TT=0 CJO=2.81771E-09 VJ=2.83395 M=0.9 FC=0.1) 
+#     R:RDS _net3 _net1 R="1e+06"
+#     R:RD _net9 _net1 R="0.000690837"
+#     R:RG _net2 _net7 R="2.18034"
+#     Diode:D2 _net4 _net5 Is="1e-32" N="50" Cj0="2.27096e-09" Vj="20.7117" M="0.9" Fc="9.99997e-09"
+#     # .MODEL:MD1  D (IS=1E-32 N=50 CJO=2.27096E-09 VJ=20.7117 M=0.9 FC=9.99997E-09) 
+#     Diode:D3 gnd _net5 Is="1e-10" N="1" Rs="2.93769e-06" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD2  D (IS=1E-10 N=1 RS=2.93769E-06) 
+#     R:RL _net5 _net10 R="1"
+#     CCCS:FI2 _net4 _net7 _net9 _cnet0 G="-1"
+#     Vdc:VFI2 _cnet0 gnd U="0"
+#     VCVS:EV16 _net9 _net10 gnd _net7 G="1"
+#     C:CAP _net11 _net10 C="7.27788e-09"
+#     CCCS:FI1 _net11 _net7 _net9 _cnet1 G="-1"
+#     Vdc:VFI1 _cnet1 _net6 U="0"
+#     R:RCAP _net6 _net10 R="1"
+#     Diode:D4 gnd _net6 Is="1e-10" N="1" M="0.5" Cj0="1e-14" Vj="0.7"
+#     # .MODEL:MD3  D (IS=1E-10 N=1) 
+#   .Def:End
+#   </Model>
+# </Component>
 
 <Component IRF7416>
   <Description>

--- a/qucs/qucs-lib/library/Transistors.lib
+++ b/qucs/qucs-lib/library/Transistors.lib
@@ -4020,18 +4020,19 @@ Added by Frans Schreuder <fransschreuder@users.sourceforge.net>
   </Model>
 </Component>
 
-<Component MMST4401>
-  <Description>
-    universal silicon NPN BJT
-    40V, 600mA, 200mW, 250MHz
-    Manufacturer: Diodes Inc.
-    PNP complement: MMST4403
-    added by Leandro D'Archivio <morti667@hotmail.com>
-  </Description>
-  <Model>
-    <_BJT T_MMST4401_ 1 0 0 8 -26 0 0 "npn" 0 "1.27p" 0 "410" 0 "1" 0 "60.7m" 0 "0.15" 0 "114" 0 "24" 0 "47.7p" 0 "2" 0 "0" 0 "2" 0 "410" 0 "4" 0 "0" 0 "0" 0 "0.104" 0 "0.261" 0 "1.04" 0 "27.7p" 0 "1.1" 0 "0.5" 0 "14.2p" 0 "0.3" 0 "0.3" 0 "1" 0 "0" 0 "0.75" 0 "0" 0 "0.5" 0 "533p" 0 "0" 0 "0" 0 "0" 0 "84.1n" 0 "26.85" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1" 0 "1" 0 "0" 0>
-  </Model>
-</Component>
+# checker error, value of `Nf' (410) is out of range `[0.1,100]' in `BJT:T_MMST4401_'
+# <Component MMST4401>
+#   <Description>
+#     universal silicon NPN BJT
+#     40V, 600mA, 200mW, 250MHz
+#     Manufacturer: Diodes Inc.
+#     PNP complement: MMST4403
+#     added by Leandro D'Archivio <morti667@hotmail.com>
+#   </Description>
+#   <Model>
+#     <_BJT T_MMST4401_ 1 0 0 8 -26 0 0 "npn" 0 "1.27p" 0 "410" 0 "1" 0 "60.7m" 0 "0.15" 0 "114" 0 "24" 0 "47.7p" 0 "2" 0 "0" 0 "2" 0 "410" 0 "4" 0 "0" 0 "0" 0 "0.104" 0 "0.261" 0 "1.04" 0 "27.7p" 0 "1.1" 0 "0.5" 0 "14.2p" 0 "0.3" 0 "0.3" 0 "1" 0 "0" 0 "0.75" 0 "0" 0 "0.5" 0 "533p" 0 "0" 0 "0" 0 "0" 0 "84.1n" 0 "26.85" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1" 0 "1" 0 "0" 0>
+#   </Model>
+# </Component>
 
 <Component MMST4403>
   <Description>

--- a/qucs/qucs-lib/library/Z-Diodes.lib
+++ b/qucs/qucs-lib/library/Z-Diodes.lib
@@ -950,7 +950,7 @@
   </Description>
   <Model>
     .Def:Z_Diodes_1N5342B _net0 _net1
-      Diode:D1 _net0 _net1 Is="7.56E-18" N="1.27" Rs="0.859" Cj0="6.15E-10" Vj="0.75" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="6.645" Ibv="0.183" Af="1" Kf="0"
+      Diode:D1 _net0 _net1 Is="7.56E-18" N="1.27" Rs="0.859" Cj0="6.15E-10" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="6.645" Ibv="0.183" Af="1" Kf="0"
     .Def:End
   </Model>
 </Component>
@@ -963,7 +963,7 @@
   </Description>
   <Model>
     .Def:Z_Diodes_1N5344B _net0 _net1
-      Diode:D1 _net0 _net1 Is="4.65E-17" N="1.27" Rs="1.33" Cj0="4.64E-10" Vj="0.75" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="8.001" Ibv="0.152" Af="1" Kf="0"
+      Diode:D1 _net0 _net1 Is="4.65E-17" N="1.27" Rs="1.33" Cj0="4.64E-10" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="8.001" Ibv="0.152" Af="1" Kf="0"
     .Def:End
   </Model>
 </Component>
@@ -976,7 +976,7 @@
   </Description>
   <Model>
     .Def:Z_Diodes_1N5346B _net0 _net1
-      Diode:D1 _net0 _net1 Is="3.17E-16" N="1.27" Rs="1.82" Cj0="3.97E-10" Vj="0.75" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="8.83" Ibv="0.15" Af="1" Kf="0"
+      Diode:D1 _net0 _net1 Is="3.17E-16" N="1.27" Rs="1.82" Cj0="3.97E-10" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="8.83" Ibv="0.15" Af="1" Kf="0"
     .Def:End
   </Model>
 </Component>
@@ -1183,7 +1183,7 @@
     added by Leandro D'Archivio <morti667@hotmail.com>
   </Description>
   <Model>
-    .Def:Z-Diodes_1N5377B _net0 _net1
+    .Def:Z_Diodes_1N5377B _net0 _net1
       Diode:D1 _net0 _net1 Is="1.65E-10" N="1.27" Rs="73.3" Cj0="6.72E-11" Vj="0.75" M="0.33" Fc="0.5" Tt="5.01E-8" Bv="89.94" Ibv="0.015" Af="1" Kf="0"
     .Def:End
   </Model>


### PR DESCRIPTION
Value out of range - deactivated by commenting it out
NMOSFETs    **IRF3709ZCS_L**
NMOSFETs    **IRF3709Z_S_L**
NMOSFETs    **IRF3805S-7P**
NMOSFETs    **IRF7821**
PMOSFETs    **IRF7220**
PMOSFETs    **IRF7233**
PMOSFETs    **IRF7410**
Transistors **MMST4401**

Typos - corrected
NMOSFETs **IRF7465**                 missing \<Model\> tag
NMOSFETs **IRFB4229PBF**       Component Name and .Def Name equalized
NMOSFETs **IRFR024N**      Component Name and .Def Name equalized
NMOSFETs **IRFR110**      Component Name and .Def Name equalized
NMOSFETs **IRFR1205**      Component Name and .Def Name equalized
NMOSFETs **IRFR120N**      Component Name and .Def Name equalized
NMOSFETs **IRFR220**      Component Name and .Def Name equalized
NMOSFETs **IRFR320**      Component Name and .Def Name equalized
NMOSFETs **IRFR3910**      Component Name and .Def Name equalized
NMOSFETs **IRFR4105**      Component Name and .Def Name equalized
Z-Diodes **1N5342B**              'Vj' occurred 2x
Z-Diodes **1N5344B**              'Vj' occurred 2x
Z-Diodes **1N5346B**              'Vj' occurred 2x
Z-Diodes **1N5377B**              .Def:Z-Diodes_1N5377B -> .Def:Z_Diodes_1N5377B