### PR TITLE
Prevent spurious error message when starting qucsconv.

### DIFF
--- a/qucs/qucs/components/spicedialog.cpp
+++ b/qucs/qucs/components/spicedialog.cpp
@@ -450,7 +450,8 @@ bool SpiceDialog::loadSpiceNetList(const QString& s)
 
   QucsConv->start(Program, Arguments);
 
-  if(QucsConv->state() != QProcess::Running)
+  if((QucsConv->state() != QProcess::Starting) &&
+     (QucsConv->state() != QProcess::Running))
   {
     QMessageBox::critical(this, tr("Error"),
                           tr("Cannot execute \"%1\".").arg(QucsSettings.Qucsconv));


### PR DESCRIPTION
On the current develop branch, if I add a SPICE netlist file component to a schematic and browse to select the spice file, qucsconv correctly converts the netlist, and the SPICE net nodes list is populated correctly, but a spurious error messagebox is displayed.  This happens because the qucsconv process is in the state 'Starting', but not yet 'Running'.