### PR TITLE
This fixes an issue with components that dynamically change their number of port.

### DIFF
--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2528,7 +2528,10 @@ void Schematic::insertRawComponent(const ComponentList::holder &c, bool noOptimi
 {
     // connect every node of component to corresponding schematic node
     insertComponentNodes(c, noOptimize);
-    Components->append(c);
+    // Check if this component already exists in the list. If it does, then
+    // we shouldn't add it.
+    if(Components->find(c) == Components->end())
+        Components->append(c);
 
     // a ground symbol erases an existing label on the wire line
     if(c->obsolete_model_hack() == "GND") { // BUG.


### PR DESCRIPTION
To recreate the bug:
Use the develop branch. Open a new schematic. Add an rfedd. Change its number of port to 6. Notice how port 2 and 5 are seemingly connected to nothing? Now move the component to a new location. Now suddenly all 6 ports are connected to nothing. I.e. all ports are incorrectly displayed as blue squares.

Long time fan & user. Keep up the good work! Really happy to see qt5 now, as qt4 was becoming a real problem on modern Linux distros.