### PR TITLE
docs: fixed non UTF-8 files

### DIFF
--- a/qucs-doc/technical/coplanar.tex
+++ b/qucs-doc/technical/coplanar.tex
@@ -75,7 +75,7 @@ substrate, as shown on the left of the figure below, can be mapped
 into a parallel plate capacitor filled with dielectric $ABCD$ using
 the conformal function:
 \begin{equation}
-w = \int_{z_0}^{z} \dfrac{dz}{\sqrt{(z-W/2)(z-W/2-s)}}.
+w = \int_{z_0}^{z}\dfrac{dz}{\sqrt{(z-W/2)(z-W/2-s)}}.
 \end{equation}
 
 \begin{figure}[ht]

--- a/qucs-doc/tutorial/getstarted/content.tex
+++ b/qucs-doc/tutorial/getstarted/content.tex
@@ -2,7 +2,7 @@
 % Tutorial -- Getting Started with Qucs
 %
 % Copyright (C) 2007 Stefan Jahn <stefan@lkcc.org>
-% Copyright (C) 2007 Juan Carlos Borr·s <jcborras@gmail.com>
+% Copyright (C) 2007 Juan Carlos Borr√°s <jcborras@gmail.com>
 %
 % Permission is granted to copy, distribute and/or modify this document
 % under the terms of the GNU Free Documentation License, Version 1.1

--- a/qucs-doc/tutorial/getstarted/getstarted.tex
+++ b/qucs-doc/tutorial/getstarted/getstarted.tex
@@ -20,15 +20,15 @@
   Getting Started with Qucs}
 \tutauthor{
   Stefan Jahn\vspace*{6pt}\\
-  Juan Carlos Borr·s}
+  Juan Carlos Borr√°s}
 \tutcopyright{
   Copyright \copyright{} 2007 Stefan Jahn
   \textless stefan@lkcc.org\textgreater\\
-  Copyright \copyright{} 2007 Juan Carlos Borr·s
+  Copyright \copyright{} 2007 Juan Carlos Borr√°s
   \textless jcborras@gmail.com\textgreater}
 \tutbookfalse
 
-\tutstartup{\tutsubtitle}{Stefan Jahn and Juan Carlos Borr·s}
+\tutstartup{\tutsubtitle}{Stefan Jahn and Juan Carlos Borr√°s}
 
 \usepackage{keystroke}
 

--- a/qucs-doc/tutorial/modelbjt/content.tex
+++ b/qucs-doc/tutorial/modelbjt/content.tex
@@ -163,7 +163,7 @@ In order to simulate properly the device, you need to used the correct package, 
 
 Eventhough the device has two emitter, the model used has only one emitter. The parasitic of this model are shoyn in the spice netlist described in the choice of the transistor and reproduced in a schematic (see fig. \ref{design:pa:model:parasitSch}). These parameter are always critical to extract, either you have the knowledge to do it or then you should rely on the piece of information given by the device manucfacturer. It is also very difficult to figure out what have to be changed in such description of the device. Some fitting have been performed using 3D electromagnetic software in the time domain based on MOM methods to verify these parameters.
 
-Philips’  fifth  generation double poly silicon wideband technology uses a steep emitter doped profile resulting in transition frequencies over 20 GHz, and with poly base contacts a low base resistance is obtained. Via the buried layer, the collector contact is brought out at the top of the die. The substrate is connected directly to the emitter package lead, resulting in improved thermal performance ( see fig \ref{design:pa:model:fifthGen}).
+Philips  fifth  generation double poly silicon wideband technology uses a steep emitter doped profile resulting in transition frequencies over 20 GHz, and with poly base contacts a low base resistance is obtained. Via the buried layer, the collector contact is brought out at the top of the die. The substrate is connected directly to the emitter package lead, resulting in improved thermal performance ( see fig \ref{design:pa:model:fifthGen}).
 
 \begin{figure}[htbp]
 \begin{center}


### PR DESCRIPTION
Modern systems use UTF-8 by default and compilation (docs generation with latex) fails on non UTF-8 characters.