### PR TITLE
Fix qucs.desktop so that we can deploy AppImages

### DIFF
--- a/qucs/qucs/qucs.desktop
+++ b/qucs/qucs/qucs.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Qucs
 Comment=A Universal Circuit Simulator
 Comment[es]=Un simulador universal de circuitos
@@ -13,5 +12,5 @@ Icon=qucs
 Terminal=false
 
 Type=Application
-Categories=Education;Electronics
+Categories=Education;Electronics;
 StartupNotify=false


### PR DESCRIPTION
This fix is needed because otherways making AppImages you get this error:

```
[appimage/stdout] /home/romano/software/qucs/AppImage/qucs-qucs-0.0.20-rc2/build/AppDir/qucs.desktop: warning: key "Encoding" in group "Desktop Entry" is deprecated
[appimage/stdout] /home/romano/software/qucs/AppImage/qucs-qucs-0.0.20-rc2/build/AppDir/qucs.desktop: error: value "Education;Electronics" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```

...and if you notice, the other `.desktop` in the repo (contrib/ubuntu-debian/qucs/debian/qucs.desktop) seems correct. 
