### PR TITLE
Fix build with GCC 13

### DIFF
--- a/qucs/qucs/mouseactions.cpp
+++ b/qucs/qucs/mouseactions.cpp
@@ -46,6 +46,7 @@
 #include <QDebug>
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 

--- a/qucs/qucs/schematic_element.cpp
+++ b/qucs/qucs/schematic_element.cpp
@@ -14,6 +14,7 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
 


### PR DESCRIPTION
`uintptr_t` requires an explicit include with GCC 13, as described in https://gcc.gnu.org/gcc-13/porting_to.html

Signed-off-by: Yaakov Selkowitz <yselkowi@redhat.com>
