### PR TITLE
Fix argument type mismatch in LoadLibrary call

### DIFF
--- a/qucs/qucs/platform.h
+++ b/qucs/qucs/platform.h
@@ -76,7 +76,7 @@ inline void* dlopen(const char* f, int)
   const size_t fSize = strlen(f)+1;
   std::wstring wf( fSize, L'#' );
   mbstowcs( &wf[0], f, fSize );
-  return LoadLibrary(wf.c_str());
+  return LoadLibraryW(wf.c_str());
 }
 
 inline void dlclose(void* h)


### PR DESCRIPTION
It fixes this build error:
![qucs_ll](https://user-images.githubusercontent.com/1242858/78634599-f64a6480-78ac-11ea-82be-b79f05ec54a3.png)
