### PR TITLE
Refactor+qt5 19

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,7 +60,7 @@ build_script:
 after_build:
    - 7z a %APPVEYOR_BUILD_FOLDER%\qucs-win%MBITS%.zip %QUCSDIR%
 
- artifacts:
+artifacts:
    # variables here must use the PowerShell syntax
    - path: qucs-win$(MBITS).zip
      name: qucs-win$(MBITS).zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2019
 environment:
   matrix:
     - MSYSTEM : MINGW64
@@ -24,6 +25,8 @@ install:
   - set QUCSDIR=c:\qucs-win%MBITS%\
   - set MSYSHOME=C:\msys64\home\appveyor\
   - set "PATH=C:\msys64\usr\bin;%QTDIR%\bin;%PATH%"
+  #correction to pgk-config path (needed for Qt5)
+  - set PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/share/pkgconfig:/mingw%MBITS%/lib/pkgconfig
 
   - bash -lc ""
   - bash -lc "pacman --version"
@@ -31,7 +34,7 @@ install:
   # Switch from SF to msys2.org (default, much faster)
   - bash -lc "pacman --noconfirm --needed --sync pacman-mirrors"
   - bash -lc "pacman --noconfirm --needed -S autoconf automake bison flex"
-  #- bash -lc "pacman --noconfirm --needed -S mingw-w64-$MARCH-qt4"
+  - bash -lc "pacman --noconfirm --needed -S mingw-w64-$MARCH-qt5"
   # Qt4 was removed from MSYS2, see
   #   https://github.com/msys2/MINGW-packages/issues/3881
   #   and https://github.com/slowphil/texmacs-win-builder/issues/3 for the "fix"
@@ -43,9 +46,9 @@ install:
   #
   # download package directly into the local pacman packages directory, cached by AppVeyor
   # make sure pacman packages directory exists (may not be there if no packages downloaded yet)
-  - bash -lc "mkdir -p /var/cache/pacman/pkg"
+  #- bash -lc "mkdir -p /var/cache/pacman/pkg"
   # use "no-clobber" option for wget since the file could/should already be in the cache
-  - bash -lc "cd /var/cache/pacman/pkg && wget -nc http://repo.msys2.org/mingw/$MARCH/mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz && pacman --noconfirm --needed -U mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz"
+  #- bash -lc "cd /var/cache/pacman/pkg && wget -nc http://repo.msys2.org/mingw/$MARCH/mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz && pacman --noconfirm --needed -U mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz"
 
   # Set compiler (64bit)
   - set "CC=/c/msys64/mingw%MBITS%/bin/gcc.exe"
@@ -61,7 +64,7 @@ build_script:
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && ./bootstrap"
 
     # does not work. there is no qt5
-    #   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && export QTDIR=/c/msys64/mingw$MBITS && ./configure --prefix=/c/qucs-win$MBITS --disable-dependency-tracking"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && export PKG_CONFIG_PATH=$PKG_CONFIG_PATH && ./configure --prefix=/c/qucs-win$MBITS --disable-dependency-tracking"
     #   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && make -j2 install"
     #   - bash -lc "exec 0</dev/null && cd /c/qucs-win$MBITS/bin && ./qucs -v"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,19 +35,7 @@ install:
   - bash -lc "pacman --noconfirm --needed --sync pacman-mirrors"
   - bash -lc "pacman --noconfirm --needed -S autoconf automake bison flex"
   - bash -lc "pacman --noconfirm --needed -S mingw-w64-$MARCH-qt5"
-  # Qt4 was removed from MSYS2, see
-  #   https://github.com/msys2/MINGW-packages/issues/3881
-  #   and https://github.com/slowphil/texmacs-win-builder/issues/3 for the "fix"
-  #   copied below
-  # pacman no longer finds qt4 probably because of https://github.com/msys2/MINGW-packages/issues/3881
-  # nevertheless the binary still exists in the repo (for the moment)
-  # https://msys2.duckdns.org/repos
-  # https://wiki.archlinux.org/index.php/offline_installation_of_packages
-  #
-  # download package directly into the local pacman packages directory, cached by AppVeyor
-  # make sure pacman packages directory exists (may not be there if no packages downloaded yet)
-  #- bash -lc "mkdir -p /var/cache/pacman/pkg"
-  # use "no-clobber" option for wget since the file could/should already be in the cache
+  
   #- bash -lc "cd /var/cache/pacman/pkg && wget -nc http://repo.msys2.org/mingw/$MARCH/mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz && pacman --noconfirm --needed -U mingw-w64-$MARCH-qt4-4.8.7-4-any.pkg.tar.xz"
 
   # Set compiler (64bit)
@@ -62,23 +50,21 @@ build_script:
 
   ## Build Qucs-GUI applications and install
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && ./bootstrap"
-
-    # does not work. there is no qt5
   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && export PKG_CONFIG_PATH=$PKG_CONFIG_PATH && ./configure --prefix=/c/qucs-win$MBITS --disable-dependency-tracking"
-    #   - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && make -j2 install"
-    #   - bash -lc "exec 0</dev/null && cd /c/qucs-win$MBITS/bin && ./qucs -v"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && make -j2 install"
+  - bash -lc "exec 0</dev/null && cd /c/qucs-win$MBITS/bin && ./qucs -v"
 
   ## Check
-  # - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && make check || :"
+  - bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/qucs && make check || :"
 
-# after_build:
-#   - 7z a %APPVEYOR_BUILD_FOLDER%\qucs-win%MBITS%.zip %QUCSDIR%
+after_build:
+   - 7z a %APPVEYOR_BUILD_FOLDER%\qucs-win%MBITS%.zip %QUCSDIR%
 
-# artifacts:
-#   # variables here must use the PowerShell syntax
-#   - path: qucs-win$(MBITS).zip
-#     name: qucs-win$(MBITS).zip
+ artifacts:
+   # variables here must use the PowerShell syntax
+   - path: qucs-win$(MBITS).zip
+     name: qucs-win$(MBITS).zip
 
-#on_failure:
-#  - bash -lc "exec 0</dev/null && cat $APPVEYOR_BUILD_FOLDER/qucs/config.log"
-#  - ps: Get-ChildItem .\*.log -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+on_failure:
+  - bash -lc "exec 0</dev/null && cat $APPVEYOR_BUILD_FOLDER/qucs/config.log"
+  - ps: Get-ChildItem .\*.log -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ cache:
   # cache pacman packages
   # max cache size is 1 GB, which should be enough
   # but in case we could cache only mingw-w64-*-qt4-*
-  - C:\msys64\var\cache\pacman\pkg\ -> .appveyor.yml
+  - C:\msys64\var\cache\pacman\pkg\
 
 install:
 


### PR DESCRIPTION
I'm not sure where I should merge this. I was trying to work on #1020, but the build is not working on windows (Qt5 not found). I think I fix it.
The last path of pkg-config is not correct. I just add `/mingw%MBITS%` and now  Qt5 is correctly linked.