### PR TITLE
netlist library components get painted as boxes FIX

### DIFF
--- a/qucs-lib/symbolwidget.cpp
+++ b/qucs-lib/symbolwidget.cpp
@@ -356,7 +356,7 @@ int SymbolWidget::createStandardSymbol(const QString& Lib_, const QString& Comp_
  * \param SymbolString
  * \param Lib_
  * \param Comp_
- * \return the number of painting elements or a negative nuber if error
+ * \return the number of painting elements or a negative number if error
  */
 int SymbolWidget::setSymbol( QString& SymbolString,
                             const QString& Lib_, const QString& Comp_)

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -1083,7 +1083,7 @@ int Component::analyseLine(const QString& Row, int numProps)
 
     i1 = 1;
     auto pp = Props.begin();
-    for(int i = 0; i < (numProps-1) && pp != Props.end(); ++i)
+    for(int i = 0; i < (numProps) && pp != Props.end(); ++i)
       ++pp;
     for(;;) {
       s = Row.section('"', i1,i1);

--- a/qucs/misc.cpp
+++ b/qucs/misc.cpp
@@ -440,8 +440,9 @@ bool misc::checkVersion(QString& Line)
 
 // a small class to handle the application version string
 //   loosely modeled after the standard Semantic Versioning...
-VersionTriplet::VersionTriplet(const QString& version) {
+VersionTriplet::VersionTriplet(const QString& raw_version) {
   // TODO should be likely made more robust...
+  QString version = raw_version.mid(0, raw_version.indexOf("-"));
   if (version.isEmpty()) {
     major = minor = patch = 0;
   } else {


### PR DESCRIPTION
STATING the problem
-

Component libraries (.lib) contain component definitions or SPICE like netlists.
The SPICE netlists components (such as bridges or some MOSFETS)  get drawn as boxes without ports.

I saw 2 separate failure origins masking one another.

ORIGIN N.1
=========

This fails in the -dev version due to a failing check between QucsVersion and LibVersion:

- FiX
components/libcomp.cpp:108
  if (LibVersion > QucsVersion) // wrong version number ?
    return -3;

since
PACKAGE_VERSION = 0.0.21-dev

but in main.cpp:
QucsVersion = VersionTriplet(PACKAGE_VERSION)

returns:
QucsVersion="0.0.0"

I cracked on towards misc.cpp: VersionTriplet() and stripped the -dev for a quick fix but I fully agree with the todo comment.

- CONTEXT 1 (backtrace)
-    
LibComp::loadSection
LibComp::loadSymbol
LibComp::createSymbol
MultiviewComponent::recreate
getComponentFromName
Schematic::dragEnterEvent

ORIGIN N.2
=========

Once the symbol is loaded, a segmentation fault arises when LibComp::newOne tries to copy the new component - See CONTEXT 2

The problem starts in CONTEXT 1 when getComponentFromName recreates component (around line 1700: c->recreate(0);) just 1 Property remains after recreate.
That's because Libcomp::recreate() -> LibComp::createSymbol() -> LimbComp::loadSymbol() -> Component:analyseLine() erases the last property in line 1108.

I decided to extend the loop in 1806 from

for(int i = 0; i < (numProps - 1) && pp != Props.end(); ++i)

to

for(int i = 0; i < (numProps) && pp != Props.end(); ++i)

The ultimate reason for that -1 is beyond my scope, so the solution might well have been adding something extra in libXXX.lib  due to an improper format design.

- CONTEXT 2 (backtrace)

Component::prop
LibComp::newOne
MouseActions::MPressElements
Schematic::dropEvent
