### PR TITLE
Library typos corrections

### DIFF
--- a/qucs/qucs-lib/library/PMOSFETs.lib
+++ b/qucs/qucs-lib/library/PMOSFETs.lib
@@ -351,7 +351,7 @@
 <Component BUZ272>
   <Description>
    Enhancement p-channel power MOSFET
-   -100 V, -15 A, 0.3mOhm
+   -100 V, -15 A, 0.3 Ohm
    Manufacturer: Infineon Technologies
    added by Gunther Kraut <gn.kraut@online.de>
   </Description>

--- a/qucs/qucs-lib/library/Transistors.lib
+++ b/qucs/qucs-lib/library/Transistors.lib
@@ -2606,11 +2606,11 @@ Added by Frans Schreuder <fransschreuder@users.sourceforge.net>
 
 <Component BFR92A>
   <Description>
-    Si  pnp 300mW 20V 25mA 5GHz pkg:SOT-23 2,1,3
+    Si  npn 300mW 20V 25mA 5GHz pkg:SOT-23 2,1,3
     added by Frans Schreuder
   </Description>
   <Model>
-<_BJT BFR92A_ 1 0 0 8 -26 0 0 "pnp" 0 "4.11877E-016" 0 "9.97275E-001" 0 "9.96202E-001" 0 "3.20054E+000" 0 "1.28155E+000" 0 "6.26719E+001" 0 "3.36915E+000" 0 " 4.01062E-015" 0 "1.57708E+000" 0 "2.79905E-016" 0 "1.07543E+000" 0 "314" 0 "1.81086E+001" 0 "1.00000E+001" 0 "1.00000E-006" 0 "2.32000E+000" 0 "1.16450E+000" 0 "1.00000E+001" 0 "8.90512E-013" 0 "6.00000E-001" 0 "2.58570E-001" 0 "5.46563E-013" 0 "3.80824E-001" 0 "2.02935E-001" 0 "1" 0 "0" 0 "0.75" 0 "0" 0 "0.5" 0 "1.54973E-011" 0 "3.91402E+001" 0 "2.15279E+000" 0 "2.13776E-001" 0 "3.04e-07" 0 "26.85" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1.5" 0 "3.00000E+000" 0 "1.11" 0 "26.85" 0 "1" 0>
+<_BJT BFR92A_ 1 0 0 8 -26 0 0 "npn" 0 "4.11877E-016" 0 "9.97275E-001" 0 "9.96202E-001" 0 "3.20054E+000" 0 "1.28155E+000" 0 "6.26719E+001" 0 "3.36915E+000" 0 " 4.01062E-015" 0 "1.57708E+000" 0 "2.79905E-016" 0 "1.07543E+000" 0 "314" 0 "1.81086E+001" 0 "1.00000E+001" 0 "1.00000E-006" 0 "2.32000E+000" 0 "1.16450E+000" 0 "1.00000E+001" 0 "8.90512E-013" 0 "6.00000E-001" 0 "2.58570E-001" 0 "5.46563E-013" 0 "3.80824E-001" 0 "2.02935E-001" 0 "1" 0 "0" 0 "0.75" 0 "0" 0 "0.5" 0 "1.54973E-011" 0 "3.91402E+001" 0 "2.15279E+000" 0 "2.13776E-001" 0 "3.04e-07" 0 "26.85" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1" 0 "1" 0 "0" 0 "1.5" 0 "3.00000E+000" 0 "1.11" 0 "26.85" 0 "1" 0>
   </Model>
 </Component>
 
@@ -3711,7 +3711,7 @@ Added by Frans Schreuder <fransschreuder@users.sourceforge.net>
 <Component MMBTH10>
   <Description>
     VHF/UHF silicon NPN BJT
-    25V, 50mA, 300mW, 650GHz
+    25V, 50mA, 300mW, 650MHz
     Manufacturer: Diodes Inc.
     PNP complement: not available
     added by Leandro D'Archivio <morti667@hotmail.com>
@@ -3724,7 +3724,7 @@ Added by Frans Schreuder <fransschreuder@users.sourceforge.net>
 <Component MMBTH24>
   <Description>
     VHF/UHF silicon NPN BJT
-    40V, 50mA, 300mW, 400GHz
+    40V, 50mA, 300mW, 400MHz
     Manufacturer: Diodes Inc.
     PNP complement: not available
     added by Leandro D'Archivio <morti667@hotmail.com>


### PR DESCRIPTION
corrections:
BFR92A  pnp -> npn  https://www.nxp.com/docs/en/data-sheet/BFR92A_N.pdf
MMBTH10 650GHz -> 650MHz https://www.diodes.com/assets/Datasheets/ds31031.pdf
MMBTH24 400GHz -> 400MHz https://www.diodes.com/assets/Datasheets/ds31034.pdf
BUZ272  0.3 mOhm -> 0.3 Ohm http://pdf.datasheetcatalog.com/datasheet/infineon/1-buz272.pdf
Issue https://github.com/Qucs/qucs/issues/979 #979 