### PR TITLE
Fixes to allow compilation on Windows using MSYS2 MINGW64 toolchain

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,7 +250,7 @@ if test "x$PKG_CONFIG" != "x"; then
 
       PKG_CHECK_MODULES([QTest], [${qt_name}Test])
 
-      PKG_CHECK_MODULES([QT], [${qt_name}Core ${qt_name}Gui ${qt_name}Svg ${qt_name}Xml], [
+      PKG_CHECK_MODULES([QT], [${qt_name}Core ${qt_name}Gui ${qt_name}Script  ${qt_name}Svg ${qt_name}Xml], [
         QT_CFLAGS="$QT_CFLAGS $QT_DEF -DQT_DEPRECATED_WARNINGS -D_REENTRANT"
         case $host_os in
           *freebsd*) QT_LIBS="$QT_LIBS -pthread" ;;
@@ -358,6 +358,7 @@ fi # end of Qt4 logic when pkg-config is not found
 AS_IF([test $QT_MAJOR_VERSION -ge 5],
           [ QT_CFLAGS="$QT_CFLAGS -fPIC"
       PKG_CHECK_MODULES([QtPrintSupport], [${qt_name}PrintSupport])
+      PKG_CHECK_MODULES([QtScript], [${qt_name}Script])
 	   ])
 
     QT_CFLAGS="$QT_CFLAGS $QtPrintSupport_CFLAGS $QtScript_CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -837,7 +837,7 @@ dnl Check for Git short SHA to tag version
 dnl The release package should also keep it on the config.h
 GIT="unknown"
 if test -d "../.git"; then
-  m4_define([GIT_REVISION], m4_esyscmd([git log --pretty=format:'%h' -n 1u]))
+  m4_define([GIT_REVISION], m4_esyscmd([git log --pretty=format:'%h' -n 1]))
   AC_DEFINE([GIT], ["GIT_REVISION"], [Git short revision hash.])
   GIT=GIT_REVISION
   echo "\nFound Git clone... $GIT"

--- a/qucs-activefilter/qucsactivefilter.cpp
+++ b/qucs-activefilter/qucsactivefilter.cpp
@@ -117,15 +117,15 @@ QucsActiveFilter::QucsActiveFilter(QWidget *parent)
 
     lblTyp = new QLabel(tr("Approximation type:"));
     cbxFilterFunc = new QComboBox;
-    QStringList lst2;
-    lst2<<tr("Butterworth")
+    QStringList list2;
+    list2<<tr("Butterworth")
         <<tr("Chebyshev")
         <<tr("Inverse Chebyshev")
         <<tr("Cauer (Elliptic)")
         <<tr("Bessel")
         <<tr("Legendre")
         <<tr("User defined");
-    cbxFilterFunc->addItems(lst2);
+    cbxFilterFunc->addItems(list2);
     connect(cbxFilterFunc,SIGNAL(currentIndexChanged(int)),this,SLOT(slotSwitchParameters()));
 
     btnDefineTransferFunc = new QPushButton(tr("Manually define transfer function"));
@@ -142,12 +142,12 @@ QucsActiveFilter::QucsActiveFilter(QWidget *parent)
     lblSch = new QLabel(tr("Filter topology"));
     lblResp = new QLabel(tr("Filter type:"));
     cbxResponse = new QComboBox;
-    QStringList lst3;
-    lst3<<tr("Low Pass")
+    QStringList list3;
+    list3<<tr("Low Pass")
         <<tr("High Pass")
         <<tr("Band Pass")
         <<tr("Band Stop");
-    cbxResponse->addItems(lst3);
+    cbxResponse->addItems(list3);
     connect(cbxResponse,SIGNAL(currentIndexChanged(int)),this,SLOT(slotUpdateResponse()));
     connect(cbxResponse,SIGNAL(currentIndexChanged(int)),this,SLOT(slotUpdateSchematic()));
     connect(cbxResponse,SIGNAL(currentIndexChanged(int)),this,SLOT(slotSetLabels()));

--- a/qucs-lib/symbolwidget.h
+++ b/qucs-lib/symbolwidget.h
@@ -30,7 +30,6 @@
 #include <QMessageBox>
 
 #include "element.h"
-using namespace qucs;
 
 /*!
  * \file symbolwidget.h
@@ -72,10 +71,10 @@ private:
   QString Warning;
   int TextWidth, DragNDropWidth, TextHeight;
   int cx, cy, x1, x2, y1, y2;
-  QList<Line *> Lines;
-  QList<Arc *> Arcs;
-  QList<Area *> Rects, Ellips;
-  QList<Text *>  Texts;
+  QList<qucs::Line *> Lines;
+  QList<qucs::Arc *> Arcs;
+  QList<qucs::Area *> Rects, Ellips;
+  QList<qucs::Text *>  Texts;
 };
 
 #endif // SYMBOLWIDGET_H

--- a/qucs-lib/symbolwidget.h
+++ b/qucs-lib/symbolwidget.h
@@ -30,6 +30,7 @@
 #include <QMessageBox>
 
 #include "element.h"
+using namespace qucs;
 
 /*!
  * \file symbolwidget.h

--- a/qucs/components/DLS_1ton.cpp
+++ b/qucs/components/DLS_1ton.cpp
@@ -14,9 +14,9 @@ DLS_1ton::DLS_1ton()
 {
   Description = QObject::tr ("data voltage level shifter (digital to analogue) verilog device");
 
-  Props.push_back (Property ("LEVEL", "5 V", false,
+  Props.push_back(qucs::Property("LEVEL", "5 V", false,
     QObject::tr ("voltage level")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("time delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -46,24 +46,24 @@ Element * DLS_1ton::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void DLS_1ton::createSymbol()
 {
-  Lines.push_back(Line(-30, -30, 30,-30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 30, -30, 30, 30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 30, 30,-30, 30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line(-30, 30, -30, -30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, -30, 30,-30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 30, -30, 30, 30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 30, 30,-30, 30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, 30, -30, -30,QPen(Qt::darkRed,2)));
  
-  Lines.push_back(Line(-30, 30, 30, -30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, 30, 30, -30,QPen(Qt::darkRed,2)));
 
-  Lines.push_back(Line(-40,  0,-30,  0,QPen(Qt::darkRed,2))); // Lin
-  Lines.push_back(Line( 30,  0, 40,  0,QPen(Qt::darkRed,2))); // Lout
+  Lines.push_back(qucs::Line(-40,  0,-30,  0,QPen(Qt::darkRed,2))); // Lin
+  Lines.push_back(qucs::Line( 30,  0, 40,  0,QPen(Qt::darkRed,2))); // Lout
   
-  Lines.push_back(Line(-25, -20,-15, -20,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 25,  20, 15,  20,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-25, -20,-15, -20,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 25,  20, 15,  20,QPen(Qt::darkRed,2)));
   
-  Texts.push_back(Text(-10,-32, "1", Qt::darkRed, 12.0));
-  Texts.push_back(Text(  0,  8, "n", Qt::darkRed, 12.0));
+  Texts.push_back(qucs::Text(-10,-32, "1", Qt::darkRed, 12.0));
+  Texts.push_back(qucs::Text(  0,  8, "n", Qt::darkRed, 12.0));
  
-  Ports.push_back(Port(-40, 0));  // Lin
-  Ports.push_back(Port( 40, 0));  // Lout
+  Ports.push_back(qucs::Port(-40, 0));  // Lin
+  Ports.push_back(qucs::Port( 40, 0));  // Lout
 
   x1 = -40; y1 = -34;
   x2 =  40; y2 =  34;

--- a/qucs/components/DLS_nto1.cpp
+++ b/qucs/components/DLS_nto1.cpp
@@ -14,10 +14,10 @@ DLS_nto1::DLS_nto1()
 {
   Description = QObject::tr ("data voltage level shifter (analogue to digital) verilog device");
 
-  Props.push_back (Property ("LEVEL", "5 V", false,
+  Props.push_back(qucs::Property("LEVEL", "5 V", false,
     QObject::tr ("voltage level")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("time delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -47,24 +47,24 @@ Element * DLS_nto1::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void DLS_nto1::createSymbol()
 {
-  Lines.push_back(Line(-30, -30, 30,-30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 30, -30, 30, 30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 30, 30,-30, 30,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line(-30, 30, -30, -30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, -30, 30,-30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 30, -30, 30, 30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 30, 30,-30, 30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, 30, -30, -30,QPen(Qt::darkRed,2)));
  
-  Lines.push_back(Line(-30, 30, 30, -30,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-30, 30, 30, -30,QPen(Qt::darkRed,2)));
 
-  Lines.push_back(Line(-40,  0,-30,  0,QPen(Qt::darkRed,2)));  // Lin
-  Lines.push_back(Line( 30,  0, 40,  0,QPen(Qt::darkRed,2)));  // Lout
+  Lines.push_back(qucs::Line(-40,  0,-30,  0,QPen(Qt::darkRed,2)));  // Lin
+  Lines.push_back(qucs::Line( 30,  0, 40,  0,QPen(Qt::darkRed,2)));  // Lout
   
-  Lines.push_back(Line(-25, -20,-15, -20,QPen(Qt::darkRed,2)));
-  Lines.push_back(Line( 25,  20, 15,  20,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line(-25, -20,-15, -20,QPen(Qt::darkRed,2)));
+  Lines.push_back(qucs::Line( 25,  20, 15,  20,QPen(Qt::darkRed,2)));
   
-  Texts.push_back(Text(-10,-32, "n", Qt::darkRed, 12.0));
-  Texts.push_back(Text(  0,  8, "1", Qt::darkRed, 12.0));
+  Texts.push_back(qucs::Text(-10,-32, "n", Qt::darkRed, 12.0));
+  Texts.push_back(qucs::Text(  0,  8, "1", Qt::darkRed, 12.0));
  
-  Ports.push_back(Port(-40, 0));  // Lin
-  Ports.push_back(Port( 40, 0));  // Lout
+  Ports.push_back(qucs::Port(-40, 0));  // Lin
+  Ports.push_back(qucs::Port( 40, 0));  // Lout
 
 
   x1 = -40; y1 = -34;

--- a/qucs/components/EKV26MOS.cpp
+++ b/qucs/components/EKV26MOS.cpp
@@ -14,151 +14,151 @@ EKV26MOS::EKV26MOS()
 {
   Description = QObject::tr ("EPFL-EKV MOS 2.6 verilog device");
 
-  Props.push_back (Property ("Type", "nmos", true,
+  Props.push_back(qucs::Property("Type", "nmos", true,
     QObject::tr ("polarity") + " [nmos, pmos]"));
-  Props.push_back (Property ("LEVEL", "1", false,
+  Props.push_back(qucs::Property("LEVEL", "1", false,
     QObject::tr ("long = 1, short = 2")));
-  Props.push_back (Property ("L", "0.5e-6", false,
+  Props.push_back(qucs::Property("L", "0.5e-6", false,
     QObject::tr ("length parameter")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("W", "10e-6", false,
+  Props.push_back(qucs::Property("W", "10e-6", false,
     QObject::tr ("Width parameter")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Np", "1.0", false,
+  Props.push_back(qucs::Property("Np", "1.0", false,
     QObject::tr ("parallel multiple device number")));
-  Props.push_back (Property ("Ns", "1.0", false,
+  Props.push_back(qucs::Property("Ns", "1.0", false,
     QObject::tr ("series multiple device number")));
-  Props.push_back (Property ("Cox", "3.45e-3", false,
+  Props.push_back(qucs::Property("Cox", "3.45e-3", false,
     QObject::tr ("gate oxide capacitance per unit area")
     +" ("+QObject::tr ("F/m**2")+")"));
-  Props.push_back (Property ("Xj", "0.15e-6", false,
+  Props.push_back(qucs::Property("Xj", "0.15e-6", false,
     QObject::tr ("metallurgical junction depth")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Dw", "-0.02e-6", false,
+  Props.push_back(qucs::Property("Dw", "-0.02e-6", false,
     QObject::tr ("channel width correction")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Dl", "-0.05e-6", false,
+  Props.push_back(qucs::Property("Dl", "-0.05e-6", false,
     QObject::tr ("channel length correction")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Vto", "0.6", false,
+  Props.push_back(qucs::Property("Vto", "0.6", false,
     QObject::tr ("long channel threshold voltage")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Gamma", "0.71", false,
+  Props.push_back(qucs::Property("Gamma", "0.71", false,
     QObject::tr ("body effect parameter")
     +" ("+QObject::tr ("V**(1/2)")+")"));
-  Props.push_back (Property ("Phi", "0.97", false,
+  Props.push_back(qucs::Property("Phi", "0.97", false,
     QObject::tr ("bulk Fermi potential")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Kp", "150e-6", false,
+  Props.push_back(qucs::Property("Kp", "150e-6", false,
     QObject::tr ("transconductance parameter")
     +" ("+QObject::tr ("A/V**2")+")"));
-  Props.push_back (Property ("Theta", "50e-3", false,
+  Props.push_back(qucs::Property("Theta", "50e-3", false,
     QObject::tr ("mobility reduction coefficient")
     +" ("+QObject::tr ("1/V")+")"));
-  Props.push_back (Property ("EO", "88.0e6", false,
+  Props.push_back(qucs::Property("EO", "88.0e6", false,
     QObject::tr ("mobility coefficient")
     +" ("+QObject::tr ("V/m")+")"));
-  Props.push_back (Property ("Ucrit", "4.5e6", false,
+  Props.push_back(qucs::Property("Ucrit", "4.5e6", false,
     QObject::tr ("longitudinal critical field")
     +" ("+QObject::tr ("V/m")+")"));
-  Props.push_back (Property ("Lambda", "0.23", false,
+  Props.push_back(qucs::Property("Lambda", "0.23", false,
     QObject::tr ("depletion length coefficient")));
-  Props.push_back (Property ("Weta", "0.05", false,
+  Props.push_back(qucs::Property("Weta", "0.05", false,
     QObject::tr ("narrow-channel effect coefficient")));
-  Props.push_back (Property ("Leta", "0.28", false,
+  Props.push_back(qucs::Property("Leta", "0.28", false,
     QObject::tr ("longitudinal critical field")));
-  Props.push_back (Property ("Q0", "280e-6", false,
+  Props.push_back(qucs::Property("Q0", "280e-6", false,
     QObject::tr ("reverse short channel charge density")
     +" ("+QObject::tr ("A*s/m**2")+")"));
-  Props.push_back (Property ("Lk", "0.5e-6", false,
+  Props.push_back(qucs::Property("Lk", "0.5e-6", false,
     QObject::tr ("characteristic length")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Tcv", "1.5e-3", false,
+  Props.push_back(qucs::Property("Tcv", "1.5e-3", false,
     QObject::tr ("threshold voltage temperature coefficient")
     +" ("+QObject::tr ("V/K")+")"));
-  Props.push_back (Property ("Bex", "-1.5", false,
+  Props.push_back(qucs::Property("Bex", "-1.5", false,
     QObject::tr ("mobility temperature coefficient")));
-  Props.push_back (Property ("Ucex", "1.7", false,
+  Props.push_back(qucs::Property("Ucex", "1.7", false,
     QObject::tr ("Longitudinal critical field temperature exponent")));
-  Props.push_back (Property ("Ibbt", "0.0", false,
+  Props.push_back(qucs::Property("Ibbt", "0.0", false,
     QObject::tr ("Ibb temperature coefficient")
     +" ("+QObject::tr ("1/K")+")"));
-  Props.push_back (Property ("Hdif", "0.9e-6", false,
+  Props.push_back(qucs::Property("Hdif", "0.9e-6", false,
     QObject::tr ("heavily doped diffusion length")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Rsh", "510.0", false,
+  Props.push_back(qucs::Property("Rsh", "510.0", false,
     QObject::tr ("drain/source diffusion sheet resistance")
     +" ("+QObject::tr ("Ohm/square")+")"));
-  Props.push_back (Property ("Rsc", "0.0", false,
+  Props.push_back(qucs::Property("Rsc", "0.0", false,
     QObject::tr ("source contact resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Rdc", "0.0", false,
+  Props.push_back(qucs::Property("Rdc", "0.0", false,
     QObject::tr ("drain contact resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Cgso", "1.5e-10", false,
+  Props.push_back(qucs::Property("Cgso", "1.5e-10", false,
     QObject::tr ("gate to source overlap capacitance")
     +" ("+QObject::tr ("F/m")+")"));
-  Props.push_back (Property ("Cgdo", "1.5e-10", false,
+  Props.push_back(qucs::Property("Cgdo", "1.5e-10", false,
     QObject::tr ("gate to drain overlap capacitance")
     +" ("+QObject::tr ("F/m")+")"));
-  Props.push_back (Property ("Cgbo", "4.0e-10", false,
+  Props.push_back(qucs::Property("Cgbo", "4.0e-10", false,
     QObject::tr ("gate to bulk overlap capacitance")
     +" ("+QObject::tr ("F/m")+")"));
-  Props.push_back (Property ("Iba", "2e8", false,
+  Props.push_back(qucs::Property("Iba", "2e8", false,
     QObject::tr ("first impact ionization coefficient")
     +" ("+QObject::tr ("1/m")+")"));
-  Props.push_back (Property ("Ibb", "3.5e8", false,
+  Props.push_back(qucs::Property("Ibb", "3.5e8", false,
     QObject::tr ("second impact ionization coefficient")
     +" ("+QObject::tr ("V/m")+")"));
-  Props.push_back (Property ("Ibn", "1.0", false,
+  Props.push_back(qucs::Property("Ibn", "1.0", false,
     QObject::tr ("saturation voltage factor for impact ionization")));
-  Props.push_back (Property ("Kf", "1.0e-27", false,
+  Props.push_back(qucs::Property("Kf", "1.0e-27", false,
     QObject::tr ("flicker noise coefficient")));
-  Props.push_back (Property ("Af", "1.0", false,
+  Props.push_back(qucs::Property("Af", "1.0", false,
     QObject::tr ("flicker noise exponent")));
-  Props.push_back (Property ("Avto", "0.0", false,
+  Props.push_back(qucs::Property("Avto", "0.0", false,
     QObject::tr ("area related theshold voltage mismatch parameter")
     +" ("+QObject::tr ("V*m")+")"));
-  Props.push_back (Property ("Akp", "0.0", false,
+  Props.push_back(qucs::Property("Akp", "0.0", false,
     QObject::tr ("area related gain mismatch parameter")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("Agamma", "0.0", false,
+  Props.push_back(qucs::Property("Agamma", "0.0", false,
     QObject::tr ("area related body effect mismatch parameter")
     +" ("+QObject::tr ("sqrt(V)*m")+")"));
-  Props.push_back (Property ("N", "1.0", false,
+  Props.push_back(qucs::Property("N", "1.0", false,
     QObject::tr ("emission coefficient")));
-  Props.push_back (Property ("Is", "1e-14", false,
+  Props.push_back(qucs::Property("Is", "1e-14", false,
     QObject::tr ("saturation current")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Bv", "100", false,
+  Props.push_back(qucs::Property("Bv", "100", false,
     QObject::tr ("reverse breakdown voltage")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Ibv", "1e-3", false,
+  Props.push_back(qucs::Property("Ibv", "1e-3", false,
     QObject::tr ("current at reverse breakdown voltage")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Vj", "1.0", false,
+  Props.push_back(qucs::Property("Vj", "1.0", false,
     QObject::tr ("junction potential")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Cj0", "300e-15", false,
+  Props.push_back(qucs::Property("Cj0", "300e-15", false,
     QObject::tr ("zero-bias junction capacitance")
     +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("M", "0.5", false,
+  Props.push_back(qucs::Property("M", "0.5", false,
     QObject::tr ("grading coefficient")));
-  Props.push_back (Property ("Area", "1.0", false,
+  Props.push_back(qucs::Property("Area", "1.0", false,
     QObject::tr ("diode relative area")));
-  Props.push_back (Property ("Fc", "0.5", false,
+  Props.push_back(qucs::Property("Fc", "0.5", false,
     QObject::tr ("forward-bias depletion capacitance coefficient")));
-  Props.push_back (Property ("Tt", "0.1e-9", false,
+  Props.push_back(qucs::Property("Tt", "0.1e-9", false,
     QObject::tr ("transit time")
     +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Xti", "3.0", false,
+  Props.push_back(qucs::Property("Xti", "3.0", false,
     QObject::tr ("saturation current temperature exponent")));
-  Props.push_back (Property ("Xpart", "0.4", false,
+  Props.push_back(qucs::Property("Xpart", "0.4", false,
     QObject::tr ("charge partition parameter")));
-  Props.push_back (Property ("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
     QObject::tr ("parameter measurement temperature")
     +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
     QObject::tr ("simulation temperature")));
 
   createSymbol ();
@@ -222,49 +222,49 @@ Element * EKV26MOS::info_pmos(QString& Name, char * &BitmapFile, bool getNewOne)
 void EKV26MOS::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 11,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  0, 20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 11,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  0, 20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
   
-  Lines.push_back(Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
 
   // arrow
   if(getProperty("Type").Value == "nmos") {
-    Lines.push_back(Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
   } else {
-    Lines.push_back(Line( -5,  5,  0,   0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -5,  -5, 0,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5,  5,  0,   0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5,  -5, 0,  0,QPen(Qt::darkBlue,2)));
   }
   
-  Lines.push_back(Line(-10, -3,-10,  3,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-10, -8,-10, -6,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-10,  8,-10,  6,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10, -3,-10,  3,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10, -8,-10, -6,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10,  8,-10,  6,QPen(Qt::darkBlue,3)));
 
   // E
-  Lines.push_back(Line(-30,-30,-30,-24,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-30,-30,-26,-30,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-30,-27,-26,-27,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-30,-24,-26,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,-30,-30,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,-30,-26,-30,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,-27,-26,-27,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,-24,-26,-24,QPen(Qt::darkBlue,1)));
   // K
-  Lines.push_back(Line(-24,-30,-24,-24,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-24,-27,-20,-30,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-24,-27,-20,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-24,-30,-24,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-24,-27,-20,-30,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-24,-27,-20,-24,QPen(Qt::darkBlue,1)));
   // V
-  Lines.push_back(Line(-18,-30,-16,-24,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-14,-30,-16,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-18,-30,-16,-24,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-14,-30,-16,-24,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(  0,-30)); // drain
-  Ports.push_back(Port(-30,  0)); // gate
-  Ports.push_back(Port(  0, 30)); // source
-  Ports.push_back(Port( 20,  0)); // bulk
+  Ports.push_back(qucs::Port(  0,-30)); // drain
+  Ports.push_back(qucs::Port(-30,  0)); // gate
+  Ports.push_back(qucs::Port(  0, 30)); // source
+  Ports.push_back(qucs::Port( 20,  0)); // bulk
 
   x1 = -30; y1 = -30;
   x2 =  20; y2 =  30;

--- a/qucs/components/MESFET.cpp
+++ b/qucs/components/MESFET.cpp
@@ -12,143 +12,143 @@
 
 MESFET::MESFET()
 {
-  Description = QObject::tr ("MESFET verilog device");
+  Description = QObject::tr("MESFET verilog device");
 
-  Props.push_back (Property ("LEVEL", "1", false,
-    QObject::tr ("model selector")));
-  Props.push_back (Property ("Vto", "-1.8", false,
-    QObject::tr ("pinch-off voltage")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Beta", "3e-3", false,
-    QObject::tr ("transconductance parameter")
-    +" ("+QObject::tr ("A/(V*V)")+")"));
-  Props.push_back (Property ("Alpha", "2.25", false,
-    QObject::tr ("saturation voltage parameter")
-    +" ("+QObject::tr ("1/V")+")"));
-  Props.push_back (Property ("Lambda", "0.05", false,
-    QObject::tr ("channel length modulation parameter")
-    +" ("+QObject::tr ("1/V")+")"));
-  Props.push_back (Property ("B", "0.3", false,
-    QObject::tr ("doping profile parameter")
-    +" ("+QObject::tr ("1/V")+")"));
-  Props.push_back (Property ("Qp", "2.1", false,
-    QObject::tr ("power law exponent parameter")));
-  Props.push_back (Property ("Delta", "0.1", false,
-    QObject::tr ("power feedback parameter")
-    +" ("+QObject::tr ("1/W")+")"));
-  Props.push_back (Property ("Vmax", "0.5", false,
-    QObject::tr ("maximum junction voltage limit before capacitance limiting")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Vdelta1", "0.3", false,
-    QObject::tr ("capacitance saturation transition voltage")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Vdelta2", "0.2", false,
-    QObject::tr ("capacitance threshold transition voltage")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Gamma", "0.015", false,
-    QObject::tr ("dc drain pull coefficient")));
-  Props.push_back (Property ("Nsc", "1", false,
-    QObject::tr ("subthreshold conductance parameter")));
-  Props.push_back (Property ("Is", "1e-14", false,
-    QObject::tr ("diode saturation current")
-    +" ("+QObject::tr ("I")+")"));
-  Props.push_back (Property ("N", "1", false,
-    QObject::tr ("diode emission coefficient")));
-  Props.push_back (Property ("Vbi", "1.0", false,
-    QObject::tr ("built-in gate potential")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Bv", "60", false,
-    QObject::tr ("gate-drain junction reverse bias breakdown voltage")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Xti", "3.0", false,
-    QObject::tr ("diode saturation current temperature coefficient")));
-  Props.push_back (Property ("Fc", "0.5", false,
-    QObject::tr ("forward-bias depletion capacitance coefficient")));
-  Props.push_back (Property ("Tau", "1e-9", false,
-    QObject::tr ("transit time under gate")
-    +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Rin", "1e-3", false,
-    QObject::tr ("channel resistance")
-    +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Area", "1", false,
-    QObject::tr ("area factor")));
-  Props.push_back (Property ("Eg", "1.11", false,
-    QObject::tr ("energy gap")
-    +" ("+QObject::tr ("eV")+")"));
-  Props.push_back (Property ("M", "0.5", false,
-    QObject::tr ("grading coefficient")));
-  Props.push_back (Property ("Cgd", "0.2e-12", false,
-    QObject::tr ("zero bias gate-drain junction capacitance")
-    +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("Cgs", "1e-12", false,
-    QObject::tr ("zero bias gate-source junction capacitance")
-    +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("Cds", "1e-12", false,
-    QObject::tr ("zero bias drain-source junction capacitance")
-    +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("Betatc", "0", false,
-    QObject::tr ("Beta temperature coefficient")
-    +" ("+QObject::tr ("%/Celsius")+")"));
-  Props.push_back (Property ("Alphatc", "0", false,
-    QObject::tr ("Alpha temperature coefficient")
-    +" ("+QObject::tr ("%/Celsius")+")"));
-  Props.push_back (Property ("Gammatc", "0", false,
-    QObject::tr ("Gamma temperature coefficient")
-    +" ("+QObject::tr ("%/Celsius")+")"));
-  Props.push_back (Property ("Ng", "2.65", false,
-    QObject::tr ("Subthreshold slope gate parameter")));
-  Props.push_back (Property ("Nd", "-0.19", false,
-    QObject::tr ("subthreshold drain pull parameter")));
-  Props.push_back (Property ("ILEVELS", "3", false,
-    QObject::tr ("gate-source current equation selector")));
-  Props.push_back (Property ("ILEVELD", "3", false,
-    QObject::tr ("gate-drain current equation selector")));
-  Props.push_back (Property ("QLEVELS", "2", false,
-    QObject::tr ("gate-source charge equation selector")));
-  Props.push_back (Property ("QLEVELD", "2", false,
-    QObject::tr ("gate-drain charge equation selector")));
-  Props.push_back (Property ("QLEVELDS", "2", false,
-    QObject::tr ("drain-source charge equation selector")));
-  Props.push_back (Property ("Vtotc", "0", false,
-    QObject::tr ("Vto temperature coefficient")));
-  Props.push_back (Property ("Rg", "5.1", false,
-    QObject::tr ("gate resistance")
-    +" ("+QObject::tr ("Ohms")+")"));
-  Props.push_back (Property ("Rd", "1.3", false,
-    QObject::tr ("drain resistance")
-    +" ("+QObject::tr ("Ohms")+")"));
-  Props.push_back (Property ("Rs", "1.3", false,
-    QObject::tr ("source resistance")
-    +" ("+QObject::tr ("Ohms")+")"));
-  Props.push_back (Property ("Rgtc", "0", false,
-    QObject::tr ("gate resistance temperature coefficient")
-    +" ("+QObject::tr ("1/Celsius")+")"));
-  Props.push_back (Property ("Rdtc", "0", false,
-    QObject::tr ("drain resistance temperature coefficient")
-    +" ("+QObject::tr ("1/Celsius")+")"));
-  Props.push_back (Property ("Rstc", "0", false,
-    QObject::tr ("source resistance temperature coefficient")
-    +" ("+QObject::tr ("1/Celsius")+")"));
-  Props.push_back (Property ("Ibv", "1e-3", false,
-    QObject::tr ("gate reverse breakdown currrent")
-    +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Rf", "10", false,
-    QObject::tr ("forward bias slope resistance")
-    +" ("+QObject::tr ("Ohms")+")"));
-  Props.push_back (Property ("R1", "10", false,
-    QObject::tr ("breakdown slope resistance")
-    +" ("+QObject::tr ("Ohms")+")"));
-  Props.push_back (Property ("Af", "1", false,
-    QObject::tr ("flicker noise exponent")));
-  Props.push_back (Property ("Kf", "0", false,
-    QObject::tr ("flicker noise coefficient")));
-  Props.push_back (Property ("Gdsnoi", "1", false,
-    QObject::tr ("shot noise coefficient")));
-  Props.push_back (Property ("Tnom", "26.85", false,
-    QObject::tr ("parameter measurement temperature")
-    +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Temp", "26.85", false,
-    QObject::tr ("simulation temperature")));
+  Props.push_back(qucs::Property("LEVEL", "1", false,
+    QObject::tr("model selector")));
+  Props.push_back(qucs::Property("Vto", "-1.8", false,
+    QObject::tr("pinch-off voltage")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Beta", "3e-3", false,
+    QObject::tr("transconductance parameter")
+    +" ("+QObject::tr("A/(V*V)")+")"));
+  Props.push_back(qucs::Property("Alpha", "2.25", false,
+    QObject::tr("saturation voltage parameter")
+    +" ("+QObject::tr("1/V")+")"));
+  Props.push_back(qucs::Property("Lambda", "0.05", false,
+    QObject::tr("channel length modulation parameter")
+    +" ("+QObject::tr("1/V")+")"));
+  Props.push_back(qucs::Property("B", "0.3", false,
+    QObject::tr("doping profile parameter")
+    +" ("+QObject::tr("1/V")+")"));
+  Props.push_back(qucs::Property("Qp", "2.1", false,
+    QObject::tr("power law exponent parameter")));
+  Props.push_back(qucs::Property("Delta", "0.1", false,
+    QObject::tr("power feedback parameter")
+    +" ("+QObject::tr("1/W")+")"));
+  Props.push_back(qucs::Property("Vmax", "0.5", false,
+    QObject::tr("maximum junction voltage limit before capacitance limiting")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Vdelta1", "0.3", false,
+    QObject::tr("capacitance saturation transition voltage")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Vdelta2", "0.2", false,
+    QObject::tr("capacitance threshold transition voltage")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Gamma", "0.015", false,
+    QObject::tr("dc drain pull coefficient")));
+  Props.push_back(qucs::Property("Nsc", "1", false,
+    QObject::tr("subthreshold conductance parameter")));
+  Props.push_back(qucs::Property("Is", "1e-14", false,
+    QObject::tr("diode saturation current")
+    +" ("+QObject::tr("I")+")"));
+  Props.push_back(qucs::Property("N", "1", false,
+    QObject::tr("diode emission coefficient")));
+  Props.push_back(qucs::Property("Vbi", "1.0", false,
+    QObject::tr("built-in gate potential")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Bv", "60", false,
+    QObject::tr("gate-drain junction reverse bias breakdown voltage")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Xti", "3.0", false,
+    QObject::tr("diode saturation current temperature coefficient")));
+  Props.push_back(qucs::Property("Fc", "0.5", false,
+    QObject::tr("forward-bias depletion capacitance coefficient")));
+  Props.push_back(qucs::Property("Tau", "1e-9", false,
+    QObject::tr("transit time under gate")
+    +" ("+QObject::tr("s")+")"));
+  Props.push_back(qucs::Property("Rin", "1e-3", false,
+    QObject::tr("channel resistance")
+    +" ("+QObject::tr("Ohm")+")"));
+  Props.push_back(qucs::Property("Area", "1", false,
+    QObject::tr("area factor")));
+  Props.push_back(qucs::Property("Eg", "1.11", false,
+    QObject::tr("energy gap")
+    +" ("+QObject::tr("eV")+")"));
+  Props.push_back(qucs::Property("M", "0.5", false,
+    QObject::tr("grading coefficient")));
+  Props.push_back(qucs::Property("Cgd", "0.2e-12", false,
+    QObject::tr("zero bias gate-drain junction capacitance")
+    +" ("+QObject::tr("F")+")"));
+  Props.push_back(qucs::Property("Cgs", "1e-12", false,
+    QObject::tr("zero bias gate-source junction capacitance")
+    +" ("+QObject::tr("F")+")"));
+  Props.push_back(qucs::Property("Cds", "1e-12", false,
+    QObject::tr("zero bias drain-source junction capacitance")
+    +" ("+QObject::tr("F")+")"));
+  Props.push_back(qucs::Property("Betatc", "0", false,
+    QObject::tr("Beta temperature coefficient")
+    +" ("+QObject::tr("%/Celsius")+")"));
+  Props.push_back(qucs::Property("Alphatc", "0", false,
+    QObject::tr("Alpha temperature coefficient")
+    +" ("+QObject::tr("%/Celsius")+")"));
+  Props.push_back(qucs::Property("Gammatc", "0", false,
+    QObject::tr("Gamma temperature coefficient")
+    +" ("+QObject::tr("%/Celsius")+")"));
+  Props.push_back(qucs::Property("Ng", "2.65", false,
+    QObject::tr("Subthreshold slope gate parameter")));
+  Props.push_back(qucs::Property("Nd", "-0.19", false,
+    QObject::tr("subthreshold drain pull parameter")));
+  Props.push_back(qucs::Property("ILEVELS", "3", false,
+    QObject::tr("gate-source current equation selector")));
+  Props.push_back(qucs::Property("ILEVELD", "3", false,
+    QObject::tr("gate-drain current equation selector")));
+  Props.push_back(qucs::Property("QLEVELS", "2", false,
+    QObject::tr("gate-source charge equation selector")));
+  Props.push_back(qucs::Property("QLEVELD", "2", false,
+    QObject::tr("gate-drain charge equation selector")));
+  Props.push_back(qucs::Property("QLEVELDS", "2", false,
+    QObject::tr("drain-source charge equation selector")));
+  Props.push_back(qucs::Property("Vtotc", "0", false,
+    QObject::tr("Vto temperature coefficient")));
+  Props.push_back(qucs::Property("Rg", "5.1", false,
+    QObject::tr("gate resistance")
+    +" ("+QObject::tr("Ohms")+")"));
+  Props.push_back(qucs::Property("Rd", "1.3", false,
+    QObject::tr("drain resistance")
+    +" ("+QObject::tr("Ohms")+")"));
+  Props.push_back(qucs::Property("Rs", "1.3", false,
+    QObject::tr("source resistance")
+    +" ("+QObject::tr("Ohms")+")"));
+  Props.push_back(qucs::Property("Rgtc", "0", false,
+    QObject::tr("gate resistance temperature coefficient")
+    +" ("+QObject::tr("1/Celsius")+")"));
+  Props.push_back(qucs::Property("Rdtc", "0", false,
+    QObject::tr("drain resistance temperature coefficient")
+    +" ("+QObject::tr("1/Celsius")+")"));
+  Props.push_back(qucs::Property("Rstc", "0", false,
+    QObject::tr("source resistance temperature coefficient")
+    +" ("+QObject::tr("1/Celsius")+")"));
+  Props.push_back(qucs::Property("Ibv", "1e-3", false,
+    QObject::tr("gate reverse breakdown currrent")
+    +" ("+QObject::tr("A")+")"));
+  Props.push_back(qucs::Property("Rf", "10", false,
+    QObject::tr("forward bias slope resistance")
+    +" ("+QObject::tr("Ohms")+")"));
+  Props.push_back(qucs::Property("R1", "10", false,
+    QObject::tr("breakdown slope resistance")
+    +" ("+QObject::tr("Ohms")+")"));
+  Props.push_back(qucs::Property("Af", "1", false,
+    QObject::tr("flicker noise exponent")));
+  Props.push_back(qucs::Property("Kf", "0", false,
+    QObject::tr("flicker noise coefficient")));
+  Props.push_back(qucs::Property("Gdsnoi", "1", false,
+    QObject::tr("shot noise coefficient")));
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
+    QObject::tr("parameter measurement temperature")
+    +" ("+QObject::tr("Celsius")+")"));
+  Props.push_back(qucs::Property("Temp", "26.85", false,
+    QObject::tr("simulation temperature")));
 
   createSymbol ();
   tx = x2 + 4;
@@ -177,18 +177,18 @@ Element * MESFET::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void MESFET::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-10,  0,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-10,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,  0, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 10,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-10,  0,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-10,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,  0, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 10,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -30;
   x2 =   4; y2 =  30;

--- a/qucs/components/ac_sim.cpp
+++ b/qucs/components/ac_sim.cpp
@@ -31,9 +31,9 @@ AC_Sim::AC_Sim()
   if (a < 8 || s.length() - b < 8) b = -1;
   if (b != -1) s[b] = '\n';
 
-  Texts.push_back(Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
   if (b != -1)
-    Texts.push_back(Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+128; y2 = y1+41;
@@ -44,15 +44,15 @@ AC_Sim::AC_Sim()
   Name  = "AC";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.push_back(Property("Type", "lin", true,
+  Props.push_back(qucs::Property("Type", "lin", true,
 			QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.push_back(Property("Start", "1 GHz", true,
+  Props.push_back(qucs::Property("Start", "1 GHz", true,
 			QObject::tr("start frequency in Hertz")));
-  Props.push_back(Property("Stop", "10 GHz", true,
+  Props.push_back(qucs::Property("Stop", "10 GHz", true,
 			QObject::tr("stop frequency in Hertz")));
-  Props.push_back(Property("Points", "19", true,
+  Props.push_back(qucs::Property("Points", "19", true,
 			QObject::tr("number of simulation steps")));
-  Props.push_back(Property("Noise", "no", false,
+  Props.push_back(qucs::Property("Noise", "no", false,
 			QObject::tr("calculate noise voltages")+
 			" [yes, no]"));
 }
@@ -77,7 +77,7 @@ Element* AC_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 void AC_Sim::recreate(Schematic*)
 {
-  Property &pp = Props.front();
+  qucs::Property &pp = Props.front();
   if((pp.Value == "list") || (pp.Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.
     prop(1).Name = "Symbol";

--- a/qucs/components/am_modulator.cpp
+++ b/qucs/components/am_modulator.cpp
@@ -22,23 +22,23 @@ AM_Modulator::AM_Modulator()
 {
   Description = QObject::tr("ac voltage source with amplitude modulator");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,-18, 11,-18,QPen(Qt::red,1)));
-  Lines.push_back(Line(  8,-21,  8,-15,QPen(Qt::red,1)));
-  Lines.push_back(Line(  5, 18, 11, 18,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,-18, 11,-18,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(  8,-21,  8,-15,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(  5, 18, 11, 18,QPen(Qt::black,1)));
 
-  Lines.push_back(Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text(-30,-22, QObject::tr("AM"), Qt::black, 10.0,1.0,0.0));
+  Lines.push_back(qucs::Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text(-30,-22, QObject::tr("AM"), Qt::black, 10.0,1.0,0.0));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -30;
   x2 =  14; y2 =  30;
@@ -48,13 +48,13 @@ AM_Modulator::AM_Modulator()
   Model = "AM_Mod";
   Name  = "V";
 
-  Props.push_back(Property("U", "1 V", true,
+  Props.push_back(qucs::Property("U", "1 V", true,
 		QObject::tr("peak voltage in Volts")));
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("Phase", "0", false,
+  Props.push_back(qucs::Property("Phase", "0", false,
 		QObject::tr("initial phase in degrees")));
-  Props.push_back(Property("m", "1.0", false,
+  Props.push_back(qucs::Property("m", "1.0", false,
 		QObject::tr("modulation level")));
 }
 

--- a/qucs/components/ampere_ac.cpp
+++ b/qucs/components/ampere_ac.cpp
@@ -22,17 +22,17 @@ Ampere_ac::Ampere_ac()
 {
   Description = QObject::tr("ideal ac current source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
-  Arcs.push_back(Arc( 12,  5,  6,  6,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 12, 11,  6,  6, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc( 12,  5,  6,  6,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 12, 11,  6,  6, 16*90, 16*180,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  16;
@@ -42,13 +42,13 @@ Ampere_ac::Ampere_ac()
   Model = "Iac";
   Name  = "I";
 
-  Props.push_back(Property("I", "1 mA", true,
+  Props.push_back(qucs::Property("I", "1 mA", true,
 		QObject::tr("peak current in Ampere")));
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("Phase", "0", false,
+  Props.push_back(qucs::Property("Phase", "0", false,
 		QObject::tr("initial phase in degrees")));
-  Props.push_back(Property("Theta", "0", false,
+  Props.push_back(qucs::Property("Theta", "0", false,
 		QObject::tr("damping factor (transient simulation only)")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/ampere_dc.cpp
+++ b/qucs/components/ampere_dc.cpp
@@ -22,15 +22,15 @@ Ampere_dc::Ampere_dc()
 {
   Description = QObject::tr("ideal dc current source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -40,7 +40,7 @@ Ampere_dc::Ampere_dc()
   Model = "Idc";
   Name  = "I";
 
-  Props.push_back(Property("I", "1 mA", true,
+  Props.push_back(qucs::Property("I", "1 mA", true,
 		QObject::tr("current in Ampere")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/ampere_noise.cpp
+++ b/qucs/components/ampere_noise.cpp
@@ -22,22 +22,22 @@ Ampere_noise::Ampere_noise()
 {
   Description = QObject::tr("noise current source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  6, -7,  3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  3, -7,  6,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7, 10, -2,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, -4, 10, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -1, 12, 12, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  6, -7,  3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  3, -7,  6,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7, 10, -2,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, -4, 10, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -1, 12, 12, -1,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -15;
   x2 =  30; y2 =  15;
@@ -47,13 +47,13 @@ Ampere_noise::Ampere_noise()
   Model = "Inoise";
   Name  = "I";
 
-  Props.push_back(Property("i", "1e-6", true,
+  Props.push_back(qucs::Property("i", "1e-6", true,
 		QObject::tr("current power spectral density in A^2/Hz")));
-  Props.push_back(Property("e", "0", false,
+  Props.push_back(qucs::Property("e", "0", false,
 		QObject::tr("frequency exponent")));
-  Props.push_back(Property("c", "1", false,
+  Props.push_back(qucs::Property("c", "1", false,
 		QObject::tr("frequency coefficient")));
-  Props.push_back(Property("a", "0", false,
+  Props.push_back(qucs::Property("a", "0", false,
 		QObject::tr("additive frequency term")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/amplifier.cpp
+++ b/qucs/components/amplifier.cpp
@@ -22,15 +22,15 @@ Amplifier::Amplifier()
 {
   Description = QObject::tr("ideal amplifier");
 
-  Lines.push_back(Line(-16,-20,-16, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-20, 16,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, 20, 16,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-20,-16, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-20, 16,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, 20, 16,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-16,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-16,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -23;
   x2 =  30; y2 =  23;
@@ -40,13 +40,13 @@ Amplifier::Amplifier()
   Model = "Amp";
   Name  = "X";
 
-  Props.push_back(Property("G", "10", true,
+  Props.push_back(qucs::Property("G", "10", true,
 		QObject::tr("voltage gain")));
-  Props.push_back(Property("Z1", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z1", "50 Ohm", false,
 		QObject::tr("reference impedance of input port")));
-  Props.push_back(Property("Z2", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z2", "50 Ohm", false,
 		QObject::tr("reference impedance of output port")));
-  Props.push_back(Property("NF", "0 dB", false,
+  Props.push_back(qucs::Property("NF", "0 dB", false,
 		QObject::tr("noise figure")));
 }
 

--- a/qucs/components/andor4x2.cpp
+++ b/qucs/components/andor4x2.cpp
@@ -24,9 +24,9 @@ andor4x2::andor4x2()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4x2 andor verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,48 +56,48 @@ Element * andor4x2::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void andor4x2::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  60,-30, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  60,-30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  60,-30, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  60,-30,-60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30, -30,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,   0,  0,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  30,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -60,  0, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -30,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,   0,  0,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  30,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -60,  0, 60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
-  Lines.push_back(Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));   //A21
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));   //A22
+  Lines.push_back(qucs::Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
+  Lines.push_back(qucs::Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));   //A21
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));   //A22
 
-  Lines.push_back(Line(-50, 10, -30, 10,QPen(Qt::darkBlue,2)));  //A31
-  Lines.push_back(Line(-50, 20, -30, 20,QPen(Qt::darkBlue,2)));  //A32
-  Lines.push_back(Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2)));  //A41
-  Lines.push_back(Line(-50, 50, -30, 50,QPen(Qt::darkBlue,2)));  //A42
-  Lines.push_back(Line( 30,  0,  50,  0,QPen(Qt::darkBlue,2)));  //Y
+  Lines.push_back(qucs::Line(-50, 10, -30, 10,QPen(Qt::darkBlue,2)));  //A31
+  Lines.push_back(qucs::Line(-50, 20, -30, 20,QPen(Qt::darkBlue,2)));  //A32
+  Lines.push_back(qucs::Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2)));  //A41
+  Lines.push_back(qucs::Line(-50, 50, -30, 50,QPen(Qt::darkBlue,2)));  //A42
+  Lines.push_back(qucs::Line( 30,  0,  50,  0,QPen(Qt::darkBlue,2)));  //Y
 
-  Texts.push_back(Text( -20, -60, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20, -30, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,   0, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,  30, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -60, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -30, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,   0, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,  30, "&", Qt::darkBlue, 12.0));
  
-  Lines.push_back(Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
 
 
-  Ports.push_back(Port(-50,-50));  // A11
-  Ports.push_back(Port(-50,-40));  // A12
-  Ports.push_back(Port(-50,-20));  // A21
-  Ports.push_back(Port(-50,-10));  // A22
-  Ports.push_back(Port(-50, 10));  // A31
-  Ports.push_back(Port(-50, 20));  // A32
-  Ports.push_back(Port(-50, 40));  // A41
-  Ports.push_back(Port(-50, 50));  // A42
+  Ports.push_back(qucs::Port(-50,-50));  // A11
+  Ports.push_back(qucs::Port(-50,-40));  // A12
+  Ports.push_back(qucs::Port(-50,-20));  // A21
+  Ports.push_back(qucs::Port(-50,-10));  // A22
+  Ports.push_back(qucs::Port(-50, 10));  // A31
+  Ports.push_back(qucs::Port(-50, 20));  // A32
+  Ports.push_back(qucs::Port(-50, 40));  // A41
+  Ports.push_back(qucs::Port(-50, 50));  // A42
 
-  Ports.push_back(Port( 50, 0 )); // Y
+  Ports.push_back(qucs::Port( 50, 0 )); // Y
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  64;

--- a/qucs/components/andor4x3.cpp
+++ b/qucs/components/andor4x3.cpp
@@ -24,9 +24,9 @@ andor4x3::andor4x3()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4x3 andor verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,61 +56,61 @@ Element * andor4x3::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void andor4x3::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  100,-30,100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  100,-30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  100,-30,100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  100,-30,-60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30, -20,  0,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  20,  0, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  60,  0, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -60,  0,100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -20,  0,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  20,  0, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  60,  0, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -60,  0,100,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
-  Lines.push_back(Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));   //A13
+  Lines.push_back(qucs::Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
+  Lines.push_back(qucs::Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));   //A13
 
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));   //A21
-  Lines.push_back(Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));   //A22
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));   //A23
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));   //A21
+  Lines.push_back(qucs::Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));   //A22
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));   //A23
 
-  Lines.push_back(Line(-50, 30, -30, 30,QPen(Qt::darkBlue,2)));  //A31
-  Lines.push_back(Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2)));  //A32
-  Lines.push_back(Line(-50, 50,-30,  50,QPen(Qt::darkBlue,2)));   //A33
+  Lines.push_back(qucs::Line(-50, 30, -30, 30,QPen(Qt::darkBlue,2)));  //A31
+  Lines.push_back(qucs::Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2)));  //A32
+  Lines.push_back(qucs::Line(-50, 50,-30,  50,QPen(Qt::darkBlue,2)));   //A33
 
-  Lines.push_back(Line(-50, 70, -30, 70,QPen(Qt::darkBlue,2)));  //A41
-  Lines.push_back(Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2)));  //A42
-  Lines.push_back(Line(-50, 90,-30,  90,QPen(Qt::darkBlue,2)));   //A43
+  Lines.push_back(qucs::Line(-50, 70, -30, 70,QPen(Qt::darkBlue,2)));  //A41
+  Lines.push_back(qucs::Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2)));  //A42
+  Lines.push_back(qucs::Line(-50, 90,-30,  90,QPen(Qt::darkBlue,2)));   //A43
 
-  Lines.push_back(Line( 30,  20, 50, 20,QPen(Qt::darkBlue,2)));  //Y
+  Lines.push_back(qucs::Line( 30,  20, 50, 20,QPen(Qt::darkBlue,2)));  //Y
 
-  Texts.push_back(Text( -20, -60, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20, -20, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,  20, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,  60, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -60, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -20, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,  20, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,  60, "&", Qt::darkBlue, 12.0));
  
-  Lines.push_back(Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
 
-  Ports.push_back(Port(-50,-50));  // A11
-  Ports.push_back(Port(-50,-40));  // A12
-  Ports.push_back(Port(-50,-30));  // A13
+  Ports.push_back(qucs::Port(-50,-50));  // A11
+  Ports.push_back(qucs::Port(-50,-40));  // A12
+  Ports.push_back(qucs::Port(-50,-30));  // A13
 
-  Ports.push_back(Port(-50,-10));  // A21
-  Ports.push_back(Port(-50,  0));  // A22
-  Ports.push_back(Port(-50, 10));  // A23
+  Ports.push_back(qucs::Port(-50,-10));  // A21
+  Ports.push_back(qucs::Port(-50,  0));  // A22
+  Ports.push_back(qucs::Port(-50, 10));  // A23
 
-  Ports.push_back(Port(-50, 30));  // A31
-  Ports.push_back(Port(-50, 40));  // A32
-  Ports.push_back(Port(-50, 50));  // A33
+  Ports.push_back(qucs::Port(-50, 30));  // A31
+  Ports.push_back(qucs::Port(-50, 40));  // A32
+  Ports.push_back(qucs::Port(-50, 50));  // A33
 
-  Ports.push_back(Port(-50, 70));  // A41
-  Ports.push_back(Port(-50, 80));  // A42
-  Ports.push_back(Port(-50, 90));  // A43
+  Ports.push_back(qucs::Port(-50, 70));  // A41
+  Ports.push_back(qucs::Port(-50, 80));  // A42
+  Ports.push_back(qucs::Port(-50, 90));  // A43
 
-  Ports.push_back(Port( 50, 20));  // Y
+  Ports.push_back(qucs::Port( 50, 20));  // Y
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  104;

--- a/qucs/components/andor4x4.cpp
+++ b/qucs/components/andor4x4.cpp
@@ -24,9 +24,9 @@ andor4x4::andor4x4()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4x4 andor verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,69 +56,69 @@ Element * andor4x4::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void andor4x4::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 140,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  140,-30,140,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  140,-30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 140,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  140,-30,140,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  140,-30,-60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30, -10,  0,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  40,  0, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  90,  0, 90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -60,  0,140,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -10,  0,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  40,  0, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  90,  0, 90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -60,  0,140,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
-  Lines.push_back(Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));   //A13
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));   //A14
+  Lines.push_back(qucs::Line(-50,-50,-30,-50,QPen(Qt::darkBlue,2)));   //A11
+  Lines.push_back(qucs::Line(-50,-40,-30,-40,QPen(Qt::darkBlue,2)));   //A12
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));   //A13
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));   //A14
 
-  Lines.push_back(Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));   //A21
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));   //A22
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));   //A23
-  Lines.push_back(Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));   //A24
+  Lines.push_back(qucs::Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));   //A21
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));   //A22
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));   //A23
+  Lines.push_back(qucs::Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));   //A24
 
-  Lines.push_back(Line(-50, 50, -30, 50,QPen(Qt::darkBlue,2)));  //A31
-  Lines.push_back(Line(-50, 60, -30, 60,QPen(Qt::darkBlue,2)));  //A32
-  Lines.push_back(Line(-50, 70,-30,  70,QPen(Qt::darkBlue,2)));  //A33
-  Lines.push_back(Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2)));   //A34
+  Lines.push_back(qucs::Line(-50, 50, -30, 50,QPen(Qt::darkBlue,2)));  //A31
+  Lines.push_back(qucs::Line(-50, 60, -30, 60,QPen(Qt::darkBlue,2)));  //A32
+  Lines.push_back(qucs::Line(-50, 70,-30,  70,QPen(Qt::darkBlue,2)));  //A33
+  Lines.push_back(qucs::Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2)));   //A34
 
-  Lines.push_back(Line(-50, 100,-30,100,QPen(Qt::darkBlue,2)));  //A41
-  Lines.push_back(Line(-50, 110,-30,110,QPen(Qt::darkBlue,2)));  //A42
-  Lines.push_back(Line(-50, 120,-30,120,QPen(Qt::darkBlue,2)));  //A43
-  Lines.push_back(Line(-50, 130,-30,130,QPen(Qt::darkBlue,2)));  //A44
+  Lines.push_back(qucs::Line(-50, 100,-30,100,QPen(Qt::darkBlue,2)));  //A41
+  Lines.push_back(qucs::Line(-50, 110,-30,110,QPen(Qt::darkBlue,2)));  //A42
+  Lines.push_back(qucs::Line(-50, 120,-30,120,QPen(Qt::darkBlue,2)));  //A43
+  Lines.push_back(qucs::Line(-50, 130,-30,130,QPen(Qt::darkBlue,2)));  //A44
 
-  Lines.push_back(Line( 30,  40, 50, 40,QPen(Qt::darkBlue,2)));  //Y
+  Lines.push_back(qucs::Line( 30,  40, 50, 40,QPen(Qt::darkBlue,2)));  //Y
 
-  Texts.push_back(Text( -20, -60, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20, -10, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,  40, "&", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -20,  90, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -60, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20, -10, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,  40, "&", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -20,  90, "&", Qt::darkBlue, 12.0));
  
-  Lines.push_back(Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
-  Lines.push_back(Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line(  7, -45, 17, -40,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line(  7, -35, 17, -40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, -30, 17, -35,QPen(Qt::darkBlue,2))); 
+  Lines.push_back(qucs::Line( 22, -30, 22, -45,QPen(Qt::darkBlue,2)));  
 
-  Ports.push_back(Port(-50,-50));  // A11
-  Ports.push_back(Port(-50,-40));  // A12
-  Ports.push_back(Port(-50,-30));  // A13
-  Ports.push_back(Port(-50,-20));  // A14
+  Ports.push_back(qucs::Port(-50,-50));  // A11
+  Ports.push_back(qucs::Port(-50,-40));  // A12
+  Ports.push_back(qucs::Port(-50,-30));  // A13
+  Ports.push_back(qucs::Port(-50,-20));  // A14
 
-  Ports.push_back(Port(-50,  0));  // A21
-  Ports.push_back(Port(-50, 10));  // A22
-  Ports.push_back(Port(-50, 20));  // A23
-  Ports.push_back(Port(-50, 30));  // A24
+  Ports.push_back(qucs::Port(-50,  0));  // A21
+  Ports.push_back(qucs::Port(-50, 10));  // A22
+  Ports.push_back(qucs::Port(-50, 20));  // A23
+  Ports.push_back(qucs::Port(-50, 30));  // A24
 
-  Ports.push_back(Port(-50, 50));  // A31
-  Ports.push_back(Port(-50, 60));  // A32
-  Ports.push_back(Port(-50, 70));  // A33
-  Ports.push_back(Port(-50, 80));  // A34
+  Ports.push_back(qucs::Port(-50, 50));  // A31
+  Ports.push_back(qucs::Port(-50, 60));  // A32
+  Ports.push_back(qucs::Port(-50, 70));  // A33
+  Ports.push_back(qucs::Port(-50, 80));  // A34
 
-  Ports.push_back(Port(-50,100));  // A41
-  Ports.push_back(Port(-50,110));  // A42
-  Ports.push_back(Port(-50,120));  // A43
-  Ports.push_back(Port(-50,130));  // A44
+  Ports.push_back(qucs::Port(-50,100));  // A41
+  Ports.push_back(qucs::Port(-50,110));  // A42
+  Ports.push_back(qucs::Port(-50,120));  // A43
+  Ports.push_back(qucs::Port(-50,130));  // A44
 
-  Ports.push_back(Port( 50, 40));  // Y
+  Ports.push_back(qucs::Port( 50, 40));  // Y
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 = 144;

--- a/qucs/components/attenuator.cpp
+++ b/qucs/components/attenuator.cpp
@@ -22,23 +22,23 @@ Attenuator::Attenuator()
 {
   Description = QObject::tr("attenuator");
 
-  Lines.push_back(Line( -4, -6, -4,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -4, -6,  4, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4, -6,  4,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -4,  6,  4,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-11,  0, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  6,  0, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, -6, -4,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, -6,  4, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4, -6,  4,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4,  6,  4,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-11,  0, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  6,  0, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -17;
   x2 =  30; y2 =  17;
@@ -48,11 +48,11 @@ Attenuator::Attenuator()
   Model = "Attenuator";
   Name  = "X";
 
-  Props.push_back(Property("L", "10 dB", true,
+  Props.push_back(qucs::Property("L", "10 dB", true,
 		QObject::tr("power attenuation")));
-  Props.push_back(Property("Zref", "50 Ohm", false,
+  Props.push_back(qucs::Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/biast.cpp
+++ b/qucs/components/biast.cpp
@@ -22,27 +22,27 @@ BiasT::BiasT()
 {
   Description = QObject::tr("bias t");
 
-  Arcs.push_back(Arc( -3,  2, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( -3,  8, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( -3, 14, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-22,-10, 22,-10,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-22,-10,-22, 22,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-22, 22, 22, 22,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 22,-10, 22, 22,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -3,  2, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -3,  8, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -3, 14, 6, 6, 16*270, 16*180,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-22,-10, 22,-10,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-22,-10,-22, 22,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-22, 22, 22, 22,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 22,-10, 22, 22,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line(-13, -6,-13,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9, -6, -9,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  0, 22,  0,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-22,  0,-13,  0,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-30,  0,-22,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 22,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  0,  0,  2,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(  0, 20,  0, 22,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(  0, 22,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -6,-13,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9, -6, -9,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  0, 22,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-22,  0,-13,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,  0,-22,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 22,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  0,  0,  2,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(  0, 20,  0, 22,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(  0, 22,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -13;
   x2 =  30; y2 =  30;
@@ -52,9 +52,9 @@ BiasT::BiasT()
   Model = "BiasT";
   Name  = "X";
 
-  Props.push_back(Property("L", "1 uH", false,
+  Props.push_back(qucs::Property("L", "1 uH", false,
 	QObject::tr("for transient simulation: inductance in Henry")));
-  Props.push_back(Property("C", "1 uF", false,
+  Props.push_back(qucs::Property("C", "1 uF", false,
 	QObject::tr("for transient simulation: capacitance in Farad")));
 }
 

--- a/qucs/components/binarytogrey4bit.cpp
+++ b/qucs/components/binarytogrey4bit.cpp
@@ -24,9 +24,9 @@ binarytogrey4bit::binarytogrey4bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4bit binary to Gray converter verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,44 +56,44 @@ Element * binarytogrey4bit::info(QString& Name, char * &BitmapFile, bool getNewO
 
 void binarytogrey4bit::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  40,-30, -60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  40,-30, -60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // B0
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B1
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B2
-  Lines.push_back(Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // B3
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // B0
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B1
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B2
+  Lines.push_back(qucs::Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // B3
 
-  Lines.push_back(Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // G3
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // G2
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // G1
-  Lines.push_back(Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // G0
+  Lines.push_back(qucs::Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // G3
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // G2
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // G1
+  Lines.push_back(qucs::Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // G0
  
-  Texts.push_back(Text(-16,-59, "B", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -2,-59, "/", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5,-59, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-16,-59, "B", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -2,-59, "/", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5,-59, "G", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,-23, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, -3, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 17, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-23, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, -3, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 17, "3", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 15,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-23, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, -3, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 17, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-23, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, -3, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 17, "3", Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-50,-30));  // B0
-  Ports.push_back(Port(-50,-10));  // B1
-  Ports.push_back(Port(-50, 10));  // B2
-  Ports.push_back(Port(-50, 30));  // B3
+  Ports.push_back(qucs::Port(-50,-30));  // B0
+  Ports.push_back(qucs::Port(-50,-10));  // B1
+  Ports.push_back(qucs::Port(-50, 10));  // B2
+  Ports.push_back(qucs::Port(-50, 30));  // B3
 
-  Ports.push_back(Port( 50, 30));  // G3
-  Ports.push_back(Port( 50, 10));  // G2
-  Ports.push_back(Port( 50,-10));  // G1
-  Ports.push_back(Port( 50,-30));  // G0
+  Ports.push_back(qucs::Port( 50, 30));  // G3
+  Ports.push_back(qucs::Port( 50, 10));  // G2
+  Ports.push_back(qucs::Port( 50,-10));  // G1
+  Ports.push_back(qucs::Port( 50,-30));  // G0
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  44;

--- a/qucs/components/bjt.cpp
+++ b/qucs/components/bjt.cpp
@@ -66,25 +66,25 @@ Element* BJT::info_pnp(QString& Name, char* &BitmapFile, bool getNewOne)
 // -------------------------------------------------------
 void BJT::createSymbol()
 {
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
 
   if(Props.front().Value == "npn") {
-    Lines.push_back(Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line( -5, 10, -5, 16,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -5, 10,  1, 10,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5, 10, -5, 16,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5, 10,  1, 10,QPen(Qt::darkBlue,2)));
   }
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -30;
   x2 =   4; y2 =  30;

--- a/qucs/components/bjtsub.cpp
+++ b/qucs/components/bjtsub.cpp
@@ -21,101 +21,101 @@
 Basic_BJT::Basic_BJT()
 {
   // this must be the first property in the list  !!!
-  Props.push_back(Property("Type", "npn", true,
+  Props.push_back(qucs::Property("Type", "npn", true,
 	QObject::tr("polarity")+" [npn, pnp]"));
-  Props.push_back(Property("Is", "1e-16", true,
+  Props.push_back(qucs::Property("Is", "1e-16", true,
 	QObject::tr("saturation current")));
-  Props.push_back(Property("Nf", "1", true,
+  Props.push_back(qucs::Property("Nf", "1", true,
 	QObject::tr("forward emission coefficient")));
-  Props.push_back(Property("Nr", "1", false,
+  Props.push_back(qucs::Property("Nr", "1", false,
 	QObject::tr("reverse emission coefficient")));
-  Props.push_back(Property("Ikf", "0", false,
+  Props.push_back(qucs::Property("Ikf", "0", false,
 	QObject::tr("high current corner for forward beta")));
-  Props.push_back(Property("Ikr", "0", false,
+  Props.push_back(qucs::Property("Ikr", "0", false,
 	QObject::tr("high current corner for reverse beta")));
-  Props.push_back(Property("Vaf", "0", true,
+  Props.push_back(qucs::Property("Vaf", "0", true,
 	QObject::tr("forward early voltage")));
-  Props.push_back(Property("Var", "0", false,
+  Props.push_back(qucs::Property("Var", "0", false,
 	QObject::tr("reverse early voltage")));
-  Props.push_back(Property("Ise", "0", false,
+  Props.push_back(qucs::Property("Ise", "0", false,
 	QObject::tr("base-emitter leakage saturation current")));
-  Props.push_back(Property("Ne", "1.5", false,
+  Props.push_back(qucs::Property("Ne", "1.5", false,
 	QObject::tr("base-emitter leakage emission coefficient")));
-  Props.push_back(Property("Isc", "0", false,
+  Props.push_back(qucs::Property("Isc", "0", false,
 	QObject::tr("base-collector leakage saturation current")));
-  Props.push_back(Property("Nc", "2", false,
+  Props.push_back(qucs::Property("Nc", "2", false,
 	QObject::tr("base-collector leakage emission coefficient")));
-  Props.push_back(Property("Bf", "100", true,
+  Props.push_back(qucs::Property("Bf", "100", true,
 	QObject::tr("forward beta")));
-  Props.push_back(Property("Br", "1", false,
+  Props.push_back(qucs::Property("Br", "1", false,
 	QObject::tr("reverse beta")));
-  Props.push_back(Property("Rbm", "0", false,
+  Props.push_back(qucs::Property("Rbm", "0", false,
 	QObject::tr("minimum base resistance for high currents")));
-  Props.push_back(Property("Irb", "0", false,
+  Props.push_back(qucs::Property("Irb", "0", false,
 	QObject::tr("current for base resistance midpoint")));
-  Props.push_back(Property("Rc", "0", false,
+  Props.push_back(qucs::Property("Rc", "0", false,
 	QObject::tr("collector ohmic resistance")));
-  Props.push_back(Property("Re", "0", false,
+  Props.push_back(qucs::Property("Re", "0", false,
 	QObject::tr("emitter ohmic resistance")));
-  Props.push_back(Property("Rb", "0", false,
+  Props.push_back(qucs::Property("Rb", "0", false,
 	QObject::tr("zero-bias base resistance (may be high-current dependent)")));
-  Props.push_back(Property("Cje", "0", false,
+  Props.push_back(qucs::Property("Cje", "0", false,
 	QObject::tr("base-emitter zero-bias depletion capacitance")));
-  Props.push_back(Property("Vje", "0.75", false,
+  Props.push_back(qucs::Property("Vje", "0.75", false,
 	QObject::tr("base-emitter junction built-in potential")));
-  Props.push_back(Property("Mje", "0.33", false,
+  Props.push_back(qucs::Property("Mje", "0.33", false,
 	QObject::tr("base-emitter junction exponential factor")));
-  Props.push_back(Property("Cjc", "0", false,
+  Props.push_back(qucs::Property("Cjc", "0", false,
 	QObject::tr("base-collector zero-bias depletion capacitance")));
-  Props.push_back(Property("Vjc", "0.75", false,
+  Props.push_back(qucs::Property("Vjc", "0.75", false,
 	QObject::tr("base-collector junction built-in potential")));
-  Props.push_back(Property("Mjc", "0.33", false,
+  Props.push_back(qucs::Property("Mjc", "0.33", false,
 	QObject::tr("base-collector junction exponential factor")));
-  Props.push_back(Property("Xcjc", "1.0", false,
+  Props.push_back(qucs::Property("Xcjc", "1.0", false,
 	QObject::tr("fraction of Cjc that goes to internal base pin")));
-  Props.push_back(Property("Cjs", "0", false,
+  Props.push_back(qucs::Property("Cjs", "0", false,
 	QObject::tr("zero-bias collector-substrate capacitance")));
-  Props.push_back(Property("Vjs", "0.75", false,
+  Props.push_back(qucs::Property("Vjs", "0.75", false,
 	QObject::tr("substrate junction built-in potential")));
-  Props.push_back(Property("Mjs", "0", false,
+  Props.push_back(qucs::Property("Mjs", "0", false,
 	QObject::tr("substrate junction exponential factor")));
-  Props.push_back(Property("Fc", "0.5", false,
+  Props.push_back(qucs::Property("Fc", "0.5", false,
 	QObject::tr("forward-bias depletion capacitance coefficient")));
-  Props.push_back(Property("Tf", "0.0", false,
+  Props.push_back(qucs::Property("Tf", "0.0", false,
 	QObject::tr("ideal forward transit time")));
-  Props.push_back(Property("Xtf", "0.0", false,
+  Props.push_back(qucs::Property("Xtf", "0.0", false,
 	QObject::tr("coefficient of bias-dependence for Tf")));
-  Props.push_back(Property("Vtf", "0.0", false,
+  Props.push_back(qucs::Property("Vtf", "0.0", false,
 	QObject::tr("voltage dependence of Tf on base-collector voltage")));
-  Props.push_back(Property("Itf", "0.0", false,
+  Props.push_back(qucs::Property("Itf", "0.0", false,
 	QObject::tr("high-current effect on Tf")));
-  Props.push_back(Property("Tr", "0.0", false,
+  Props.push_back(qucs::Property("Tr", "0.0", false,
 	QObject::tr("ideal reverse transit time")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Kf", "0.0", false,
+  Props.push_back(qucs::Property("Kf", "0.0", false,
 	QObject::tr("flicker noise coefficient")));
-  Props.push_back(Property("Af", "1.0", false,
+  Props.push_back(qucs::Property("Af", "1.0", false,
 	QObject::tr("flicker noise exponent")));
-  Props.push_back(Property("Ffe", "1.0", false,
+  Props.push_back(qucs::Property("Ffe", "1.0", false,
 	QObject::tr("flicker noise frequency exponent")));
-  Props.push_back(Property("Kb", "0.0", false,
+  Props.push_back(qucs::Property("Kb", "0.0", false,
 	QObject::tr("burst noise coefficient")));
-  Props.push_back(Property("Ab", "1.0", false,
+  Props.push_back(qucs::Property("Ab", "1.0", false,
 	QObject::tr("burst noise exponent")));
-  Props.push_back(Property("Fb", "1.0", false,
+  Props.push_back(qucs::Property("Fb", "1.0", false,
 	QObject::tr("burst noise corner frequency in Hertz")));
-  Props.push_back(Property("Ptf", "0.0", false,
+  Props.push_back(qucs::Property("Ptf", "0.0", false,
 	QObject::tr("excess phase in degrees")));
-  Props.push_back(Property("Xtb", "0.0", false,
+  Props.push_back(qucs::Property("Xtb", "0.0", false,
 	QObject::tr("temperature exponent for forward- and reverse beta")));
-  Props.push_back(Property("Xti", "3.0", false,
+  Props.push_back(qucs::Property("Xti", "3.0", false,
 	QObject::tr("saturation current temperature exponent")));
-  Props.push_back(Property("Eg", "1.11", false,
+  Props.push_back(qucs::Property("Eg", "1.11", false,
 	QObject::tr("energy bandgap in eV")));
-  Props.push_back(Property("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
 	QObject::tr("temperature at which parameters were extracted")));
-  Props.push_back(Property("Area", "1.0", false,
+  Props.push_back(qucs::Property("Area", "1.0", false,
 	QObject::tr("default area for bipolar transistor")));
 
   Name  = "T";
@@ -167,29 +167,29 @@ Element* BJTsub::info_pnp(QString& Name, char* &BitmapFile, bool getNewOne)
 // -------------------------------------------------------
 void BJTsub::createSymbol()
 {
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  9,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  9, -7,  9,  7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  9,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  9, -7,  9,  7,QPen(Qt::darkBlue,3)));
 
   if(Props.front().Value == "npn") {
-    Lines.push_back(Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line( -5, 10, -5, 16,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -5, 10,  1, 10,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5, 10, -5, 16,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -5, 10,  1, 10,QPen(Qt::darkBlue,2)));
   }
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;

--- a/qucs/components/bondwire.cpp
+++ b/qucs/components/bondwire.cpp
@@ -22,15 +22,15 @@ BondWire::BondWire()
 {
   Description = QObject::tr("bond wire");
 
-  Lines.push_back(Line(-30, 0,-8, 0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 30, 0, 8, 0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30, 0,-8, 0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 30, 0, 8, 0,QPen(Qt::darkBlue,3)));
 
-  Arcs.push_back(Arc(-11,-10, 22, 26, 16*30,16*120,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-19,-13, 10, 13,16*205,16*130,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  9,-13, 10, 13,16*205,16*130,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-11,-10, 22, 26, 16*30,16*120,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-19,-13, 10, 13,16*205,16*130,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  9,-13, 10, 13,16*205,16*130,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-13;
   x2 =  30; y2 =  5;
@@ -40,21 +40,21 @@ BondWire::BondWire()
   Model = "BOND";
   Name  = "Line";
 
-  Props.push_back(Property("L", "3 mm", true,
+  Props.push_back(qucs::Property("L", "3 mm", true,
 		QObject::tr("length of the wire")));
-  Props.push_back(Property("D", "50 um", true,
+  Props.push_back(qucs::Property("D", "50 um", true,
 		QObject::tr("diameter of the wire")));
-  Props.push_back(Property("H", "2 mm", true,
+  Props.push_back(qucs::Property("H", "2 mm", true,
 		QObject::tr("height above ground plane")));
-  Props.push_back(Property("rho", "0.022e-6", false,
+  Props.push_back(qucs::Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of the metal")));
-  Props.push_back(Property("mur", "1", false,
+  Props.push_back(qucs::Property("mur", "1", false,
 		QObject::tr("relative permeability of the metal")));
-  Props.push_back(Property("Model", "FREESPACE", false,
+  Props.push_back(qucs::Property("Model", "FREESPACE", false,
 	QObject::tr("bond wire model")+" [FREESPACE, MIRROR, DESCHARLES]"));
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/capacitor.cpp
+++ b/qucs/components/capacitor.cpp
@@ -22,11 +22,11 @@ Capacitor::Capacitor()
 {
   Description = QObject::tr("capacitor");
 
-  Props.push_back(Property("C", "1 pF", true,
+  Props.push_back(qucs::Property("C", "1 pF", true,
 		QObject::tr("capacitance in Farad")));
-  Props.push_back(Property("V", "", false,
+  Props.push_back(qucs::Property("V", "", false,
 		QObject::tr("initial voltage for transient simulation")));
-  Props.push_back(Property("Symbol", "neutral", false,
+  Props.push_back(qucs::Property("Symbol", "neutral", false,
 	QObject::tr("schematic symbol")+" [neutral, polar]"));
 
   createSymbol();
@@ -53,21 +53,21 @@ Element* Capacitor::info(QString& Name, char* &BitmapFile, bool getNewOne)
 void Capacitor::createSymbol()
 {
   if(Props.back().Value.at(0) == 'n') {
-    Lines.push_back(Line( -4,-11, -4, 11,QPen(Qt::darkBlue,4)));
-    Lines.push_back(Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
+    Lines.push_back(qucs::Line( -4,-11, -4, 11,QPen(Qt::darkBlue,4)));
+    Lines.push_back(qucs::Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
   }
   else {
-    Lines.push_back(Line(-11, -5,-11,-11,QPen(Qt::red,1)));
-    Lines.push_back(Line(-14, -8, -8, -8,QPen(Qt::red,1)));
-    Lines.push_back(Line( -4,-11, -4, 11,QPen(Qt::darkBlue,3)));
-    Arcs.push_back(Arc(4,-12, 20, 24, 16*122, 16*116,QPen(Qt::darkBlue,3)));
+    Lines.push_back(qucs::Line(-11, -5,-11,-11,QPen(Qt::red,1)));
+    Lines.push_back(qucs::Line(-14, -8, -8, -8,QPen(Qt::red,1)));
+    Lines.push_back(qucs::Line( -4,-11, -4, 11,QPen(Qt::darkBlue,3)));
+    Arcs.push_back(qucs::Arc(4,-12, 20, 24, 16*122, 16*116,QPen(Qt::darkBlue,3)));
   }
 
-  Lines.push_back(Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -13;
   x2 =  30; y2 =  13;

--- a/qucs/components/capq.cpp
+++ b/qucs/components/capq.cpp
@@ -28,28 +28,28 @@ capq::capq()
   Description = QObject::tr("Lossy capacitor");
 
   //Lines connection device and ports
-  Lines.push_back(Line( -4,-11, -4, 11,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line( -4,-11, -4, 11,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
 
 
-  Lines.push_back(Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
 
   //Draw Q
   //Horizontal lines
-  Lines.push_back(Line( 10,  -10, 17,  -10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  -17, 17,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -10, 17,  -10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -17, 17,  -17,QPen(Qt::darkBlue,2)));
   //Vertical lines
-  Lines.push_back(Line( 17,  -10, 17,  -17,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  -10, 10,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  -10, 17,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -10, 10,  -17,QPen(Qt::darkBlue,2)));
   //Middle line
-  Lines.push_back(Line( 18,  -9, 14,  -13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  -9, 14,  -13,QPen(Qt::darkBlue,2)));
 
 
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -13;
   x2 =  30; y2 =  13;
@@ -59,16 +59,16 @@ capq::capq()
   Model = "CAPQ";
   Name  = "CAPQ";
 
-  Props.push_back(Property("C", "1 pF", true,
+  Props.push_back(qucs::Property("C", "1 pF", true,
 		QObject::tr("Capacitance")));
-  Props.push_back(Property("Q", "100", true,
+  Props.push_back(qucs::Property("Q", "100", true,
 		QObject::tr("Quality factor")));
-  Props.push_back(Property("f", "100 MHz", false,
+  Props.push_back(qucs::Property("f", "100 MHz", false,
 		QObject::tr("Frequency at which Q is measured")));
-  Props.push_back(Property("Mode", "Linear", false,
+  Props.push_back(qucs::Property("Mode", "Linear", false,
 		QObject::tr("Q frequency profile")+
 		" [Linear, SquareRoot, Constant]"));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
                 QObject::tr("simulation temperature in degree Celsius")));
 }
 capq::~capq()

--- a/qucs/components/cccs.cpp
+++ b/qucs/components/cccs.cpp
@@ -22,32 +22,32 @@ CCCS::CCCS()
 {
   Description = QObject::tr("current controlled current source");
 
-  Arcs.push_back(Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -57,9 +57,9 @@ CCCS::CCCS()
   Model = "CCCS";
   Name  = "SRC";
 
-  Props.push_back(Property("G", "1", true,
+  Props.push_back(qucs::Property("G", "1", true,
 		QObject::tr("forward transfer factor")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 }
 
 CCCS::~CCCS()

--- a/qucs/components/ccvs.cpp
+++ b/qucs/components/ccvs.cpp
@@ -22,33 +22,33 @@ CCVS::CCVS()
 {
   Description = QObject::tr("current controlled voltage source");
 
-  Arcs.push_back(Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 20,-17, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 20, -8, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 19,-21, 19,-15,QPen(Qt::red,1)));
-  Lines.push_back(Line( 16,-18, 22,-18,QPen(Qt::red,1)));
-  Lines.push_back(Line( 16, 18, 22, 18,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line( 19,-21, 19,-15,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 16,-18, 22,-18,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 16, 18, 22, 18,QPen(Qt::black,1)));
 
-  Lines.push_back(Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -58,9 +58,9 @@ CCVS::CCVS()
   Model = "CCVS";
   Name  = "SRC";
 
-  Props.push_back(Property("G", "1 Ohm", true,
+  Props.push_back(qucs::Property("G", "1 Ohm", true,
 		QObject::tr("forward transfer factor")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 }
 
 CCVS::~CCVS()

--- a/qucs/components/circline.cpp
+++ b/qucs/components/circline.cpp
@@ -28,17 +28,17 @@ CircLine::CircLine()
 {
   Description = QObject::tr("Circular Waveguide");
 
-  Arcs.push_back(Arc(-20, -9, 18, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-18, -7, 14, 14,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 4, -9, 18, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-20, -9, 18, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-18, -7, 14, 14,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 4, -9, 18, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 19,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, -9, 12, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  9, 12,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, -9, 12, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  9, 12,  9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-16;
   x2 =  30; y2 = 14;
@@ -48,21 +48,21 @@ CircLine::CircLine()
   Model = "CIRCLINE";
   Name  = "Line";
 
-  Props.push_back(Property("a", "2.95 mm", true,
+  Props.push_back(qucs::Property("a", "2.95 mm", true,
 		QObject::tr("Radius")));
-  Props.push_back(Property("L", "1500 mm", true,
+  Props.push_back(qucs::Property("L", "1500 mm", true,
 		QObject::tr("Mechanical length of the line")));
-  Props.push_back(Property("er", "1", false,
+  Props.push_back(qucs::Property("er", "1", false,
 		QObject::tr("Relative permittivity of dielectric")));
-  Props.push_back(Property("mur", "1", false,
+  Props.push_back(qucs::Property("mur", "1", false,
 		QObject::tr("Relative permeability of conductor")));
-  Props.push_back(Property("tand", "0", false,
+  Props.push_back(qucs::Property("tand", "0", false,
 		QObject::tr("Loss tangent")));
-  Props.push_back(Property("rho", "0.022e-6", false,
+  Props.push_back(qucs::Property("rho", "0.022e-6", false,
 		QObject::tr("Specific resistance of conductor")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("Simulation temperature in degree Celsius")));
-  Props.push_back(Property("Material", "unspecified", false,
+  Props.push_back(qucs::Property("Material", "unspecified", false,
 		QObject::tr("Material parameter for temperature model")+
 			    " [unspecified, Copper, StainlessSteel, Gold]"));
 }

--- a/qucs/components/circularloop.cpp
+++ b/qucs/components/circularloop.cpp
@@ -29,13 +29,13 @@ circularloop::circularloop()
   Description = QObject::tr("Printed loop inductor");
 
   //Loop
-  Arcs.push_back(Arc(-18, -25, 35, 35, -370, 16*230,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-18, -25, 35, 35, -370, 16*230,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-30,  0, -16,  0,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line(  16,  0, 30,  0,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(-30,  0, -16,  0,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(  16,  0, 30,  0,QPen(Qt::darkBlue,4)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-30;
   x2 =  30; y2 = 5;
@@ -45,13 +45,13 @@ circularloop::circularloop()
   Model = "CIRCULARLOOP";
   Name  = "CIRCULARLOOP";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("Substrate")));
-  Props.push_back(Property("W", "25 um", false,
+  Props.push_back(qucs::Property("W", "25 um", false,
 		QObject::tr("Width of line")));
-  Props.push_back(Property("a", "500 um", false,
+  Props.push_back(qucs::Property("a", "500 um", false,
 		QObject::tr("Radius")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 
 }

--- a/qucs/components/circulator.cpp
+++ b/qucs/components/circulator.cpp
@@ -22,20 +22,20 @@ Circulator::Circulator()
 {
   Description = QObject::tr("circulator");
 
-  Arcs.push_back(Arc(-14,-14, 28, 28,  0,16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 14,  0, 30,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-14,-14, 28, 28,  0,16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 14,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( -8, -6, 16, 16,16*20,16*150,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  0,  9, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  0,  2, -1,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -8, -6, 16, 16,16*20,16*150,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  0,  9, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  0,  2, -1,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));   // marks port 1
+  Lines.push_back(qucs::Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));   // marks port 1
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -16;
   x2 =  30; y2 =  30;
@@ -45,11 +45,11 @@ Circulator::Circulator()
   Model = "Circulator";
   Name  = "X";
 
-  Props.push_back(Property("Z1", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z1", "50 Ohm", false,
 		QObject::tr("reference impedance of port 1")));
-  Props.push_back(Property("Z2", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z2", "50 Ohm", false,
 		QObject::tr("reference impedance of port 2")));
-  Props.push_back(Property("Z3", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z3", "50 Ohm", false,
 		QObject::tr("reference impedance of port 3")));
 }
 

--- a/qucs/components/coaxialline.cpp
+++ b/qucs/components/coaxialline.cpp
@@ -22,16 +22,16 @@ CoaxialLine::CoaxialLine()
 {
   Description = QObject::tr("coaxial transmission line");
 
-  Arcs.push_back(Arc(-20, -9, 8, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 11, -9, 8, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-20, -9, 8, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 11, -9, 8, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-16,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 19,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,  9, 16,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-16,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,  9, 16,  9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-12;
   x2 =  30; y2 = 12;
@@ -41,21 +41,21 @@ CoaxialLine::CoaxialLine()
   Model = "COAX";
   Name  = "Line";
 
-  Props.push_back(Property("er", "2.29", true,
+  Props.push_back(qucs::Property("er", "2.29", true,
 		QObject::tr("relative permittivity of dielectric")));
-  Props.push_back(Property("rho", "0.022e-6", false,
+  Props.push_back(qucs::Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of conductor")));
-  Props.push_back(Property("mur", "1", false,
+  Props.push_back(qucs::Property("mur", "1", false,
 		QObject::tr("relative permeability of conductor")));
-  Props.push_back(Property("D", "2.95 mm", false,
+  Props.push_back(qucs::Property("D", "2.95 mm", false,
 		QObject::tr("inner diameter of shield")));
-  Props.push_back(Property("d", "0.9 mm", false,
+  Props.push_back(qucs::Property("d", "0.9 mm", false,
 		QObject::tr("diameter of inner conductor")));
-  Props.push_back(Property("L", "1500 mm", true,
+  Props.push_back(qucs::Property("L", "1500 mm", true,
 		QObject::tr("mechanical length of the line")));
-  Props.push_back(Property("tand", "4e-4", false,
+  Props.push_back(qucs::Property("tand", "4e-4", false,
 		QObject::tr("loss tangent")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/comp_1bit.cpp
+++ b/qucs/components/comp_1bit.cpp
@@ -24,9 +24,9 @@ comp_1bit::comp_1bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("1bit comparator verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,30 +56,30 @@ Element * comp_1bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void comp_1bit::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  30,-30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  30,-30, -60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  30,-30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  30,-30, -60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // X
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // Y
-  Lines.push_back(Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));  // L
-  Lines.push_back(Line( 30,  0, 50,  0,QPen(Qt::darkBlue,2)));  // G
-  Lines.push_back(Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));  // E
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // X
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // Y
+  Lines.push_back(qucs::Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));  // L
+  Lines.push_back(qucs::Line( 30,  0, 50,  0,QPen(Qt::darkBlue,2)));  // G
+  Lines.push_back(qucs::Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));  // E
 
-  Texts.push_back(Text(-25,-55, "COMP", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-55, "COMP", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-23,   "X",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, -3,   "Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,  7, "X<Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,-13, "X>Y", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,-33, "X=Y", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-23,   "X",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, -3,   "Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,  7, "X<Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,-13, "X>Y", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,-33, "X=Y", Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-50,-10));  // X
-  Ports.push_back(Port(-50, 10));  // Y
-  Ports.push_back(Port( 50, 20));  // L
-  Ports.push_back(Port( 50,  0));  // G
-  Ports.push_back(Port( 50,-20));  // E
+  Ports.push_back(qucs::Port(-50,-10));  // X
+  Ports.push_back(qucs::Port(-50, 10));  // Y
+  Ports.push_back(qucs::Port( 50, 20));  // L
+  Ports.push_back(qucs::Port( 50,  0));  // G
+  Ports.push_back(qucs::Port( 50,-20));  // E
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  34;

--- a/qucs/components/comp_2bit.cpp
+++ b/qucs/components/comp_2bit.cpp
@@ -24,9 +24,9 @@ comp_2bit::comp_2bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("2bit comparator verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,40 +56,40 @@ Element * comp_2bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void comp_2bit::createSymbol()
 {
-  Lines.push_back(Line(-40, -50, 40,-50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40, -50, 40, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  60,-40, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-40,  60,-40, -50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40, -50, 40,-50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40, -50, 40, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  60,-40, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40,  60,-40, -50,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X0
-  Lines.push_back(Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X1
-  Lines.push_back(Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
-  Lines.push_back(Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // L
-  Lines.push_back(Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // G
-  Lines.push_back(Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // E
+  Lines.push_back(qucs::Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X0
+  Lines.push_back(qucs::Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X1
+  Lines.push_back(qucs::Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // L
+  Lines.push_back(qucs::Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // G
+  Lines.push_back(qucs::Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // E
 
-  Texts.push_back(Text(-25,-45, "COMP", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-45, "COMP", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-20,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15,-15,   "X",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35,-23,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, -3,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 22,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15, 27,   "Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5, 17, "X<Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5, -3, "X>Y", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5,-23, "X=Y", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-20,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15,-15,   "X",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-23,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, -3,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 22,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15, 27,   "Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5, 17, "X<Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5, -3, "X>Y", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5,-23, "X=Y", Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-60,-10));  // X0
-  Ports.push_back(Port(-60, 10));  // X1
-  Ports.push_back(Port(-60, 30));  // Y0
-  Ports.push_back(Port(-60, 50));  // Y1
-  Ports.push_back(Port( 60, 30));  // L
-  Ports.push_back(Port( 60, 10));  // G
-  Ports.push_back(Port( 60,-10));  // E
+  Ports.push_back(qucs::Port(-60,-10));  // X0
+  Ports.push_back(qucs::Port(-60, 10));  // X1
+  Ports.push_back(qucs::Port(-60, 30));  // Y0
+  Ports.push_back(qucs::Port(-60, 50));  // Y1
+  Ports.push_back(qucs::Port( 60, 30));  // L
+  Ports.push_back(qucs::Port( 60, 10));  // G
+  Ports.push_back(qucs::Port( 60,-10));  // E
 
   x1 = -60; y1 = -54;
   x2 =  60; y2 =  64;

--- a/qucs/components/comp_4bit.cpp
+++ b/qucs/components/comp_4bit.cpp
@@ -24,9 +24,9 @@ comp_4bit::comp_4bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4bit comparator verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,52 +56,52 @@ Element * comp_4bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void comp_4bit::createSymbol()
 {
-  Lines.push_back(Line(-40, -90, 40,-90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40, -90, 40,100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40, 100,-40,100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-40, 100,-40,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40, -90, 40,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40, -90, 40,100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40, 100,-40,100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40, 100,-40,-90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-60,-50,-40,-50,QPen(Qt::darkBlue,2)));  // X0
-  Lines.push_back(Line(-60,-30,-40,-30,QPen(Qt::darkBlue,2)));  // X1
-  Lines.push_back(Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X2
-  Lines.push_back(Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X3
-  Lines.push_back(Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
-  Lines.push_back(Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line(-60, 70,-40, 70,QPen(Qt::darkBlue,2)));  // Y2
-  Lines.push_back(Line(-60, 90,-40, 90,QPen(Qt::darkBlue,2)));  // Y3
-  Lines.push_back(Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // L
-  Lines.push_back(Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // G
-  Lines.push_back(Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // E
+  Lines.push_back(qucs::Line(-60,-50,-40,-50,QPen(Qt::darkBlue,2)));  // X0
+  Lines.push_back(qucs::Line(-60,-30,-40,-30,QPen(Qt::darkBlue,2)));  // X1
+  Lines.push_back(qucs::Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X2
+  Lines.push_back(qucs::Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X3
+  Lines.push_back(qucs::Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line(-60, 70,-40, 70,QPen(Qt::darkBlue,2)));  // Y2
+  Lines.push_back(qucs::Line(-60, 90,-40, 90,QPen(Qt::darkBlue,2)));  // Y3
+  Lines.push_back(qucs::Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // L
+  Lines.push_back(qucs::Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // G
+  Lines.push_back(qucs::Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // E
 
-  Texts.push_back(Text(-25,-85, "COMP", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-85, "COMP", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-40,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15,-35,   "X",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35,-63,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35,-43,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35,-23,   "2",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, -3,   "3",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 42,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15, 47,   "Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 57,   "2",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 77,   "3",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5, 17, "X<Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5, -3, "X>Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5,-23, "X=Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-40,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15,-35,   "X",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-63,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-43,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-23,   "2",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, -3,   "3",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 42,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15, 47,   "Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 57,   "2",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 77,   "3",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5, 17, "X<Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5, -3, "X>Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5,-23, "X=Y",  Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-60,-50));  // X0
-  Ports.push_back(Port(-60,-30));  // X1
-  Ports.push_back(Port(-60,-10));  // X2
-  Ports.push_back(Port(-60, 10));  // X3
-  Ports.push_back(Port(-60, 30));  // Y0
-  Ports.push_back(Port(-60, 50));  // Y1
-  Ports.push_back(Port(-60, 70));  // Y2
-  Ports.push_back(Port(-60, 90));  // Y3
-  Ports.push_back(Port( 60, 30));  // L
-  Ports.push_back(Port( 60, 10));  // G
-  Ports.push_back(Port( 60,-10));  // E
+  Ports.push_back(qucs::Port(-60,-50));  // X0
+  Ports.push_back(qucs::Port(-60,-30));  // X1
+  Ports.push_back(qucs::Port(-60,-10));  // X2
+  Ports.push_back(qucs::Port(-60, 10));  // X3
+  Ports.push_back(qucs::Port(-60, 30));  // Y0
+  Ports.push_back(qucs::Port(-60, 50));  // Y1
+  Ports.push_back(qucs::Port(-60, 70));  // Y2
+  Ports.push_back(qucs::Port(-60, 90));  // Y3
+  Ports.push_back(qucs::Port( 60, 30));  // L
+  Ports.push_back(qucs::Port( 60, 10));  // G
+  Ports.push_back(qucs::Port( 60,-10));  // E
 
   x1 = -60; y1 = -94;
   x2 =  60; y2 =  104;

--- a/qucs/components/component.cpp
+++ b/qucs/components/component.cpp
@@ -77,7 +77,7 @@ void Component::Bounding(int& _x1, int& _y1, int& _x2, int& _y2)
 
 // -------------------------------------------------------
 
-Property &Component::prop(int n)
+qucs::Property &Component::prop(int n)
 {
   auto p = Props.begin();
   while (n-- > 0 && p != Props.end())
@@ -86,7 +86,7 @@ Property &Component::prop(int n)
   return *p;
 }
 
-const Property &Component::prop(int n) const
+const qucs::Property &Component::prop(int n) const
 {
   auto p = Props.begin();
   while (n-- > 0 && p != Props.end())
@@ -95,7 +95,7 @@ const Property &Component::prop(int n) const
   return *p;
 }
 
-Port &Component::port(int n)
+qucs::Port &Component::port(int n)
 {
   auto p = Ports.begin();
   while (n-- > 0 && p != Ports.end())
@@ -104,7 +104,7 @@ Port &Component::port(int n)
   return *p;
 }
 
-const Port &Component::port(int n) const
+const qucs::Port &Component::port(int n) const
 {
   auto p = Ports.begin();
   while (n-- > 0 && p != Ports.end())
@@ -769,7 +769,7 @@ void Schematic::saveComponent(QTextStream& s, Component /*const*/ * c) const
   el.setAttribute ("mirror", mirroredX);
   el.setAttribute ("rotate", rotated);
 
-  for (Property *pr = Props.front(); pr != 0; pr = Props.next()) {
+  for (qucs::Property *pr = Props.front(); pr != 0; pr = Props.next()) {
     el.setAttribute (pr->Name, (pr->display ? "1@" : "0@") + pr.Value);
   }
   qDebug (doc.toString());
@@ -908,7 +908,7 @@ bool Schematic::loadComponent(const QString& _s, const std::shared_ptr<Component
 
   /// BUG FIXME. dont use Component parameter dictionary.
   for(; tmp<=(int)counts/2; tmp++)
-    c->Props.push_back(Property("p", "", true, " "));
+    c->Props.push_back(qucs::Property("p", "", true, " "));
 
   // BUG this is weird ...
 
@@ -995,7 +995,7 @@ bool Schematic::loadComponent(const QString& _s, const std::shared_ptr<Component
         if((unsigned int)c->Props.size() < (counts>>1)) {
           auto p1next = p1;
           ++p1next;
-          c->Props.insert(p1next, Property("y", "1", true));
+          c->Props.insert(p1next, qucs::Property("y", "1", true));
         }
       }
     if(Model == "R" && z == 6 && counts == 6) {    // backward compatible
@@ -1030,7 +1030,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(!getIntegers(Row, &i1, &i2, &i3))
       return -1;
     for(i6 = Ports.size(); i6<i3; i6++)  // if ports not in numerical order
-      Ports.push_back(Port(0, 0, false));
+      Ports.push_back(qucs::Port(0, 0, false));
 
     auto po = Ports.begin();
     for(int i = 0; i < (i3-1) && po != Ports.end(); ++i)
@@ -1050,7 +1050,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(!getPen(Row, Pen, 5))  return -1;
     i3 += i1;
     i4 += i2;
-    Lines.push_back(Line(i1, i2, i3, i4, Pen));
+    Lines.push_back(qucs::Line(i1, i2, i3, i4, Pen));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;
@@ -1066,7 +1066,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(!getIntegers(Row, &i1, &i2, &i3, &i4, &i5, &i6))
       return -1;
     if(!getPen(Row, Pen, 7))  return -1;
-    Arcs.push_back(Arc(i1, i2, i3, i4, i5, i6, Pen));
+    Arcs.push_back(qucs::Arc(i1, i2, i3, i4, i5, i6, Pen));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1+i3 > x2)  x2 = i1+i3;
@@ -1091,7 +1091,7 @@ int Component::analyseLine(const QString& Row, int numProps)
 
       ++pp;
       if(pp == Props.end()) {
-        Props.push_back(Property());
+        Props.push_back(qucs::Property());
         pp = --Props.end();
         pp->display = (s.at(0) == '1');
         pp->Value = s.section('=', 2,2);
@@ -1127,12 +1127,12 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(i4 < y1)  y1 = i4;
     if(i4 > y2)  y2 = i4;
 
-    Lines.push_back(Line(i1, i2, i3, i4, Pen));   // base line
+    Lines.push_back(qucs::Line(i1, i2, i3, i4, Pen));   // base line
 
     double w = beta+phi;
     i5 = i3-int(Length*cos(w));
     i6 = i4-int(Length*sin(w));
-    Lines.push_back(Line(i3, i4, i5, i6, Pen)); // arrow head
+    Lines.push_back(qucs::Line(i3, i4, i5, i6, Pen)); // arrow head
     if(i5 < x1)  x1 = i5;  // keep track of component boundings
     if(i5 > x2)  x2 = i5;
     if(i6 < y1)  y1 = i6;
@@ -1141,7 +1141,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     w = phi-beta;
     i5 = i3-int(Length*cos(w));
     i6 = i4-int(Length*sin(w));
-    Lines.push_back(Line(i3, i4, i5, i6, Pen));
+    Lines.push_back(qucs::Line(i3, i4, i5, i6, Pen));
     if(i5 < x1)  x1 = i5;  // keep track of component boundings
     if(i5 > x2)  x2 = i5;
     if(i6 < y1)  y1 = i6;
@@ -1153,7 +1153,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(!getIntegers(Row, &i1, &i2, &i3, &i4))  return -1;
     if(!getPen(Row, Pen, 5))  return -1;
     if(!getBrush(Row, Brush, 8))  return -1;
-    Ellips.push_back(Area(i1, i2, i3, i4, Pen, Brush));
+    Ellips.push_back(qucs::Area(i1, i2, i3, i4, Pen, Brush));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;
@@ -1169,7 +1169,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(!getIntegers(Row, &i1, &i2, &i3, &i4))  return -1;
     if(!getPen(Row, Pen, 5))  return -1;
     if(!getBrush(Row, Brush, 8))  return -1;
-    Rects.push_back(Area(i1, i2, i3, i4, Pen, Brush));
+    Rects.push_back(qucs::Area(i1, i2, i3, i4, Pen, Brush));
 
     if(i1 < x1)  x1 = i1;  // keep track of component boundings
     if(i1 > x2)  x2 = i1;
@@ -1191,7 +1191,7 @@ int Component::analyseLine(const QString& Row, int numProps)
     if(s.isEmpty()) return -1;
     misc::convert2Unicode(s);
 
-    Texts.push_back(Text(i1, i2, s, Color, float(i3),
+    Texts.push_back(qucs::Text(i1, i2, s, Color, float(i3),
                           float(cos(float(i4)*pi/180.0)),
                           float(sin(float(i4)*pi/180.0))));
 
@@ -1311,14 +1311,14 @@ bool Component::getBrush(const QString& s, QBrush& Brush, int i)
 }
 
 // ---------------------------------------------------------------------
-Property &Component::getProperty(const QString& name)
+qucs::Property &Component::getProperty(const QString& name)
 {
   for(auto pp = Props.begin(); pp != Props.end(); ++pp) {
     if(pp->Name == name) {
       return *pp;
     }
   }
-  Props.push_back(Property());
+  Props.push_back(qucs::Property());
   Props.back().Name = name;
   return Props.back();
 }
@@ -1444,17 +1444,17 @@ GateComponent::GateComponent()
   Name  = "Y";
 
   // the list order must be preserved !!!
-  Props.push_back(Property("in", "2", false,
+  Props.push_back(qucs::Property("in", "2", false,
 		QObject::tr("number of input ports")));
-  Props.push_back(Property("V", "1 V", false,
+  Props.push_back(qucs::Property("V", "1 V", false,
 		QObject::tr("voltage of high level")));
-  Props.push_back(Property("t", "0", false,
+  Props.push_back(qucs::Property("t", "0", false,
 		QObject::tr("delay time")));
-  Props.push_back(Property("TR", "10", false,
+  Props.push_back(qucs::Property("TR", "10", false,
 		QObject::tr("transfer function scaling factor")));
 
   // this must be the last property in the list !!!
-  Props.push_back(Property("Symbol", "old", false,
+  Props.push_back(qucs::Property("Symbol", "old", false,
 		QObject::tr("schematic symbol")+" [old, DIN40900]"));
 }
 
@@ -1607,29 +1607,29 @@ void GateComponent::createSymbol()
   if(Props.back().Value.at(0) == 'D') {  // DIN symbol
     xl = -15;
     xr =  15;
-    Lines.push_back(Line( 15,-y, 15, y,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-y, 15,-y,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15, y, 15, y,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-y,-15, y,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 15, 0, 30, 0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15,-y, 15, y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-y, 15,-y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, y, 15, y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-y,-15, y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15, 0, 30, 0,QPen(Qt::darkBlue,2)));
 
     if(Model.at(z) == 'O') {
-      Lines.push_back(Line(-11, 6-y,-6, 9-y,QPen(Qt::darkBlue,0)));
-      Lines.push_back(Line(-11,12-y,-6, 9-y,QPen(Qt::darkBlue,0)));
-      Lines.push_back(Line(-11,14-y,-6,14-y,QPen(Qt::darkBlue,0)));
-      Lines.push_back(Line(-11,16-y,-6,16-y,QPen(Qt::darkBlue,0)));
-      Texts.push_back(Text( -4, 3-y, "1", Qt::darkBlue, 15.0));
+      Lines.push_back(qucs::Line(-11, 6-y,-6, 9-y,QPen(Qt::darkBlue,0)));
+      Lines.push_back(qucs::Line(-11,12-y,-6, 9-y,QPen(Qt::darkBlue,0)));
+      Lines.push_back(qucs::Line(-11,14-y,-6,14-y,QPen(Qt::darkBlue,0)));
+      Lines.push_back(qucs::Line(-11,16-y,-6,16-y,QPen(Qt::darkBlue,0)));
+      Texts.push_back(qucs::Text( -4, 3-y, "1", Qt::darkBlue, 15.0));
     }
     else if(Model.at(z) == 'A')
-      Texts.push_back(Text( -10, 3-y, "&", Qt::darkBlue, 15.0));
+      Texts.push_back(qucs::Text( -10, 3-y, "&", Qt::darkBlue, 15.0));
     else if(Model.at(0) == 'X') {
       if(Model.at(1) == 'N') {
-	Ellips.push_back(Area(xr,-4, 8, 8,
+	Ellips.push_back(qucs::Area(xr,-4, 8, 8,
                   QPen(Qt::darkBlue,0), QBrush(Qt::darkBlue)));
-        Texts.push_back(Text( -11, 3-y, "=1", Qt::darkBlue, 15.0));
+        Texts.push_back(qucs::Text( -11, 3-y, "=1", Qt::darkBlue, 15.0));
       }
       else
-        Texts.push_back(Text( -11, 3-y, "=1", Qt::darkBlue, 15.0));
+        Texts.push_back(qucs::Text( -11, 3-y, "=1", Qt::darkBlue, 15.0));
     }
   }
   else {   // old symbol
@@ -1637,39 +1637,39 @@ void GateComponent::createSymbol()
     if(Model.at(z) == 'O')  xl = 10;
     else  xl = -10;
     xr = 10;
-    Lines.push_back(Line(-10,-y,-10, y,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 10, 0, 30, 0,QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,-y, 40, 30, 0, 16*90,QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,y-30, 40, 30, 0,-16*90,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 10,15-y, 10, y-15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-10,-y,-10, y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 10, 0, 30, 0,QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,-y, 40, 30, 0, 16*90,QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,y-30, 40, 30, 0,-16*90,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 10,15-y, 10, y-15,QPen(Qt::darkBlue,2)));
 
     if(Model.at(0) == 'X') {
-      Lines.push_back(Line(-5, 0, 5, 0,QPen(Qt::darkBlue,1)));
+      Lines.push_back(qucs::Line(-5, 0, 5, 0,QPen(Qt::darkBlue,1)));
       if(Model.at(1) == 'N') {
-        Lines.push_back(Line(-5,-3, 5,-3,QPen(Qt::darkBlue,1)));
-        Lines.push_back(Line(-5, 3, 5, 3,QPen(Qt::darkBlue,1)));
+        Lines.push_back(qucs::Line(-5,-3, 5,-3,QPen(Qt::darkBlue,1)));
+        Lines.push_back(qucs::Line(-5, 3, 5, 3,QPen(Qt::darkBlue,1)));
       }
       else {
-        Arcs.push_back(Arc(-5,-5, 10, 10, 0, 16*360,QPen(Qt::darkBlue,1)));
-        Lines.push_back(Line( 0,-5, 0, 5,QPen(Qt::darkBlue,1)));
+        Arcs.push_back(qucs::Arc(-5,-5, 10, 10, 0, 16*360,QPen(Qt::darkBlue,1)));
+        Lines.push_back(qucs::Line( 0,-5, 0, 5,QPen(Qt::darkBlue,1)));
       }
     }
   }
 
   if(Model.at(0) == 'N')
-    Ellips.push_back(Area(xr,-4, 8, 8,
+    Ellips.push_back(qucs::Area(xr,-4, 8, 8,
                   QPen(Qt::darkBlue,0), QBrush(Qt::darkBlue)));
 
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
   y += 10;
   for(z=0; z<Num; z++) {
     y -= 20;
-    Ports.push_back(Port(-30, y));
+    Ports.push_back(qucs::Port(-30, y));
     if(xl == 10) if((z == 0) || (z == Num-1)) {
-      Lines.push_back(Line(-30, y, 9, y,QPen(Qt::darkBlue,2)));
+      Lines.push_back(qucs::Line(-30, y, 9, y,QPen(Qt::darkBlue,2)));
       continue;
     }
-    Lines.push_back(Line(-30, y, xl, y,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30, y, xl, y,QPen(Qt::darkBlue,2)));
   }
 }
 

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -19,7 +19,6 @@
 #define COMPONENT_H
 
 #include "element.h"
-using namespace qucs;
 #include <list>
 
 class Schematic;
@@ -65,12 +64,12 @@ public:
   virtual void dialgButtStuff(ComponentDialog&)const;
 
   //  gets property by index
-  Property &prop(int n);
-  const Property &prop(int n) const;
+  qucs::Property &prop(int n);
+  const qucs::Property &prop(int n) const;
 
   //  gets port by index
-  Port &port(int n);
-  const Port &port(int n) const;
+  qucs::Port &port(int n);
+  const qucs::Port &port(int n) const;
 
   std::list<qucs::Line>   Lines;
   std::list<qucs::Arc>    Arcs;
@@ -132,7 +131,7 @@ protected:
   bool getBrush(const QString&, QBrush&, int);
 
   void copyComponent(const Component &);
-  Property &getProperty(const QString&);
+  qucs::Property &getProperty(const QString&);
   Schematic* containingSchematic;
 };
 

--- a/qucs/components/component.h
+++ b/qucs/components/component.h
@@ -19,7 +19,7 @@
 #define COMPONENT_H
 
 #include "element.h"
-
+using namespace qucs;
 #include <list>
 
 class Schematic;
@@ -72,13 +72,13 @@ public:
   Port &port(int n);
   const Port &port(int n) const;
 
-  std::list<Line>   Lines;
-  std::list<Arc>    Arcs;
-  std::list<Area>   Rects;
-  std::list<Area>   Ellips;
-  std::list<Port>   Ports;
-  std::list<Text>   Texts;
-  std::list<Property>   Props;
+  std::list<qucs::Line>   Lines;
+  std::list<qucs::Arc>    Arcs;
+  std::list<qucs::Area>   Rects;
+  std::list<qucs::Area>   Ellips;
+  std::list<qucs::Port>   Ports;
+  std::list<qucs::Text>   Texts;
+  std::list<qucs::Property>   Props;
 
   #define COMP_IS_OPEN    0
   #define COMP_IS_ACTIVE  1

--- a/qucs/components/componentdialog.cpp
+++ b/qucs/components/componentdialog.cpp
@@ -1026,7 +1026,7 @@ void ComponentDialog::slotApplyInput()
         Q_ASSERT(prop->rowCount() >= 0);
         if ( (int) Comp->Props.size() < prop->rowCount() +1) {
             qDebug() << "adding to Comp ";
-            Comp->Props.push_back(Property(name, value, display, desc));
+            Comp->Props.push_back(qucs::Property(name, value, display, desc));
             changed = true;
         }
       }

--- a/qucs/components/coplanar.cpp
+++ b/qucs/components/coplanar.cpp
@@ -22,31 +22,31 @@ Coplanar::Coplanar()
 {
   Description = QObject::tr("coplanar line");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8, 23, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8, 13,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8, 23, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-24;
   x2 =  30; y2 = 24;
@@ -56,18 +56,18 @@ Coplanar::Coplanar()
   Model = "CLIN";
   Name  = "CL";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 		QObject::tr("width of a gap")));
-  Props.push_back(Property("L", "10 mm", true,
+  Props.push_back(qucs::Property("L", "10 mm", true,
 		QObject::tr("length of the line")));
-  Props.push_back(Property("Backside", "Air", false,
+  Props.push_back(qucs::Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+
 		" [Metal, Air]"));
-  Props.push_back(Property("Approx", "yes", false,
+  Props.push_back(qucs::Property("Approx", "yes", false,
 		QObject::tr("use approximation instead of precise equation")+
 		" [yes, no]"));
 }

--- a/qucs/components/coupler.cpp
+++ b/qucs/components/coupler.cpp
@@ -22,34 +22,34 @@ Coupler::Coupler()
 {
   Description = QObject::tr("ideal coupler");
 
-  Lines.push_back(Line(-23,-24, 23,-24,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 23,-24, 23, 24,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 23, 24,-23, 24,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-23, 24,-23,-24,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-23,-24, 23,-24,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 23,-24, 23, 24,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 23, 24,-23, 24,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-23, 24,-23,-24,QPen(Qt::darkGray,1)));
 
-  Lines.push_back(Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-20, 20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-20, 20,-20,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 20, 20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 20, 20, 20,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-20, 20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-20, 20,-20,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 20, 20, 20,QPen(Qt::darkBlue,4)));
 
-  Lines.push_back(Line( 14, 14,-14,-14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-14,-14, -9,-14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-14,-14,-14, -9,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(  9, 14, 14, 14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 14,  9, 14, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 14, 14,-14,-14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-14,-14, -9,-14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-14,-14,-14, -9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(  9, 14, 14, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 14,  9, 14, 14,QPen(Qt::darkBlue,1)));
   
-  Lines.push_back(Line( 14,-14,-14, 14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 14,-14,  9,-14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 14,-14, 14, -9,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-14, 14, -9, 14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-14, 14,-14,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 14,-14,-14, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 14,-14,  9,-14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 14,-14, 14, -9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-14, 14, -9, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-14, 14,-14,  9,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(-30,-20));
-  Ports.push_back(Port( 30,-20));
-  Ports.push_back(Port( 30, 20));
-  Ports.push_back(Port(-30, 20));
+  Ports.push_back(qucs::Port(-30,-20));
+  Ports.push_back(qucs::Port( 30,-20));
+  Ports.push_back(qucs::Port( 30, 20));
+  Ports.push_back(qucs::Port(-30, 20));
 
 
   x1 = -30; y1 = -25;
@@ -60,11 +60,11 @@ Coupler::Coupler()
   Model = "Coupler";
   Name  = "X";
 
-  Props.push_back(Property("k", "0.7071", true,
+  Props.push_back(qucs::Property("k", "0.7071", true,
 		QObject::tr("coupling factor")));
-  Props.push_back(Property("phi", "180", true,
+  Props.push_back(qucs::Property("phi", "180", true,
 		QObject::tr("phase shift of coupling path in degree")));
-  Props.push_back(Property("Z", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z", "50 Ohm", false,
 		QObject::tr("reference impedance")));
 }
 

--- a/qucs/components/cpwgap.cpp
+++ b/qucs/components/cpwgap.cpp
@@ -22,35 +22,35 @@ CPWgap::CPWgap()
 {
   Description = QObject::tr("coplanar gap");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,  2, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, -8, 23, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -2,  8, 13,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  2, -8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, -8, -2,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,  2, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, -8, 23, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -2,  8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  2, -8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, -8, -2,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-24;
   x2 =  30; y2 = 24;
@@ -60,13 +60,13 @@ CPWgap::CPWgap()
   Model = "CGAP";
   Name  = "CL";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 		QObject::tr("width of a gap")));
-  Props.push_back(Property("G", "0.5 mm", true,
+  Props.push_back(qucs::Property("G", "0.5 mm", true,
 		QObject::tr("width of gap between the two lines")));
 }
 

--- a/qucs/components/cpwopen.cpp
+++ b/qucs/components/cpwopen.cpp
@@ -22,34 +22,34 @@ CPWopen::CPWopen()
 {
   Description = QObject::tr("coplanar open");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,  0, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8,-10,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -8,-10,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,  0, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8,-10,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -8,-10,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-13, 11,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-25, 13, -5, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-13, -5, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,-13, 11,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 13, -5, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-13, -5, 13,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-21, 15,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-21, 15,-14,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line( 10,-11, 15, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, -6, 15,  2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4, -1, 15, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  1,  4, 15, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-11, 15, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, -6, 15,  2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4, -1, 15, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  1,  4, 15, 18,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25, 18,-22, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-22, 13,-14, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 13, -6, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, 13,  2, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -2,  9, 10, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 18,-22, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22, 13,-14, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 13, -6, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, 13,  2, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -2,  9, 10, 21,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
 
   x1 = -30; y1 =-24;
   x2 =  17; y2 = 24;
@@ -59,15 +59,15 @@ CPWopen::CPWopen()
   Model = "COPEN";
   Name  = "CL";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 		QObject::tr("width of a gap")));
-  Props.push_back(Property("G", "5 mm", true,
+  Props.push_back(qucs::Property("G", "5 mm", true,
 		QObject::tr("width of gap at end of line")));
-  Props.push_back(Property("Backside", "Air", false,
+  Props.push_back(qucs::Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+
 		" [Metal, Air]"));
 }

--- a/qucs/components/cpwshort.cpp
+++ b/qucs/components/cpwshort.cpp
@@ -22,33 +22,33 @@ CPWshort::CPWshort()
 {
   Description = QObject::tr("coplanar short");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,  3, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8, -7,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,  3, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8, -7,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-13,  6,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-25, 13,-10, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  6,-13,  3, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  8,-10, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,-13,  6,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 13,-10, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6,-13,  3, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  8,-10, 13,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-21, 12, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-21, 12,-17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-21, 12, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-21, 12,-17,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(  4, -9, 12, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  1, -4, 12,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -2,  1, 12, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4, -9, 12, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  1, -4, 12,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -2,  1, 12, 15,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25, 18,-22, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-22, 13,-14, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 13, -6, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 11,  2, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  6, 10, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 18,-22, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22, 13,-14, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 13, -6, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 11,  2, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  6, 10, 21,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
 
   x1 = -30; y1 =-24;
   x2 =  14; y2 = 24;
@@ -58,13 +58,13 @@ CPWshort::CPWshort()
   Model = "CSHORT";
   Name  = "CL";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 		QObject::tr("width of a gap")));
-  Props.push_back(Property("Backside", "Air", false,
+  Props.push_back(qucs::Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+
 		" [Metal, Air]"));
 }

--- a/qucs/components/cpwstep.cpp
+++ b/qucs/components/cpwstep.cpp
@@ -22,37 +22,37 @@ CPWstep::CPWstep()
 {
   Description = QObject::tr("coplanar step");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  6,-10, 24,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, 10, 12, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, -6,  4, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-22,  6, -4,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  6,-10,  4, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, 10, -4,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, -6,-22,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 24,-10, 12, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6,-10, 24,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, 10, 12, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, -6,  4, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22,  6, -4,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6,-10,  4, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, 10, -4,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, -6,-22,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 24,-10, 12, 10,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,-13, 25,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-21, 24,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-21, 16,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-21,  8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-21,  0,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-21, -8,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24,-21,-16,-13,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 13, 25, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 13,-16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, 13, -8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 13,  0, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 13,  8, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, 13, 16, 21,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16, 13, 24, 21,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-24;
   x2 =  30; y2 = 24;
@@ -62,15 +62,15 @@ CPWstep::CPWstep()
   Model = "CSTEP";
   Name  = "CL";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W1", "1 mm", true,
+  Props.push_back(qucs::Property("W1", "1 mm", true,
 		QObject::tr("width of line 1")));
-  Props.push_back(Property("W2", "2 mm", true,
+  Props.push_back(qucs::Property("W2", "2 mm", true,
 		QObject::tr("width of line 2")));
-  Props.push_back(Property("S", "3 mm", true,
+  Props.push_back(qucs::Property("S", "3 mm", true,
 		QObject::tr("distance between ground planes")));
-  Props.push_back(Property("Backside", "Air", false,
+  Props.push_back(qucs::Property("Backside", "Air", false,
 		QObject::tr("material at the backside of the substrate")+
 		" [Metal, Air]"));
 }

--- a/qucs/components/ctline.cpp
+++ b/qucs/components/ctline.cpp
@@ -18,30 +18,30 @@ CoupledTLine::CoupledTLine()
 {
   Description = QObject::tr("coupled transmission lines");
 
-  Arcs.push_back(Arc(-28,-40, 18, 38,16*232, 16*33,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-28,  2, 18, 38, 16*95, 16*33,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-28,-40, 18, 38,16*232, 16*33,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-28,  2, 18, 38, 16*95, 16*33,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-20,-2,-16,-2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 2,-16, 2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-2,-16,-2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 2,-16, 2,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( 10,-40, 18, 38,16*270, 16*40,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 10,  2, 18, 38, 16*50, 16*40,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 10,-40, 18, 38,16*270, 16*40,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 10,  2, 18, 38, 16*50, 16*40,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(-38,-10, 16, 28, 16*45, 16*45,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-38,-18, 16, 28,16*270, 16*45,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 22,-10, 16, 28, 16*90, 16*45,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 22,-18, 16, 28,16*225, 16*45,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-38,-10, 16, 28, 16*45, 16*45,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-38,-18, 16, 28,16*270, 16*45,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 22,-10, 16, 28, 16*90, 16*45,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 22,-18, 16, 28,16*225, 16*45,QPen(Qt::darkBlue,2)));
 
   // shield
-  Arcs.push_back(Arc(-20, -9, 8, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 11, -9, 8, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,  9, 16,  9,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-20, -9, 8, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 11, -9, 8, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,  9, 16,  9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,-10));
-  Ports.push_back(Port( 30,-10));
-  Ports.push_back(Port( 30, 10));
-  Ports.push_back(Port(-30, 10));
+  Ports.push_back(qucs::Port(-30,-10));
+  Ports.push_back(qucs::Port( 30,-10));
+  Ports.push_back(qucs::Port( 30, 10));
+  Ports.push_back(qucs::Port(-30, 10));
 
   x1 = -30; y1 =-12;
   x2 =  30; y2 = 12;
@@ -51,21 +51,21 @@ CoupledTLine::CoupledTLine()
   Model = "CTLIN";
   Name  = "Line";
 
-  Props.push_back(Property("Ze", "50 Ohm", true,
+  Props.push_back(qucs::Property("Ze", "50 Ohm", true,
 		QObject::tr("characteristic impedance of even mode")));
-  Props.push_back(Property("Zo", "50 Ohm", true,
+  Props.push_back(qucs::Property("Zo", "50 Ohm", true,
 		QObject::tr("characteristic impedance of odd mode")));
-  Props.push_back(Property("L", "1 mm", true,
+  Props.push_back(qucs::Property("L", "1 mm", true,
 		QObject::tr("electrical length of the line")));
-  Props.push_back(Property("Ere", "1", false,
+  Props.push_back(qucs::Property("Ere", "1", false,
 		QObject::tr("relative dielectric constant of even mode")));
-  Props.push_back(Property("Ero", "1", false,
+  Props.push_back(qucs::Property("Ero", "1", false,
 		QObject::tr("relative dielectric constant of odd mode")));
-  Props.push_back(Property("Ae", "0 dB", false,
+  Props.push_back(qucs::Property("Ae", "0 dB", false,
 		QObject::tr("attenuation factor per length of even mode")));
-  Props.push_back(Property("Ao", "0 dB", false,
+  Props.push_back(qucs::Property("Ao", "0 dB", false,
 		QObject::tr("attenuation factor per length of odd mode")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/d_flipflop.cpp
+++ b/qucs/components/d_flipflop.cpp
@@ -23,28 +23,28 @@ D_FlipFlop::D_FlipFlop()
   Type = isDigitalComponent;
   Description = QObject::tr("D flip flop with asynchron reset");
 
-  Props.push_back(Property("t", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("t", "0", false, QObject::tr("delay time")));
 
-  Lines.push_back(Line(-20,-20, 20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 20, 20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-20, 20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-20, 20, 20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-10,-20,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10,-20, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-10, 20,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 20,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-10,-20,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10,-20, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-10, 20,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 20,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-18,-21, "D", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  6,-21, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -4,  4, "R", Qt::darkBlue, 9.0));
-  Lines.push_back(Line(-20,  6,-12, 10,QPen(Qt::darkBlue,0)));
-  Lines.push_back(Line(-20, 14,-12, 10,QPen(Qt::darkBlue,0)));
+  Texts.push_back(qucs::Text(-18,-21, "D", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  6,-21, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -4,  4, "R", Qt::darkBlue, 9.0));
+  Lines.push_back(qucs::Line(-20,  6,-12, 10,QPen(Qt::darkBlue,0)));
+  Lines.push_back(qucs::Line(-20, 14,-12, 10,QPen(Qt::darkBlue,0)));
 
-  Ports.push_back(Port(-30,-10));  // D
-  Ports.push_back(Port(-30, 10));  // Clock
-  Ports.push_back(Port( 30,-10));  // Q
-  Ports.push_back(Port(  0, 30));  // Reset
+  Ports.push_back(qucs::Port(-30,-10));  // D
+  Ports.push_back(qucs::Port(-30, 10));  // Clock
+  Ports.push_back(qucs::Port( 30,-10));  // Q
+  Ports.push_back(qucs::Port(  0, 30));  // Reset
 
   x1 = -30; y1 = -24;
   x2 =  30; y2 =  30;

--- a/qucs/components/dc_sim.cpp
+++ b/qucs/components/dc_sim.cpp
@@ -31,9 +31,9 @@ DC_Sim::DC_Sim()
   if (a < 8 || s.length() - b < 8) b = -1;
   if (b != -1) s[b] = '\n';
 
-  Texts.push_back(Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
   if (b != -1)
-    Texts.push_back(Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+128; y2 = y1+41;
@@ -43,26 +43,26 @@ DC_Sim::DC_Sim()
   Model = ".DC";
   Name  = "DC";
 
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("reltol", "0.001", false,
+  Props.push_back(qucs::Property("reltol", "0.001", false,
 		QObject::tr("relative tolerance for convergence")));
-  Props.push_back(Property("abstol", "1 pA", false,
+  Props.push_back(qucs::Property("abstol", "1 pA", false,
 		QObject::tr("absolute tolerance for currents")));
-  Props.push_back(Property("vntol", "1 uV", false,
+  Props.push_back(qucs::Property("vntol", "1 uV", false,
 		QObject::tr("absolute tolerance for voltages")));
-  Props.push_back(Property("saveOPs", "no", false,
+  Props.push_back(qucs::Property("saveOPs", "no", false,
 		QObject::tr("put operating points into dataset")+
 		" [yes, no]"));
-  Props.push_back(Property("MaxIter", "150", false,
+  Props.push_back(qucs::Property("MaxIter", "150", false,
 		QObject::tr("maximum number of iterations until error")));
-  Props.push_back(Property("saveAll", "no", false,
+  Props.push_back(qucs::Property("saveAll", "no", false,
 	QObject::tr("save subcircuit nodes into dataset")+
 	" [yes, no]"));
-  Props.push_back(Property("convHelper", "none", false,
+  Props.push_back(qucs::Property("convHelper", "none", false,
 	QObject::tr("preferred convergence algorithm")+
 	" [none, gMinStepping, SteepestDescent, LineSearch, Attenuation, SourceStepping]"));
-  Props.push_back(Property("Solver", "CroutLU", false,
+  Props.push_back(qucs::Property("Solver", "CroutLU", false,
 	QObject::tr("method for solving the circuit matrix")+
 	" [CroutLU, DoolittleLU, HouseholderQR, HouseholderLQ, GolubSVD]"));
 }

--- a/qucs/components/dcblock.cpp
+++ b/qucs/components/dcblock.cpp
@@ -21,18 +21,18 @@ dcBlock::dcBlock()
 {
   Description = QObject::tr("dc block");
 
-  Lines.push_back(Line(- 4,-11, -4, 11,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(- 4,-11, -4, 11,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(  4,-11,  4, 11,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line(-30,  0, -4,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-23,-14, 23,-14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-23, 14, 23, 14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-23,-14,-23, 14,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 23,-14, 23, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23,-14, 23,-14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23, 14, 23, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23,-14,-23, 14,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 23,-14, 23, 14,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -16;
   x2 =  30; y2 =  17;
@@ -42,7 +42,7 @@ dcBlock::dcBlock()
   Model = "DCBlock";
   Name  = "C";
 
-  Props.push_back(Property("C", "1 uF", false,
+  Props.push_back(qucs::Property("C", "1 uF", false,
 	QObject::tr("for transient simulation: capacitance in Farad")));
 }
 

--- a/qucs/components/dcfeed.cpp
+++ b/qucs/components/dcfeed.cpp
@@ -22,19 +22,19 @@ dcFeed::dcFeed()
 {
   Description = QObject::tr("dc feed");
 
-  Arcs.push_back(Arc(-17, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  5, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-17, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  5, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-23,-13, 23,-13,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-23, 13, 23, 13,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-23,-13,-23, 13,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 23,-13, 23, 13,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23,-13, 23,-13,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23, 13, 23, 13,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-23,-13,-23, 13,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 23,-13, 23, 13,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -15;
   x2 =  30; y2 =  16;
@@ -44,7 +44,7 @@ dcFeed::dcFeed()
   Model = "DCFeed";
   Name  = "L";
 
-  Props.push_back(Property("L", "1 uH", false,
+  Props.push_back(qucs::Property("L", "1 uH", false,
 	QObject::tr("for transient simulation: inductance in Henry")));
 }
 

--- a/qucs/components/dff_SR.cpp
+++ b/qucs/components/dff_SR.cpp
@@ -24,11 +24,11 @@ dff_SR::dff_SR()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("D flip flop with set and reset verilog device");
 
-  Props.push_back (Property ("TR_H", "6", false,
+  Props.push_back(qucs::Property("TR_H", "6", false,
     QObject::tr ("cross coupled gate transfer function high scaling factor")));
-  Props.push_back (Property ("TR_L", "5", false,
+  Props.push_back(qucs::Property("TR_L", "5", false,
     QObject::tr ("cross coupled gate transfer function low scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("cross coupled gate delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -59,38 +59,38 @@ Element * dff_SR::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void dff_SR::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-30,-40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-40, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 40,-30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-40, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 40,-30,-40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -30, 10,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -30, 30,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -30, 10,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -30, 30,-20, 20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  0, -50,  0, -60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  50,  0,  60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -50,  0, -60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  50,  0,  60,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( -5,-50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -5, 40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -5,-50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -5, 40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-25,-32,  "D", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,-32,  "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,-39,  "S", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,  7,  "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-32,  "D", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,-32,  "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,-39,  "S", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,  7,  "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
-  Texts.push_back(Text( -5, 17,  "R", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5, 17,  "R", Qt::darkBlue, 12.0));
  
-  Ports.push_back(Port(0,  -60));  // S
-  Ports.push_back(Port(-50,-20));  // D
-  Ports.push_back(Port(-50, 20));  // CLK
-  Ports.push_back(Port(  0, 60));  // R
-  Ports.push_back(Port( 50, 20));  // QB
-  Ports.push_back(Port( 50,-20));  // Q
+  Ports.push_back(qucs::Port(0,  -60));  // S
+  Ports.push_back(qucs::Port(-50,-20));  // D
+  Ports.push_back(qucs::Port(-50, 20));  // CLK
+  Ports.push_back(qucs::Port(  0, 60));  // R
+  Ports.push_back(qucs::Port( 50, 20));  // QB
+  Ports.push_back(qucs::Port( 50,-20));  // Q
 
   x1 = -50; y1 = -60;
   x2 =  50; y2 =  60;

--- a/qucs/components/diac.cpp
+++ b/qucs/components/diac.cpp
@@ -22,18 +22,18 @@ Diac::Diac()
 {
   Description = QObject::tr("diac (bidirectional trigger diode)");
 
-  Lines.push_back(Line(  0,-30,  0, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 30,  0,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 30,  0,  6,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18,  6, 18,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -6, 18, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  6,-18, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  6,  0, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  9, -6,  0,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  9, -6, 18,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  6, 18,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -6, 18, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  6,-18, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  6,  0, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  9, -6,  0,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  9, -6, 18,  6,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -20; y1 = -30;
   x2 =  20; y2 =  30;
@@ -43,19 +43,19 @@ Diac::Diac()
   Model = "Diac";
   Name  = "D";
 
-  Props.push_back(Property("Vbo", "30 V", true,
+  Props.push_back(qucs::Property("Vbo", "30 V", true,
 	QObject::tr("(bidirectional) breakover voltage")));
-  Props.push_back(Property("Ibo", "50 uA", false,
+  Props.push_back(qucs::Property("Ibo", "50 uA", false,
 	QObject::tr("(bidirectional) breakover current")));
-  Props.push_back(Property("Cj0", "10 pF", false,
+  Props.push_back(qucs::Property("Cj0", "10 pF", false,
 	QObject::tr("parasitic capacitance")));
-  Props.push_back(Property("Is", "1e-10 A", false,
+  Props.push_back(qucs::Property("Is", "1e-10 A", false,
 	QObject::tr("saturation current")));
-  Props.push_back(Property("N", "2", false,
+  Props.push_back(qucs::Property("N", "2", false,
 	QObject::tr("emission coefficient")));
-  Props.push_back(Property("Ri", "10 Ohm", false,
+  Props.push_back(qucs::Property("Ri", "10 Ohm", false,
 	QObject::tr("intrinsic junction resistance")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature")));
 }
 

--- a/qucs/components/digi_sim.cpp
+++ b/qucs/components/digi_sim.cpp
@@ -27,9 +27,9 @@ Digi_Sim::Digi_Sim()
   int a = s.indexOf(" ");
   if (a != -1) s[a] = '\n';  // break line before the word "simulation"
 
-  Texts.push_back(Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
   if (a != -1)
-    Texts.push_back(Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+120; y2 = y1+59;
@@ -40,11 +40,11 @@ Digi_Sim::Digi_Sim()
   Name  = "Digi";
 
   // Property list must keeps its order !
-  Props.push_back(Property("Type", "TruthTable", true,
+  Props.push_back(qucs::Property("Type", "TruthTable", true,
 	QObject::tr("type of simulation")+" [TruthTable, TimeList]"));
-  Props.push_back(Property("time", "10 ns", false,
+  Props.push_back(qucs::Property("time", "10 ns", false,
 	QObject::tr("duration of TimeList simulation")));
-  Props.push_back(Property("Model", "VHDL", false,
+  Props.push_back(qucs::Property("Model", "VHDL", false,
 	QObject::tr("netlist format")+" [VHDL, Verilog]"));
 }
 

--- a/qucs/components/digi_source.cpp
+++ b/qucs/components/digi_source.cpp
@@ -24,20 +24,20 @@ Digi_Source::Digi_Source()
   Type = isComponent;   // both analog and digital
   Description = QObject::tr("digital source");
 
-  Lines.push_back(Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
 
-  Lines.push_back(Line(-32, 5,-28, 5,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-28,-5,-24,-5,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-24, 5,-20, 5,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-28,-5,-28, 5,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-24,-5,-24, 5,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-32, 5,-28, 5,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-28,-5,-24,-5,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-24, 5,-20, 5,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-28,-5,-28, 5,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-24,-5,-24, 5,QPen(Qt::darkGreen,2)));
 
-  Ports.push_back(Port(  0,  0));
+  Ports.push_back(qucs::Port(  0,  0));
 
   x1 = -39; y1 = -14;
   x2 =   0; y2 =  14;
@@ -48,13 +48,13 @@ Digi_Source::Digi_Source()
   Name  = "S";
 
   // This property must stay in this order !
-  Props.push_back(Property("Num", "1", true,
+  Props.push_back(qucs::Property("Num", "1", true,
 		QObject::tr("number of the port")));
-  Props.push_back(Property("init", "low", false,
+  Props.push_back(qucs::Property("init", "low", false,
 		QObject::tr("initial output value")+" [low, high]"));
-  Props.push_back(Property("times", "1ns; 1ns", false,
+  Props.push_back(qucs::Property("times", "1ns; 1ns", false,
 		QObject::tr("list of times for changing output value")));
-  Props.push_back(Property("V", "1 V", false,
+  Props.push_back(qucs::Property("V", "1 V", false,
 		QObject::tr("voltage of high level")));
 }
 

--- a/qucs/components/diode.cpp
+++ b/qucs/components/diode.cpp
@@ -22,63 +22,63 @@ Diode::Diode()
 {
   Description = QObject::tr("diode");
 
-  Props.push_back(Property("Is", "1e-15 A", true,
+  Props.push_back(qucs::Property("Is", "1e-15 A", true,
 	QObject::tr("saturation current")));
-  Props.push_back(Property("N", "1", true,
+  Props.push_back(qucs::Property("N", "1", true,
 	QObject::tr("emission coefficient")));
-  Props.push_back(Property("Cj0", "10 fF", true,
+  Props.push_back(qucs::Property("Cj0", "10 fF", true,
 	QObject::tr("zero-bias junction capacitance")));
-  Props.push_back(Property("M", "0.5", false,
+  Props.push_back(qucs::Property("M", "0.5", false,
 	QObject::tr("grading coefficient")));
-  Props.push_back(Property("Vj", "0.7 V", false,
+  Props.push_back(qucs::Property("Vj", "0.7 V", false,
 	QObject::tr("junction potential")));
-  Props.push_back(Property("Fc", "0.5", false,
+  Props.push_back(qucs::Property("Fc", "0.5", false,
 	QObject::tr("forward-bias depletion capacitance coefficient")));
-  Props.push_back(Property("Cp", "0.0 fF", false,
+  Props.push_back(qucs::Property("Cp", "0.0 fF", false,
 	QObject::tr("linear capacitance")));
-  Props.push_back(Property("Isr", "0.0", false,
+  Props.push_back(qucs::Property("Isr", "0.0", false,
 	QObject::tr("recombination current parameter")));
-  Props.push_back(Property("Nr", "2.0", false,
+  Props.push_back(qucs::Property("Nr", "2.0", false,
 	QObject::tr("emission coefficient for Isr")));
-  Props.push_back(Property("Rs", "0.0 Ohm", false,
+  Props.push_back(qucs::Property("Rs", "0.0 Ohm", false,
 	QObject::tr("ohmic series resistance")));
-  Props.push_back(Property("Tt", "0.0 ps", false,
+  Props.push_back(qucs::Property("Tt", "0.0 ps", false,
 	QObject::tr("transit time")));
-  Props.push_back(Property("Ikf", "0", false,
+  Props.push_back(qucs::Property("Ikf", "0", false,
 	QObject::tr("high-injection knee current (0=infinity)")));
-  Props.push_back(Property("Kf", "0.0", false,
+  Props.push_back(qucs::Property("Kf", "0.0", false,
 	QObject::tr("flicker noise coefficient")));
-  Props.push_back(Property("Af", "1.0", false,
+  Props.push_back(qucs::Property("Af", "1.0", false,
 	QObject::tr("flicker noise exponent")));
-  Props.push_back(Property("Ffe", "1.0", false,
+  Props.push_back(qucs::Property("Ffe", "1.0", false,
 	QObject::tr("flicker noise frequency exponent")));
-  Props.push_back(Property("Bv", "0", false,
+  Props.push_back(qucs::Property("Bv", "0", false,
 	QObject::tr("reverse breakdown voltage")));
-  Props.push_back(Property("Ibv", "1 mA", false,
+  Props.push_back(qucs::Property("Ibv", "1 mA", false,
 	QObject::tr("current at reverse breakdown voltage")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Xti", "3.0", false,
+  Props.push_back(qucs::Property("Xti", "3.0", false,
 	QObject::tr("saturation current temperature exponent")));
-  Props.push_back(Property("Eg", "1.11", false,
+  Props.push_back(qucs::Property("Eg", "1.11", false,
 	QObject::tr("energy bandgap in eV")));
-  Props.push_back(Property("Tbv", "0.0", false,
+  Props.push_back(qucs::Property("Tbv", "0.0", false,
 	QObject::tr("Bv linear temperature coefficient")));
-  Props.push_back(Property("Trs", "0.0", false,
+  Props.push_back(qucs::Property("Trs", "0.0", false,
 	QObject::tr("Rs linear temperature coefficient")));
-  Props.push_back(Property("Ttt1", "0.0", false,
+  Props.push_back(qucs::Property("Ttt1", "0.0", false,
 	QObject::tr("Tt linear temperature coefficient")));
-  Props.push_back(Property("Ttt2", "0.0", false,
+  Props.push_back(qucs::Property("Ttt2", "0.0", false,
 	QObject::tr("Tt quadratic temperature coefficient")));
-  Props.push_back(Property("Tm1", "0.0", false,
+  Props.push_back(qucs::Property("Tm1", "0.0", false,
 	QObject::tr("M linear temperature coefficient")));
-  Props.push_back(Property("Tm2", "0.0", false,
+  Props.push_back(qucs::Property("Tm2", "0.0", false,
 	QObject::tr("M quadratic temperature coefficient")));
-  Props.push_back(Property("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
 	QObject::tr("temperature at which parameters were extracted")));
-  Props.push_back(Property("Area", "1.0", false,
+  Props.push_back(qucs::Property("Area", "1.0", false,
 	QObject::tr("default area for diode")));
-  Props.push_back(Property("Symbol", "normal", false,
+  Props.push_back(qucs::Property("Symbol", "normal", false,
 	QObject::tr("schematic symbol")+" [normal, US, Schottky, Zener, Varactor]"));
 
   createSymbol();
@@ -106,32 +106,32 @@ Element* Diode::info(QString& Name, char* &BitmapFile, bool getNewOne)
 void Diode::createSymbol()
 {
   if(Props.back().Value.at(0) == 'V') {
-    Lines.push_back(Line(-30,  0, -9,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -6,  0, 30,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -9, -9, -9,  9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30,  0, -9,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6,  0, 30,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9, -9, -9,  9,QPen(Qt::darkBlue,2)));
   }
   else if(Props.back().Value.at(0) == 'U') {
-    Lines.push_back(Line(-30,  0, -6,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(  6,  0, 30,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30,  0, -6,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(  6,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
-  Lines.push_back(Line( -6, -9, -6,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  6, -9,  6,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  0,  6, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, -9, -6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6, -9,  6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  0,  6, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
 
   if(Props.back().Value.at(0) == 'S') {
-    Lines.push_back(Line( -6, -9,-12,-12,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -6,  9,  0, 12,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6, -9,-12,-12,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6,  9,  0, 12,QPen(Qt::darkBlue,2)));
   }
   else if(Props.back().Value.at(0) == 'Z') {
-    Lines.push_back(Line( -6, 9, -1, 9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -6, 9, -1, 9,QPen(Qt::darkBlue,2)));
   }
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 = -11;
   x2 =  30; y2 =  11;

--- a/qucs/components/dmux2to4.cpp
+++ b/qucs/components/dmux2to4.cpp
@@ -24,9 +24,9 @@ dmux2to4::dmux2to4()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("2to4 demultiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,46 +56,46 @@ Element * dmux2to4::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void dmux2to4::createSymbol()
 {
-  Lines.push_back(Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -90, 30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  20,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  20,-30,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -90, 30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  20,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  20,-30,-90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // Y3
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // Y2
-  Lines.push_back(Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line( 30,-50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // Y3
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // Y2
+  Lines.push_back(qucs::Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line( 30,-50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
 
-  Arcs.push_back(Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-28,-63, "En",Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-20,-33, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-8, -38, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 2, -40, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 2, -20, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-28,-63, "En",Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-20,-33, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-8, -38, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 2, -40, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 2, -20, "3", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-28,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-28,-23, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-28,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-28,-23, "1", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 15,-63, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-43, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-23, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, -3, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-63, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-43, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-23, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, -3, "3", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(0, -18, 12, -18, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(0, -18, 12, -18, QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-50,-50));  // En
-  Ports.push_back(Port(-50,-30));  // A
-  Ports.push_back(Port(-50,-10));  // B
-  Ports.push_back(Port( 50, 10));  // Y3
-  Ports.push_back(Port( 50,-10));  // Y2
-  Ports.push_back(Port( 50,-30));  // Y1
-  Ports.push_back(Port( 50,-50));  // Y0
+  Ports.push_back(qucs::Port(-50,-50));  // En
+  Ports.push_back(qucs::Port(-50,-30));  // A
+  Ports.push_back(qucs::Port(-50,-10));  // B
+  Ports.push_back(qucs::Port( 50, 10));  // Y3
+  Ports.push_back(qucs::Port( 50,-10));  // Y2
+  Ports.push_back(qucs::Port( 50,-30));  // Y1
+  Ports.push_back(qucs::Port( 50,-50));  // Y0
 
   x1 = -50; y1 = -94;
   x2 =  50; y2 =  24;

--- a/qucs/components/dmux3to8.cpp
+++ b/qucs/components/dmux3to8.cpp
@@ -25,9 +25,9 @@ dmux3to8::dmux3to8()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("3to8 demultiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -57,61 +57,61 @@ Element * dmux3to8::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void dmux3to8::createSymbol()
 {
-  Lines.push_back(Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -90, 30, 100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  100,-30, 100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  100,-30, -90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -90, 30, 100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  100,-30, 100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  100,-30, -90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // C
+  Lines.push_back(qucs::Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // C
 
-  Lines.push_back(Line( 30, 90, 50, 90,QPen(Qt::darkBlue,2)));  // Y7
-  Lines.push_back(Line( 30, 70, 50, 70,QPen(Qt::darkBlue,2)));  // Y6
-  Lines.push_back(Line( 30, 50, 50, 50,QPen(Qt::darkBlue,2)));  // Y5
-  Lines.push_back(Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // Y4
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // Y3
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // Y2
-  Lines.push_back(Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line( 30,-50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line( 30, 90, 50, 90,QPen(Qt::darkBlue,2)));  // Y7
+  Lines.push_back(qucs::Line( 30, 70, 50, 70,QPen(Qt::darkBlue,2)));  // Y6
+  Lines.push_back(qucs::Line( 30, 50, 50, 50,QPen(Qt::darkBlue,2)));  // Y5
+  Lines.push_back(qucs::Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // Y4
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // Y3
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // Y2
+  Lines.push_back(qucs::Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line( 30,-50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
 
-  Arcs.push_back(Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-63, "En", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-20,-25, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-8, -30, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 2, -32, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 2, -13, "7", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-63, "En", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-20,-25, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-8, -30, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 2, -32, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 2, -13, "7", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, -3, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, -3, "2", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 15,-63, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-43, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-23, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, -3, "3", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 17, "4", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 37, "5", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 57, "6", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 77, "7", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-63, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-43, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-23, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, -3, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 17, "4", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 37, "5", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 57, "6", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 77, "7", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(0, -11, 12, -11, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(0, -11, 12, -11, QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-50,-50));  // En
-  Ports.push_back(Port(-50,-30));  // A
-  Ports.push_back(Port(-50,-10));  // B
-  Ports.push_back(Port(-50, 10));  // C
-  Ports.push_back(Port( 50, 90));  // Y7
-  Ports.push_back(Port( 50, 70));  // Y6
-  Ports.push_back(Port( 50, 50));  // Y5
-  Ports.push_back(Port( 50, 30));  // Y4
-  Ports.push_back(Port( 50, 10));  // Y3
-  Ports.push_back(Port( 50,-10));  // Y2
-  Ports.push_back(Port( 50,-30));  // Y1
-  Ports.push_back(Port( 50,-50));  // Y0
+  Ports.push_back(qucs::Port(-50,-50));  // En
+  Ports.push_back(qucs::Port(-50,-30));  // A
+  Ports.push_back(qucs::Port(-50,-10));  // B
+  Ports.push_back(qucs::Port(-50, 10));  // C
+  Ports.push_back(qucs::Port( 50, 90));  // Y7
+  Ports.push_back(qucs::Port( 50, 70));  // Y6
+  Ports.push_back(qucs::Port( 50, 50));  // Y5
+  Ports.push_back(qucs::Port( 50, 30));  // Y4
+  Ports.push_back(qucs::Port( 50, 10));  // Y3
+  Ports.push_back(qucs::Port( 50,-10));  // Y2
+  Ports.push_back(qucs::Port( 50,-30));  // Y1
+  Ports.push_back(qucs::Port( 50,-50));  // Y0
 
   x1 = -50; y1 = -94;
   x2 =  50; y2 = 104;

--- a/qucs/components/dmux4to16.cpp
+++ b/qucs/components/dmux4to16.cpp
@@ -24,9 +24,9 @@ dmux4to16::dmux4to16()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4to16 demultiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,87 +56,87 @@ Element * dmux4to16::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void dmux4to16::createSymbol()
 {
-  Lines.push_back(Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -90, 30, 110,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  110,-30, 110,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  110,-30, -90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -90, 30,-90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -90, 30, 110,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  110,-30, 110,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  110,-30, -90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // C
-  Lines.push_back(Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // D
+  Lines.push_back(qucs::Line(-50,-50,-40,-50,QPen(Qt::darkBlue,2)));  // EN
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // C
+  Lines.push_back(qucs::Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // D
 
-  Lines.push_back(Line( 30, 100, 50,100,QPen(Qt::darkBlue,2)));  // Y15
-  Lines.push_back(Line( 30,  90, 50, 90,QPen(Qt::darkBlue,2)));  // Y14
-  Lines.push_back(Line( 30,  80, 50, 80,QPen(Qt::darkBlue,2)));  // Y13
-  Lines.push_back(Line( 30,  70, 50, 70,QPen(Qt::darkBlue,2)));  // Y12
-  Lines.push_back(Line( 30,  60, 50, 60,QPen(Qt::darkBlue,2)));  // Y11
-  Lines.push_back(Line( 30,  50, 50, 50,QPen(Qt::darkBlue,2)));  // Y10
-  Lines.push_back(Line( 30,  40, 50, 40,QPen(Qt::darkBlue,2)));  // Y9
-  Lines.push_back(Line( 30,  30, 50, 30,QPen(Qt::darkBlue,2)));  // Y8
-  Lines.push_back(Line( 30,  20, 50, 20,QPen(Qt::darkBlue,2)));  // Y7
-  Lines.push_back(Line( 30,  10, 50, 10,QPen(Qt::darkBlue,2)));  // Y6
-  Lines.push_back(Line( 30,   0, 50,  0,QPen(Qt::darkBlue,2)));  // Y5
-  Lines.push_back(Line( 30, -10, 50,-10,QPen(Qt::darkBlue,2)));  // Y4
-  Lines.push_back(Line( 30, -20, 50,-20,QPen(Qt::darkBlue,2)));  // Y3
-  Lines.push_back(Line( 30, -30, 50,-30,QPen(Qt::darkBlue,2)));  // Y2
-  Lines.push_back(Line( 30, -40, 50,-40,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line( 30, -50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line( 30, 100, 50,100,QPen(Qt::darkBlue,2)));  // Y15
+  Lines.push_back(qucs::Line( 30,  90, 50, 90,QPen(Qt::darkBlue,2)));  // Y14
+  Lines.push_back(qucs::Line( 30,  80, 50, 80,QPen(Qt::darkBlue,2)));  // Y13
+  Lines.push_back(qucs::Line( 30,  70, 50, 70,QPen(Qt::darkBlue,2)));  // Y12
+  Lines.push_back(qucs::Line( 30,  60, 50, 60,QPen(Qt::darkBlue,2)));  // Y11
+  Lines.push_back(qucs::Line( 30,  50, 50, 50,QPen(Qt::darkBlue,2)));  // Y10
+  Lines.push_back(qucs::Line( 30,  40, 50, 40,QPen(Qt::darkBlue,2)));  // Y9
+  Lines.push_back(qucs::Line( 30,  30, 50, 30,QPen(Qt::darkBlue,2)));  // Y8
+  Lines.push_back(qucs::Line( 30,  20, 50, 20,QPen(Qt::darkBlue,2)));  // Y7
+  Lines.push_back(qucs::Line( 30,  10, 50, 10,QPen(Qt::darkBlue,2)));  // Y6
+  Lines.push_back(qucs::Line( 30,   0, 50,  0,QPen(Qt::darkBlue,2)));  // Y5
+  Lines.push_back(qucs::Line( 30, -10, 50,-10,QPen(Qt::darkBlue,2)));  // Y4
+  Lines.push_back(qucs::Line( 30, -20, 50,-20,QPen(Qt::darkBlue,2)));  // Y3
+  Lines.push_back(qucs::Line( 30, -30, 50,-30,QPen(Qt::darkBlue,2)));  // Y2
+  Lines.push_back(qucs::Line( 30, -40, 50,-40,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line( 30, -50, 50,-50,QPen(Qt::darkBlue,2)));  // Y0
 
-  Arcs.push_back(Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -40, -55, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-85, "DMUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-63, "En", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-26,-15, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-13,-20, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( -5,-20, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -8,  0, "15", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-63, "En", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-26,-15, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-13,-20, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( -5,-20, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -8,  0, "15", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 17, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 17, "3", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 15,-59, "0", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15,-49, "1", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15,-39, "2", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15,-29, "3", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15,-19, "4", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15, -9, "5", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15,  1, "6", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15, 11, "7", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15, 21, "8", Qt::darkBlue, 9.0));
-  Texts.push_back(Text( 15, 31, "9", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 41, "10", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 51, "11", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 61, "12", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 71, "13", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 81, "14", Qt::darkBlue, 9.0));
-  Texts.push_back(Text(  8, 91, "15", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,-59, "0", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,-49, "1", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,-39, "2", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,-29, "3", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,-19, "4", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15, -9, "5", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15,  1, "6", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15, 11, "7", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15, 21, "8", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text( 15, 31, "9", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 41, "10", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 51, "11", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 61, "12", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 71, "13", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 81, "14", Qt::darkBlue, 9.0));
+  Texts.push_back(qucs::Text(  8, 91, "15", Qt::darkBlue, 9.0));
 
-  Lines.push_back(Line(-6,  2, 9,  2, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-6,  2, 9,  2, QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-50,-50));  // En
-  Ports.push_back(Port(-50,-30));  // A
-  Ports.push_back(Port(-50,-10));  // B
-  Ports.push_back(Port(-50, 10));  // C
-  Ports.push_back(Port(-50, 30));  // D
-  Ports.push_back(Port( 50,100));  // Y15
-  Ports.push_back(Port( 50, 90));  // Y14
-  Ports.push_back(Port( 50, 80));  // Y13
-  Ports.push_back(Port( 50, 70));  // Y12
-  Ports.push_back(Port( 50, 60));  // Y11
-  Ports.push_back(Port( 50, 50));  // Y10
-  Ports.push_back(Port( 50, 40));  // Y9
-  Ports.push_back(Port( 50, 30));  // Y8
-  Ports.push_back(Port( 50, 20));  // Y7
-  Ports.push_back(Port( 50, 10));  // Y6
-  Ports.push_back(Port( 50,  0));  // Y5
-  Ports.push_back(Port( 50,-10));  // Y4
-  Ports.push_back(Port( 50,-20));  // Y3
-  Ports.push_back(Port( 50,-30));  // Y2
-  Ports.push_back(Port( 50,-40));  // Y1
-  Ports.push_back(Port( 50,-50));  // Y0
+  Ports.push_back(qucs::Port(-50,-50));  // En
+  Ports.push_back(qucs::Port(-50,-30));  // A
+  Ports.push_back(qucs::Port(-50,-10));  // B
+  Ports.push_back(qucs::Port(-50, 10));  // C
+  Ports.push_back(qucs::Port(-50, 30));  // D
+  Ports.push_back(qucs::Port( 50,100));  // Y15
+  Ports.push_back(qucs::Port( 50, 90));  // Y14
+  Ports.push_back(qucs::Port( 50, 80));  // Y13
+  Ports.push_back(qucs::Port( 50, 70));  // Y12
+  Ports.push_back(qucs::Port( 50, 60));  // Y11
+  Ports.push_back(qucs::Port( 50, 50));  // Y10
+  Ports.push_back(qucs::Port( 50, 40));  // Y9
+  Ports.push_back(qucs::Port( 50, 30));  // Y8
+  Ports.push_back(qucs::Port( 50, 20));  // Y7
+  Ports.push_back(qucs::Port( 50, 10));  // Y6
+  Ports.push_back(qucs::Port( 50,  0));  // Y5
+  Ports.push_back(qucs::Port( 50,-10));  // Y4
+  Ports.push_back(qucs::Port( 50,-20));  // Y3
+  Ports.push_back(qucs::Port( 50,-30));  // Y2
+  Ports.push_back(qucs::Port( 50,-40));  // Y1
+  Ports.push_back(qucs::Port( 50,-50));  // Y0
 
   x1 = -50; y1 = -94;
   x2 =  50; y2 = 114;

--- a/qucs/components/ecvs.cpp
+++ b/qucs/components/ecvs.cpp
@@ -21,38 +21,38 @@ ecvs::ecvs()
   Description = QObject::tr("externally controlled voltage source");
 
 
-//  Arcs.push_back(Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
-//  Arcs.push_back(Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+//  Arcs.push_back(qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
+//  Arcs.push_back(qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
 
   // Circle in middle
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
   // The 'E' symbol in middle of circle
   // horizontal lines (actually drawn vertically here)
-  Lines.push_back(Line(4, -3, 4, 3,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(0, -3, 0, 2,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-4, -3, -4, 3,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(4, -3, 4, 3,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(0, -3, 0, 2,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-4, -3, -4, 3,QPen(Qt::darkGreen,2)));
   // Vertical Line
-  Lines.push_back(Line(4, -3, -4, -3,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(4, -3, -4, -3,QPen(Qt::darkGreen,2)));
 
   // Wires at top and bottom
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
   // positive symbol
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
   // negative symbol
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
-//  Lines.push_back(Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
-//  Lines.push_back(Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
-//  Lines.push_back(Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
-//  Lines.push_back(Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
-//  Lines.push_back(Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
-//  Lines.push_back(Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
-//  Lines.push_back(Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
+//  Lines.push_back(qucs::Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
+//  Lines.push_back(qucs::Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
+//  Lines.push_back(qucs::Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
+//  Lines.push_back(qucs::Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
+//  Lines.push_back(qucs::Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
+//  Lines.push_back(qucs::Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
+//  Lines.push_back(qucs::Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -62,9 +62,9 @@ ecvs::ecvs()
   Model = "ECVS";
   Name  = "ECVS";
 
-  Props.push_back(Property("U", "0 V", true,
+  Props.push_back(qucs::Property("U", "0 V", true,
 		QObject::tr("voltage in Volts")));
-//  Props.push_back(Property("Interpolator", "linear", false,
+//  Props.push_back(qucs::Property("Interpolator", "linear", false,
 //		QObject::tr("interpolation type")+" [hold, linear, cubic]"));
 
   rotate();  // fix historical flaw

--- a/qucs/components/eqndefined.cpp
+++ b/qucs/components/eqndefined.cpp
@@ -28,15 +28,15 @@ EqnDefined::EqnDefined()
   Name  = "D";
 
   // first properties !!!
-  Props.push_back(Property("Type", "explicit", false,
+  Props.push_back(qucs::Property("Type", "explicit", false,
 		QObject::tr("type of equations")+" [explicit, implicit]"));
-  Props.push_back(Property("Branches", "1", false,
+  Props.push_back(qucs::Property("Branches", "1", false,
 		QObject::tr("number of branches")));
 
   // last properties
-  Props.push_back(Property("I1", "0", true,
+  Props.push_back(qucs::Property("I1", "0", true,
 		QObject::tr("current equation") + " 1"));
-  Props.push_back(Property("Q1", "0", false,
+  Props.push_back(qucs::Property("Q1", "0", false,
 		QObject::tr("charge equation") + " 1"));
 
   createSymbol();
@@ -116,9 +116,9 @@ void EqnDefined::createSymbol()
   int NumProps = (Props.size() - 2) / 2; // current number of properties
   if (NumProps < Num) {
     for(i = NumProps; i < Num; i++) {
-      Props.push_back(Property("I"+QString::number(i+1), "0", false,
+      Props.push_back(qucs::Property("I"+QString::number(i+1), "0", false,
 		QObject::tr("current equation") + " " +QString::number(i+1)));
-      Props.push_back(Property("Q"+QString::number(i+1), "0", false,
+      Props.push_back(qucs::Property("Q"+QString::number(i+1), "0", false,
 		QObject::tr("charge equation") + " " +QString::number(i+1)));
     }
   } else {
@@ -137,33 +137,33 @@ void EqnDefined::createSymbol()
 
   // draw symbol
   int h = (PortDistance/2)*((Num-1)) + PortDistance/2; // total component half-height
-  Lines.push_back(Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2))); // top side
-  Lines.push_back(Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2))); // right side
-  Lines.push_back(Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2))); // bottom side
-  Lines.push_back(Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2))); // left side
+  Lines.push_back(qucs::Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2))); // top side
+  Lines.push_back(qucs::Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2))); // right side
+  Lines.push_back(qucs::Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2))); // bottom side
+  Lines.push_back(qucs::Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2))); // left side
 
   i=0;
   int y = PortDistance/2-h, yh; // y is the actual vertical center
   while(i<Num) { // for every branch
     i++;
     // left connection with port
-    Lines.push_back(Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30, y));
+    Lines.push_back(qucs::Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30, y));
     // small black arrow inside the box
-    Lines.push_back(Line( 7,y-3, 10, y,QPen(Qt::black,1)));
-    Lines.push_back(Line( 7,y+3, 10, y,QPen(Qt::black,1)));
-    Lines.push_back(Line(-10, y, 10, y,QPen(Qt::black,1)));
+    Lines.push_back(qucs::Line( 7,y-3, 10, y,QPen(Qt::black,1)));
+    Lines.push_back(qucs::Line( 7,y+3, 10, y,QPen(Qt::black,1)));
+    Lines.push_back(qucs::Line(-10, y, 10, y,QPen(Qt::black,1)));
 
     if (i > 1) {
       yh = y-PortDistance/2; // bottom of the branch box
       // draw horizontal separation between boxes
-      Lines.push_back(Line(-15, yh, 15, yh, QPen(Qt::darkBlue,2)));
+      Lines.push_back(qucs::Line(-15, yh, 15, yh, QPen(Qt::darkBlue,2)));
     }
     // right connection with port
-    Lines.push_back(Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30, y));
+    Lines.push_back(qucs::Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30, y));
     // add branch number near the right connection port
-    Texts.push_back(Text(25,y-fHeight-2,QString::number(i))); // left-aligned
+    Texts.push_back(qucs::Text(25,y-fHeight-2,QString::number(i))); // left-aligned
     // move the vertical center down for the next branch
     y += PortDistance;
   }

--- a/qucs/components/equation.cpp
+++ b/qucs/components/equation.cpp
@@ -33,9 +33,9 @@ Equation::Equation()
   int xb = r.width()  >> 1;
   int yb = r.height() >> 1;
 
-  Lines.push_back(Line(-xb, -yb, -xb,  yb,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text(-xb+4,  -yb-3, QObject::tr("Equation"),
+  Lines.push_back(qucs::Line(-xb, -yb, -xb,  yb,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-xb,  yb,  xb+3,yb,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text(-xb+4,  -yb-3, QObject::tr("Equation"),
 			QColor(0,0,0), 12.0));
 
   x1 = -xb-3;  y1 = -yb-5;
@@ -46,8 +46,8 @@ Equation::Equation()
   Model = "Eqn"; // BUG: don't use
   Name  = "Eqn"; // BUG: don't use
 
-  Props.push_back(Property("y", "1", true));
-  Props.push_back(Property("Export", "yes", false,
+  Props.push_back(qucs::Property("y", "1", true));
+  Props.push_back(qucs::Property("Export", "yes", false,
   		QObject::tr("put result into dataset")+" [yes, no]"));
 }
 

--- a/qucs/components/etr_sim.cpp
+++ b/qucs/components/etr_sim.cpp
@@ -26,9 +26,9 @@ ETR_Sim::ETR_Sim()
   int a = 17;
   s[a] = '\n';
 
-  Texts.push_back(Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
   if (a != -1)
-    Texts.push_back(Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+130; y2 = y1+59;
@@ -38,39 +38,39 @@ ETR_Sim::ETR_Sim()
   Model = ".ETR";
   Name  = "ETR";
 
-  Props.push_back(Property("IntegrationMethod", "Trapezoidal", false,
+  Props.push_back(qucs::Property("IntegrationMethod", "Trapezoidal", false,
 	QObject::tr("integration method")+
 	" [Euler, Trapezoidal, Gear, AdamsMoulton]"));
-  Props.push_back(Property("Order", "2", false,
+  Props.push_back(qucs::Property("Order", "2", false,
 	QObject::tr("order of integration method")+" (1-6)"));
-  Props.push_back(Property("InitialStep", "1 ns", false,
+  Props.push_back(qucs::Property("InitialStep", "1 ns", false,
 	QObject::tr("initial step size in seconds")));
-  Props.push_back(Property("MinStep", "1e-16", false,
+  Props.push_back(qucs::Property("MinStep", "1e-16", false,
 	QObject::tr("minimum step size in seconds")));
-  Props.push_back(Property("MaxIter", "150", false,
+  Props.push_back(qucs::Property("MaxIter", "150", false,
 	QObject::tr("maximum number of iterations until error")));
-  Props.push_back(Property("reltol", "0.001", false,
+  Props.push_back(qucs::Property("reltol", "0.001", false,
 	QObject::tr("relative tolerance for convergence")));
-  Props.push_back(Property("abstol", "1 pA", false,
+  Props.push_back(qucs::Property("abstol", "1 pA", false,
 	QObject::tr("absolute tolerance for currents")));
-  Props.push_back(Property("vntol", "1 uV", false,
+  Props.push_back(qucs::Property("vntol", "1 uV", false,
 	QObject::tr("absolute tolerance for voltages")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("LTEreltol", "1e-3", false,
+  Props.push_back(qucs::Property("LTEreltol", "1e-3", false,
 	QObject::tr("relative tolerance of local truncation error")));
-  Props.push_back(Property("LTEabstol", "1e-6", false,
+  Props.push_back(qucs::Property("LTEabstol", "1e-6", false,
 	QObject::tr("absolute tolerance of local truncation error")));
-  Props.push_back(Property("LTEfactor", "1", false,
+  Props.push_back(qucs::Property("LTEfactor", "1", false,
 	QObject::tr("overestimation of local truncation error")));
-  Props.push_back(Property("Solver", "CroutLU", false,
+  Props.push_back(qucs::Property("Solver", "CroutLU", false,
 	QObject::tr("method for solving the circuit matrix")+
 	" [CroutLU, DoolittleLU, HouseholderQR, HouseholderLQ, GolubSVD]"));
-  Props.push_back(Property("relaxTSR", "no", false,
+  Props.push_back(qucs::Property("relaxTSR", "no", false,
 	QObject::tr("relax time step raster")+" [no, yes]"));
-  Props.push_back(Property("initialDC", "yes", false,
+  Props.push_back(qucs::Property("initialDC", "yes", false,
 	QObject::tr("perform an initial DC analysis")+" [yes, no]"));
-  Props.push_back(Property("MaxStep", "0", false,
+  Props.push_back(qucs::Property("MaxStep", "0", false,
 	QObject::tr("maximum step size in seconds")));
 }
 

--- a/qucs/components/fa1b.cpp
+++ b/qucs/components/fa1b.cpp
@@ -24,9 +24,9 @@ fa1b::fa1b()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("1bit full adder verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,30 +56,30 @@ Element * fa1b::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void fa1b::createSymbol()
 {
-  Lines.push_back(Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -40, 30, 50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  50,-30, 50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  50,-30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -40, 30, 50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  50,-30, 50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  50,-30,-40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // CI
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // CO
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // S
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // CI
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // CO
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // S
   
-  Texts.push_back(Text(-25, 17, "CI", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 0,  -3, "CO", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 17, "CI", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 0,  -3, "CO", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(-10,-35, 10, -35, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-35,  5, -25, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,-25,-10, -15, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-15, 10, -15, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-35, 10, -35, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-35,  5, -25, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,-25,-10, -15, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15, 10, -15, QPen(Qt::darkBlue,2)));
  
-  Ports.push_back(Port(-50,-10));  // A
-  Ports.push_back(Port(-50, 10));  // B
-  Ports.push_back(Port(-50, 30));  // CI
-  Ports.push_back(Port( 50, 10));  // CO
-  Ports.push_back(Port( 50,-10));  // S
+  Ports.push_back(qucs::Port(-50,-10));  // A
+  Ports.push_back(qucs::Port(-50, 10));  // B
+  Ports.push_back(qucs::Port(-50, 30));  // CI
+  Ports.push_back(qucs::Port( 50, 10));  // CO
+  Ports.push_back(qucs::Port( 50,-10));  // S
 
   x1 = -50; y1 = -44;
   x2 =  50; y2 =  54;

--- a/qucs/components/fa2b.cpp
+++ b/qucs/components/fa2b.cpp
@@ -24,9 +24,9 @@ fa2b::fa2b()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("2bit full adder verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,49 +56,49 @@ Element * fa2b::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void fa2b::createSymbol()
 {
-  Lines.push_back(Line(-40, -60, 40,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40, -60, 40, 90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  90,-40, 90,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-40,  90,-40, -60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40, -60, 40,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40, -60, 40, 90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  90,-40, 90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40,  90,-40, -60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X0
-  Lines.push_back(Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X1
-  Lines.push_back(Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
-  Lines.push_back(Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
-  Lines.push_back(Line(-60, 70,-40, 70,QPen(Qt::darkBlue,2)));  // CI
+  Lines.push_back(qucs::Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // X0
+  Lines.push_back(qucs::Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // X1
+  Lines.push_back(qucs::Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // Y0
+  Lines.push_back(qucs::Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // Y1
+  Lines.push_back(qucs::Line(-60, 70,-40, 70,QPen(Qt::darkBlue,2)));  // CI
 
-  Lines.push_back(Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // C0
-  Lines.push_back(Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // S1
-  Lines.push_back(Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // S0
+  Lines.push_back(qucs::Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // C0
+  Lines.push_back(qucs::Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // S1
+  Lines.push_back(qucs::Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // S0
 
-  Lines.push_back(Line( -10, -55, 10, -55, QPen(Qt::darkBlue,2)));  
-  Lines.push_back(Line( -10, -55,  0, -45, QPen(Qt::darkBlue,2)));  
-  Lines.push_back(Line(  0,  -45,-10, -35, QPen(Qt::darkBlue,2)));  
-  Lines.push_back(Line( -10, -35, 10, -35, QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line( -10, -55, 10, -55, QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line( -10, -55,  0, -45, QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line(  0,  -45,-10, -35, QPen(Qt::darkBlue,2)));  
+  Lines.push_back(qucs::Line( -10, -35, 10, -35, QPen(Qt::darkBlue,2)));  
 
-  Texts.push_back(Text(-25,-20,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15,-13,   "X",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35,-23,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, -3,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 22,   "{",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text(-15, 29,   "Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 57,  "CI",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 17,-20,   "}",  Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 3, -13,   "S",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 28,-23,   "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 28, -3,   "1",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 10, 17,  "CO",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-20,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15,-13,   "X",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-23,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, -3,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 22,   "{",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text(-15, 29,   "Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 17,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 37,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 57,  "CI",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 17,-20,   "}",  Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 3, -13,   "S",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 28,-23,   "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 28, -3,   "1",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 10, 17,  "CO",  Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-60,-10));  // X0 -> D
-  Ports.push_back(Port(-60, 10));  // X1 -> C
-  Ports.push_back(Port(-60, 30));  // Y0 -> B
-  Ports.push_back(Port(-60, 50));  // Y1 -> A
-  Ports.push_back(Port(-60, 70));  // CI -> E
-  Ports.push_back(Port( 60, 30));  // CO
-  Ports.push_back(Port( 60, 10));  // S1
-  Ports.push_back(Port( 60,-10));  // S0
+  Ports.push_back(qucs::Port(-60,-10));  // X0 -> D
+  Ports.push_back(qucs::Port(-60, 10));  // X1 -> C
+  Ports.push_back(qucs::Port(-60, 30));  // Y0 -> B
+  Ports.push_back(qucs::Port(-60, 50));  // Y1 -> A
+  Ports.push_back(qucs::Port(-60, 70));  // CI -> E
+  Ports.push_back(qucs::Port( 60, 30));  // CO
+  Ports.push_back(qucs::Port( 60, 10));  // S1
+  Ports.push_back(qucs::Port( 60,-10));  // S0
 
   x1 = -60; y1 = -64;
   x2 =  60; y2 =  94;

--- a/qucs/components/gatedDlatch.cpp
+++ b/qucs/components/gatedDlatch.cpp
@@ -24,11 +24,11 @@ gatedDlatch::gatedDlatch()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("gated D latch verilog device");
 
-  Props.push_back (Property ("TR_H", "6", false,
+  Props.push_back(qucs::Property("TR_H", "6", false,
     QObject::tr ("cross coupled gate transfer function high scaling factor")));
-  Props.push_back (Property ("TR_L", "5", false,
+  Props.push_back(qucs::Property("TR_L", "5", false,
     QObject::tr ("cross coupled gate transfer function low scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("cross coupled gate delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -58,28 +58,28 @@ Element * gatedDlatch::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void gatedDlatch::createSymbol()
 {
-  Lines.push_back(Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -40, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 40,-30, -40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -40, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 40,-30, -40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2))); // D
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2))); // C
-  Lines.push_back(Line( 40, 20, 50, 20,QPen(Qt::darkBlue,2))); // QB
-  Lines.push_back(Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2))); // Q
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2))); // D
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2))); // C
+  Lines.push_back(qucs::Line( 40, 20, 50, 20,QPen(Qt::darkBlue,2))); // QB
+  Lines.push_back(qucs::Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2))); // Q
 
-  Arcs.push_back(Arc( 30, 15, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 30, 15, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-25,-32, "D", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,  7, "C", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,-32, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,  7, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-32, "D", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,  7, "C", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,-32, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,  7, "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
 
-  Ports.push_back(Port(-50,-20));  // D
-  Ports.push_back(Port(-50, 20));  // C
-  Ports.push_back(Port( 50, 20));  // QB
-  Ports.push_back(Port( 50,-20));  // Q
+  Ports.push_back(qucs::Port(-50,-20));  // D
+  Ports.push_back(qucs::Port(-50, 20));  // C
+  Ports.push_back(qucs::Port( 50, 20));  // QB
+  Ports.push_back(qucs::Port( 50,-20));  // Q
 
   x1 = -50; y1 = -44;
   x2 =  50; y2 =  44;

--- a/qucs/components/greytobinary4bit.cpp
+++ b/qucs/components/greytobinary4bit.cpp
@@ -24,9 +24,9 @@ greytobinary4bit::greytobinary4bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4bit Gray to binary converter verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,44 +56,44 @@ Element * greytobinary4bit::info(QString& Name, char * &BitmapFile, bool getNewO
 
 void greytobinary4bit::createSymbol()
 {
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  40,-30, -60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  40,-30, -60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // G0
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // G1
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // G2
-  Lines.push_back(Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // G3
+  Lines.push_back(qucs::Line(-50,-30,-30,-30,QPen(Qt::darkBlue,2)));  // G0
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // G1
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // G2
+  Lines.push_back(qucs::Line(-50, 30,-30, 30,QPen(Qt::darkBlue,2)));  // G3
 
-  Lines.push_back(Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // B3
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // B2
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // B1
-  Lines.push_back(Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // B0
+  Lines.push_back(qucs::Line( 30, 30, 50, 30,QPen(Qt::darkBlue,2)));  // B3
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // B2
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // B1
+  Lines.push_back(qucs::Line( 30,-30, 50,-30,QPen(Qt::darkBlue,2)));  // B0
  
-  Texts.push_back(Text(-16,-59, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -2,-59, "/", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  5,-59, "B", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-16,-59, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -2,-59, "/", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  5,-59, "B", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,-23, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, -3, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 17, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-23, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, -3, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 17, "3", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 15,-43, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15,-23, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, -3, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 15, 17, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-43, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15,-23, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, -3, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 15, 17, "3", Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-50,-30));  // G0
-  Ports.push_back(Port(-50,-10));  // G1
-  Ports.push_back(Port(-50, 10));  // G2
-  Ports.push_back(Port(-50, 30));  // G3
+  Ports.push_back(qucs::Port(-50,-30));  // G0
+  Ports.push_back(qucs::Port(-50,-10));  // G1
+  Ports.push_back(qucs::Port(-50, 10));  // G2
+  Ports.push_back(qucs::Port(-50, 30));  // G3
 
-  Ports.push_back(Port( 50, 30));  // B3
-  Ports.push_back(Port( 50, 10));  // B2
-  Ports.push_back(Port( 50,-10));  // B1
-  Ports.push_back(Port( 50,-30));  // B0
+  Ports.push_back(qucs::Port( 50, 30));  // B3
+  Ports.push_back(qucs::Port( 50, 10));  // B2
+  Ports.push_back(qucs::Port( 50,-10));  // B1
+  Ports.push_back(qucs::Port( 50,-30));  // B0
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  44;

--- a/qucs/components/ground.cpp
+++ b/qucs/components/ground.cpp
@@ -24,12 +24,12 @@ Ground::Ground()
   Type = isComponent;   // both analog and digital
   Description = QObject::tr("ground (reference potential)");
 
-  Lines.push_back(Line(  0,  0,  0, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11, 10, 11, 10,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( -7, 16,  7, 16,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( -3, 22,  3, 22,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  0,  0,  0, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11, 10, 11, 10,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -7, 16,  7, 16,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -3, 22,  3, 22,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(  0,  0));
+  Ports.push_back(qucs::Port(  0,  0));
 
   x1 = -12; y1 =  0;
   x2 =  12; y2 = 25;

--- a/qucs/components/gyrator.cpp
+++ b/qucs/components/gyrator.cpp
@@ -22,26 +22,26 @@ Gyrator::Gyrator()
 {
   Description = QObject::tr("gyrator (impedance inverter)");
 
-  Arcs.push_back(Arc(  3, -9, 18, 18, 16*90, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-21, -9, 18, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  3, -9, 18, 18, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-21, -9, 18, 18,16*270, 16*180,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 12,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 12, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 12,-30, 12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12,-30, 12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-22,-22, 22,-22,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 22,-22, 22, 22,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 22, 22,-22, 22,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-22, 22,-22,-22,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-22,-22, 22,-22,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 22,-22, 22, 22,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 22, 22,-22, 22,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-22, 22,-22,-22,QPen(Qt::darkGray,1)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -51,9 +51,9 @@ Gyrator::Gyrator()
   Model = "Gyrator";
   Name  = "X";
 
-  Props.push_back(Property("R", "50 Ohm", true,
+  Props.push_back(qucs::Property("R", "50 Ohm", true,
 		QObject::tr("gyrator ratio")));
-  Props.push_back(Property("Zref", "50 Ohm", false,
+  Props.push_back(qucs::Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));
 }
 

--- a/qucs/components/ha1b.cpp
+++ b/qucs/components/ha1b.cpp
@@ -24,9 +24,9 @@ ha1b::ha1b()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("1bit half adder verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,27 +56,27 @@ Element * ha1b::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void ha1b::createSymbol()
 {
-  Lines.push_back(Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -40, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  30,-30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  30,-30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -40, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  30,-30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  30,-30,-40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // CO
-  Lines.push_back(Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // S
+  Lines.push_back(qucs::Line(-50,-10,-30,-10,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-50, 10,-30, 10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));  // CO
+  Lines.push_back(qucs::Line( 30,-10, 50,-10,QPen(Qt::darkBlue,2)));  // S
 
-  Texts.push_back(Text(0, -3, "CO", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(0, -3, "CO", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(-10,-35, 10, -35, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-35,  5, -25, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,-25,-10, -15, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-15, 10, -15, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-35, 10, -35, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-35,  5, -25, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,-25,-10, -15, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15, 10, -15, QPen(Qt::darkBlue,2)));
  
-  Ports.push_back(Port(-50,-10));  // A
-  Ports.push_back(Port(-50, 10));  // B
-  Ports.push_back(Port( 50, 10));  // CO
-  Ports.push_back(Port( 50,-10));  // S
+  Ports.push_back(qucs::Port(-50,-10));  // A
+  Ports.push_back(qucs::Port(-50, 10));  // B
+  Ports.push_back(qucs::Port( 50, 10));  // CO
+  Ports.push_back(qucs::Port( 50,-10));  // S
 
   x1 = -50; y1 = -44;
   x2 =  50; y2 =  34;

--- a/qucs/components/hb_sim.cpp
+++ b/qucs/components/hb_sim.cpp
@@ -26,9 +26,9 @@ HB_Sim::HB_Sim()
   int a = s.lastIndexOf(" ");
   if (a != -1) s[a] = '\n';    // break line before the word "simulation"
 
-  Texts.push_back(Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
   if (a != -1)
-    Texts.push_back(Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+163; y2 = y1+59;
@@ -38,17 +38,17 @@ HB_Sim::HB_Sim()
   Model = ".HB";
   Name  = "HB";
 
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("n", "4", true,
+  Props.push_back(qucs::Property("n", "4", true,
 		QObject::tr("number of harmonics")));
-  Props.push_back(Property("iabstol", "1 pA", false,
+  Props.push_back(qucs::Property("iabstol", "1 pA", false,
 		QObject::tr("absolute tolerance for currents")));
-  Props.push_back(Property("vabstol", "1 uV", false,
+  Props.push_back(qucs::Property("vabstol", "1 uV", false,
 		QObject::tr("absolute tolerance for voltages")));
-  Props.push_back(Property("reltol", "0.001", false,
+  Props.push_back(qucs::Property("reltol", "0.001", false,
 		QObject::tr("relative tolerance for convergence")));
-  Props.push_back(Property("MaxIter", "150", false,
+  Props.push_back(qucs::Property("MaxIter", "150", false,
 		QObject::tr("maximum number of iterations until error")));
 }
 

--- a/qucs/components/hpribin4bit.cpp
+++ b/qucs/components/hpribin4bit.cpp
@@ -24,9 +24,9 @@ hpribin4bit::hpribin4bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4bit highest priority encoder (binary form) verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -56,37 +56,37 @@ Element * hpribin4bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void hpribin4bit::createSymbol()
 {
-  Lines.push_back(Line(-40, -50, 40,-50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40, -50, 40, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  60,-40, 60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-40,  60,-40, -50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40, -50, 40,-50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40, -50, 40, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  60,-40, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40,  60,-40, -50,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // A
-  Lines.push_back(Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // B
-  Lines.push_back(Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // C
-  Lines.push_back(Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // D
-  Lines.push_back(Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // V
-  Lines.push_back(Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // Y
-  Lines.push_back(Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // X
+  Lines.push_back(qucs::Line(-60,-10,-40,-10,QPen(Qt::darkBlue,2)));  // A
+  Lines.push_back(qucs::Line(-60, 10,-40, 10,QPen(Qt::darkBlue,2)));  // B
+  Lines.push_back(qucs::Line(-60, 30,-40, 30,QPen(Qt::darkBlue,2)));  // C
+  Lines.push_back(qucs::Line(-60, 50,-40, 50,QPen(Qt::darkBlue,2)));  // D
+  Lines.push_back(qucs::Line( 40, 30, 60, 30,QPen(Qt::darkBlue,2)));  // V
+  Lines.push_back(qucs::Line( 40, 10, 60, 10,QPen(Qt::darkBlue,2)));  // Y
+  Lines.push_back(qucs::Line( 40,-10, 60,-10,QPen(Qt::darkBlue,2)));  // X
 
-  Texts.push_back(Text(-35,-45, "HPRI/BIN", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-45, "HPRI/BIN", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-35,-23,  "0",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, -3,  "1",  Qt::darkBlue, 12.0)); 
-  Texts.push_back(Text(-35, 17,  "2",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-35, 37,  "3",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35,-23,  "0",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, -3,  "1",  Qt::darkBlue, 12.0)); 
+  Texts.push_back(qucs::Text(-35, 17,  "2",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-35, 37,  "3",  Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text( 25, 17,  "V",  Qt::darkBlue, 12.0)); 
-  Texts.push_back(Text( 25, -3,  "Y",  Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 25,-23,  "X",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 25, 17,  "V",  Qt::darkBlue, 12.0)); 
+  Texts.push_back(qucs::Text( 25, -3,  "Y",  Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 25,-23,  "X",  Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-60,-10));  // A
-  Ports.push_back(Port(-60, 10));  // B
-  Ports.push_back(Port(-60, 30));  // C
-  Ports.push_back(Port(-60, 50));  // D
-  Ports.push_back(Port( 60, 30));  // V
-  Ports.push_back(Port( 60, 10));  // Y
-  Ports.push_back(Port( 60,-10));  // X
+  Ports.push_back(qucs::Port(-60,-10));  // A
+  Ports.push_back(qucs::Port(-60, 10));  // B
+  Ports.push_back(qucs::Port(-60, 30));  // C
+  Ports.push_back(qucs::Port(-60, 50));  // D
+  Ports.push_back(qucs::Port( 60, 30));  // V
+  Ports.push_back(qucs::Port( 60, 10));  // Y
+  Ports.push_back(qucs::Port( 60,-10));  // X
 
   x1 = -60; y1 = -54;
   x2 =  60; y2 =  64;

--- a/qucs/components/hybrid.cpp
+++ b/qucs/components/hybrid.cpp
@@ -18,31 +18,31 @@ Hybrid::Hybrid()
 {
   Description = QObject::tr("hybrid (unsymmetrical 3dB coupler)");
 
-  Lines.push_back(Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(-28,-28, 28, 28, 16*270, 16*90,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  0,-28, 28, 28, 16*180, 16*90,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-28,  0, 28, 28,      0, 16*90,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  0,  0, 28, 28,  16*90, 16*90,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-28,-28, 28, 28, 16*270, 16*90,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  0,-28, 28, 28, 16*180, 16*90,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-28,  0, 28, 28,      0, 16*90,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  0,  0, 28, 28,  16*90, 16*90,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc(-11,-11, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-11,  5, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  6,-11, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  6,  5, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 8, -12, 8, -4,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-11,-11, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-11,  5, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  6,-11, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  6,  5, 4, 6, 0, 16*360,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 8, -12, 8, -4,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-30,  0,-14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 14,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 14,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port(  0,-30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port(  0,-30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -52,9 +52,9 @@ Hybrid::Hybrid()
   Model = "Hybrid";
   Name  = "X";
 
-  Props.push_back(Property("phi", "90", true,
+  Props.push_back(qucs::Property("phi", "90", true,
 		QObject::tr("phase shift in degree")));
-  Props.push_back(Property("Zref", "50 Ohm", false,
+  Props.push_back(qucs::Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));
 }
 

--- a/qucs/components/iexp.cpp
+++ b/qucs/components/iexp.cpp
@@ -23,27 +23,27 @@ iExp::iExp()
   Description = QObject::tr("exponential current source");
 
   // normal current source symbol
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
   // write 'Exp' beside current source symbol
-  Lines.push_back(Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13,  7, 21, 7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  7, 17, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 21,  7, 21, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13,  13, 17, 17,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  13, 13, 17,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  20, 11, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  20, 17, 23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13,  20, 13, 23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  23, 13, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  7, 21, 7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  7, 17, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 21,  7, 21, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  13, 17, 17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  13, 13, 17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  20, 11, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  20, 17, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  20, 13, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  23, 13, 23,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  20;
@@ -53,17 +53,17 @@ iExp::iExp()
   Model = "Iexp";
   Name  = "I";
 
-  Props.push_back(Property("I1", "0", true,
+  Props.push_back(qucs::Property("I1", "0", true,
 		QObject::tr("current before rising edge")));
-  Props.push_back(Property("I2", "1 A", true,
+  Props.push_back(qucs::Property("I2", "1 A", true,
 		QObject::tr("maximum current of the pulse")));
-  Props.push_back(Property("T1", "0", true,
+  Props.push_back(qucs::Property("T1", "0", true,
 		QObject::tr("start time of the exponentially rising edge")));
-  Props.push_back(Property("T2", "1 ms", true,
+  Props.push_back(qucs::Property("T2", "1 ms", true,
 		QObject::tr("start of exponential decay")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("time constant of the rising edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("time constant of the falling edge")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/ifile.cpp
+++ b/qucs/components/ifile.cpp
@@ -23,23 +23,23 @@ iFile::iFile()
 {
   Description = QObject::tr("file based current source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -49,14 +49,14 @@ iFile::iFile()
   Model = "Ifile";
   Name  = "I";
 
-  Props.push_back(Property("File", "ifile.dat", true,
+  Props.push_back(qucs::Property("File", "ifile.dat", true,
 		QObject::tr("name of the sample file")));
-  Props.push_back(Property("Interpolator", "linear", false,
+  Props.push_back(qucs::Property("Interpolator", "linear", false,
 		QObject::tr("interpolation type")+" [hold, linear, cubic]"));
-  Props.push_back(Property("Repeat", "no", false,
+  Props.push_back(qucs::Property("Repeat", "no", false,
 		QObject::tr("repeat waveform")+" [no, yes]"));
-  Props.push_back(Property("G", "1", false, QObject::tr("current gain")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("G", "1", false, QObject::tr("current gain")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 
   rotate();  // fix historical flaw
 }

--- a/qucs/components/indq.cpp
+++ b/qucs/components/indq.cpp
@@ -28,28 +28,28 @@ indq::indq()
   Description = QObject::tr("Lossy inductor");
 
   //Spiral
-  Arcs.push_back(Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
 
 
   //Draw Q character
   //Horizontal lines
-  Lines.push_back(Line( 10,  -10, 17,  -10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  -17, 17,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -10, 17,  -10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -17, 17,  -17,QPen(Qt::darkBlue,2)));
   //Vertical lines
-  Lines.push_back(Line( 17,  -10, 17,  -17,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  -10, 10,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  -10, 17,  -17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  -10, 10,  -17,QPen(Qt::darkBlue,2)));
   //Middle line
-  Lines.push_back(Line( 18,  -9, 14,  -13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  -9, 14,  -13,QPen(Qt::darkBlue,2)));
 
 
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -13;
   x2 =  30; y2 =  13;
@@ -59,16 +59,16 @@ indq::indq()
   Model = "INDQ";
   Name  = "INDQ";
 
-  Props.push_back(Property("L", "1 nH", true,
+  Props.push_back(qucs::Property("L", "1 nH", true,
 		QObject::tr("Inductance")));
-  Props.push_back(Property("Q", "100", true,
+  Props.push_back(qucs::Property("Q", "100", true,
 		QObject::tr("Quality factor")));
-  Props.push_back(Property("f", "100 MHz", false,
+  Props.push_back(qucs::Property("f", "100 MHz", false,
 		QObject::tr("Frequency at which Q is measured")));
-  Props.push_back(Property("Mode", "Linear", false,
+  Props.push_back(qucs::Property("Mode", "Linear", false,
 		QObject::tr("Q frequency profile")+
 		" [Linear, SquareRoot, Constant]"));
-   Props.push_back(Property("Temp", "26.85", false,
+   Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 indq::~indq()

--- a/qucs/components/inductor.cpp
+++ b/qucs/components/inductor.cpp
@@ -22,14 +22,14 @@ Inductor::Inductor()
 {
   Description = QObject::tr("inductor");
 
-  Arcs.push_back(Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-18, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  6, -6, 12, 12,  0, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -10;
   x2 =  30; y2 =   6;
@@ -39,9 +39,9 @@ Inductor::Inductor()
   Model = "L";
   Name  = "L";
 
-  Props.push_back(Property("L", "1 nH", true,
+  Props.push_back(qucs::Property("L", "1 nH", true,
 		QObject::tr("inductance in Henry")));
-  Props.push_back(Property("I", "", false,
+  Props.push_back(qucs::Property("I", "", false,
 		QObject::tr("initial current for transient simulation")));
 }
 

--- a/qucs/components/iprobe.cpp
+++ b/qucs/components/iprobe.cpp
@@ -22,27 +22,27 @@ iProbe::iProbe()
 {
   Description = QObject::tr("current probe");
 
-  Lines.push_back(Line(-30,  0,-20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  0, 20,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  4,  0, -4, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  4,  0, -4,  4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  0, 20,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  4,  0, -4, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  4,  0, -4,  4,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-20,-31, 20,-31,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  9, 20,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-31,-20,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-31, 20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-31, 20,-31,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  9, 20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-31,-20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-31, 20,  9,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-16,-27, 16,-27,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-27,-16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-27, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-27, 16,-27,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-27,-16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-27, 16, -9,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(-20,-23, 39, 39, 16*50, 16*80,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11,-24, -2, -9,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-20,-23, 39, 39, 16*50, 16*80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11,-24, -2, -9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -34;
   x2 =  30; y2 =  12;

--- a/qucs/components/ipulse.cpp
+++ b/qucs/components/ipulse.cpp
@@ -22,22 +22,22 @@ iPulse::iPulse()
 {
   Description = QObject::tr("ideal current pulse source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
   // little pulse symbol
-  Lines.push_back(Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 19, 10, 19, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 14, 13, 17,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 10, 19, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 14, 19, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  7, 13, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19, 10, 19, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 14, 13, 17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 10, 19, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 14, 19, 14,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  20;
@@ -47,17 +47,17 @@ iPulse::iPulse()
   Model = "Ipulse";
   Name  = "I";
 
-  Props.push_back(Property("I1", "0", true,
+  Props.push_back(qucs::Property("I1", "0", true,
 		QObject::tr("current before and after the pulse")));
-  Props.push_back(Property("I2", "1 A", true,
+  Props.push_back(qucs::Property("I2", "1 A", true,
 		QObject::tr("current of the pulse")));
-  Props.push_back(Property("T1", "0", true,
+  Props.push_back(qucs::Property("T1", "0", true,
 		QObject::tr("start time of the pulse")));
-  Props.push_back(Property("T2", "1 ms", true,
+  Props.push_back(qucs::Property("T2", "1 ms", true,
 		QObject::tr("ending time of the pulse")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("fall time of the trailing edge")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/irect.cpp
+++ b/qucs/components/irect.cpp
@@ -22,24 +22,24 @@ iRect::iRect()
 {
   Description = QObject::tr("ideal rectangle current source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7,  0,  7,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0, -4,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  6,  0,  0,  4,QPen(Qt::darkBlue,3)));
 
   // little rectangle symbol
-  Lines.push_back(Line( 19,  5, 19,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13,  7, 19,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13,  7, 13, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 11, 19, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 19, 11, 19, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 15, 19, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, 15, 13, 17,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19,  5, 19,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  7, 19,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13,  7, 13, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 11, 19, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19, 11, 19, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 15, 19, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, 15, 13, 17,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  20;
@@ -49,17 +49,17 @@ iRect::iRect()
   Model = "Irect";
   Name  = "I";
 
-  Props.push_back(Property("I", "1 mA", true,
+  Props.push_back(qucs::Property("I", "1 mA", true,
 		QObject::tr("current at high pulse")));
-  Props.push_back(Property("TH", "1 ms", true,
+  Props.push_back(qucs::Property("TH", "1 ms", true,
 		QObject::tr("duration of high pulses")));
-  Props.push_back(Property("TL", "1 ms", true,
+  Props.push_back(qucs::Property("TL", "1 ms", true,
 		QObject::tr("duration of low pulses")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("fall time of the trailing edge")));
-  Props.push_back(Property("Td", "0 ns", false,
+  Props.push_back(qucs::Property("Td", "0 ns", false,
 		QObject::tr("initial delay time")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/isolator.cpp
+++ b/qucs/components/isolator.cpp
@@ -22,20 +22,20 @@ Isolator::Isolator()
 {
   Description = QObject::tr("isolator");
 
-  Lines.push_back(Line( -8,  0,  8,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  8,  0,  0, -5,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(  8,  0,  0,  5,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -8,  0,  8,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  8,  0,  0, -5,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(  8,  0,  0,  5,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -17;
   x2 =  30; y2 =  17;
@@ -45,11 +45,11 @@ Isolator::Isolator()
   Model = "Isolator";
   Name  = "X";
 
-  Props.push_back(Property("Z1", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z1", "50 Ohm", false,
 		QObject::tr("reference impedance of input port")));
-  Props.push_back(Property("Z2", "50 Ohm", false,
+  Props.push_back(qucs::Property("Z2", "50 Ohm", false,
 		QObject::tr("reference impedance of output port")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/jfet.cpp
+++ b/qucs/components/jfet.cpp
@@ -23,53 +23,53 @@ JFET::JFET()
   Description = QObject::tr("junction field-effect transistor");
 
   // this must be the first property in the list !!!
-  Props.push_back(Property("Type", "nfet", true,
+  Props.push_back(qucs::Property("Type", "nfet", true,
 	QObject::tr("polarity")+" [nfet, pfet]"));
-  Props.push_back(Property("Vt0", "-2.0 V", true,
+  Props.push_back(qucs::Property("Vt0", "-2.0 V", true,
 	QObject::tr("threshold voltage")));
-  Props.push_back(Property("Beta", "1e-4", true,
+  Props.push_back(qucs::Property("Beta", "1e-4", true,
 	QObject::tr("transconductance parameter")));
-  Props.push_back(Property("Lambda", "0.0", true,
+  Props.push_back(qucs::Property("Lambda", "0.0", true,
 	QObject::tr("channel-length modulation parameter")));
-  Props.push_back(Property("Rd", "0.0", false,
+  Props.push_back(qucs::Property("Rd", "0.0", false,
 	QObject::tr("parasitic drain resistance")));
-  Props.push_back(Property("Rs", "0.0", false,
+  Props.push_back(qucs::Property("Rs", "0.0", false,
 	QObject::tr("parasitic source resistance")));
-  Props.push_back(Property("Is", "1e-14", false,
+  Props.push_back(qucs::Property("Is", "1e-14", false,
 	QObject::tr("gate-junction saturation current")));
-  Props.push_back(Property("N", "1.0", false,
+  Props.push_back(qucs::Property("N", "1.0", false,
 	QObject::tr("gate-junction emission coefficient")));
-  Props.push_back(Property("Isr", "1e-14", false,
+  Props.push_back(qucs::Property("Isr", "1e-14", false,
 	QObject::tr("gate-junction recombination current parameter")));
-  Props.push_back(Property("Nr", "2.0", false,
+  Props.push_back(qucs::Property("Nr", "2.0", false,
 	QObject::tr("Isr emission coefficient")));
-  Props.push_back(Property("Cgs", "0.0", false,
+  Props.push_back(qucs::Property("Cgs", "0.0", false,
 	QObject::tr("zero-bias gate-source junction capacitance")));
-  Props.push_back(Property("Cgd", "0.0", false,
+  Props.push_back(qucs::Property("Cgd", "0.0", false,
 	QObject::tr("zero-bias gate-drain junction capacitance")));
-  Props.push_back(Property("Pb", "1.0", false,
+  Props.push_back(qucs::Property("Pb", "1.0", false,
 	QObject::tr("gate-junction potential")));
-  Props.push_back(Property("Fc", "0.5", false,
+  Props.push_back(qucs::Property("Fc", "0.5", false,
 	QObject::tr("forward-bias junction capacitance coefficient")));
-  Props.push_back(Property("M", "0.5", false,
+  Props.push_back(qucs::Property("M", "0.5", false,
 	QObject::tr("gate P-N grading coefficient")));
-  Props.push_back(Property("Kf", "0.0", false,
+  Props.push_back(qucs::Property("Kf", "0.0", false,
 	QObject::tr("flicker noise coefficient")));
-  Props.push_back(Property("Af", "1.0", false,
+  Props.push_back(qucs::Property("Af", "1.0", false,
 	QObject::tr("flicker noise exponent")));
-  Props.push_back(Property("Ffe", "1.0", false,
+  Props.push_back(qucs::Property("Ffe", "1.0", false,
 	QObject::tr("flicker noise frequency exponent")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Xti", "3.0", false,
+  Props.push_back(qucs::Property("Xti", "3.0", false,
 	QObject::tr("saturation current temperature exponent")));
-  Props.push_back(Property("Vt0tc", "0.0", false,
+  Props.push_back(qucs::Property("Vt0tc", "0.0", false,
 	QObject::tr("Vt0 temperature coefficient")));
-  Props.push_back(Property("Betatce", "0.0", false,
+  Props.push_back(qucs::Property("Betatce", "0.0", false,
 	QObject::tr("Beta exponential temperature coefficient")));
-  Props.push_back(Property("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
 	QObject::tr("temperature at which parameters were extracted")));
-  Props.push_back(Property("Area", "1.0", false,
+  Props.push_back(qucs::Property("Area", "1.0", false,
 	QObject::tr("default area for JFET")));
 
   createSymbol();
@@ -116,27 +116,27 @@ Element* JFET::info_p(QString& Name, char* &BitmapFile, bool getNewOne)
 // -------------------------------------------------------
 void JFET::createSymbol()
 {
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-10,  0,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-10,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,  0, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 10,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-10,  0,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-10,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,  0, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 10,  0, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
 
   if(Props.front().Value == "nfet") {
-    Lines.push_back(Line(-16, -5,-11,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-16,  5,-11,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-16, -5,-11,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-16,  5,-11,  0,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line(-18,  0,-13, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-18,  0,-13,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-18,  0,-13, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-18,  0,-13,  5,QPen(Qt::darkBlue,2)));
   }
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -30;
   x2 =   4; y2 =  30;

--- a/qucs/components/jk_flipflop.cpp
+++ b/qucs/components/jk_flipflop.cpp
@@ -25,38 +25,38 @@ JK_FlipFlop::JK_FlipFlop()
   Type = isDigitalComponent;
   Description = QObject::tr("JK flip flop with asynchron set and reset");
 
-  Props.push_back(Property("t", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("t", "0", false, QObject::tr("delay time")));
 
-  Lines.push_back(Line(-20,-30, 20,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 30, 20, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-30,-20, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-30, 20, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-30, 20,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 30, 20, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-30,-20, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-30, 20, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-20, 20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 20, 20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-30,  0,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 30,  0, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-20, 20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 30,  0, 40,QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text( -4,-29, "S", Qt::darkBlue,  9.0));
-  Texts.push_back(Text( -4, 14, "R", Qt::darkBlue,  9.0));
-  Texts.push_back(Text(-18,-31, "J", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-18,  8, "K", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  6,-31, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  6,  8, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -4,-29, "S", Qt::darkBlue,  9.0));
+  Texts.push_back(qucs::Text( -4, 14, "R", Qt::darkBlue,  9.0));
+  Texts.push_back(qucs::Text(-18,-31, "J", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-18,  8, "K", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  6,-31, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  6,  8, "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
-  Lines.push_back(Line(-20, -4,-12,  0,QPen(Qt::darkBlue,0)));
-  Lines.push_back(Line(-20,  4,-12,  0,QPen(Qt::darkBlue,0)));
+  Lines.push_back(qucs::Line(-20, -4,-12,  0,QPen(Qt::darkBlue,0)));
+  Lines.push_back(qucs::Line(-20,  4,-12,  0,QPen(Qt::darkBlue,0)));
 
-  Ports.push_back(Port(-30,-20));  // J
-  Ports.push_back(Port(-30, 20));  // K
-  Ports.push_back(Port( 30,-20));  // Q
-  Ports.push_back(Port( 30, 20));  // nQ
-  Ports.push_back(Port(-30,  0));  // Clock
-  Ports.push_back(Port(  0,-40));  // set
-  Ports.push_back(Port(  0, 40));  // reset
+  Ports.push_back(qucs::Port(-30,-20));  // J
+  Ports.push_back(qucs::Port(-30, 20));  // K
+  Ports.push_back(qucs::Port( 30,-20));  // Q
+  Ports.push_back(qucs::Port( 30, 20));  // nQ
+  Ports.push_back(qucs::Port(-30,  0));  // Clock
+  Ports.push_back(qucs::Port(  0,-40));  // set
+  Ports.push_back(qucs::Port(  0, 40));  // reset
 
   x1 = -30; y1 = -40;
   x2 =  30; y2 =  40;

--- a/qucs/components/jkff_SR.cpp
+++ b/qucs/components/jkff_SR.cpp
@@ -24,11 +24,11 @@ jkff_SR::jkff_SR()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("jk flip flop with set and reset verilog device");
 
-  Props.push_back (Property ("TR_H", "6", false,
+  Props.push_back(qucs::Property("TR_H", "6", false,
     QObject::tr ("cross coupled gate transfer function high scaling factor")));
-  Props.push_back (Property ("TR_L", "5", false,
+  Props.push_back(qucs::Property("TR_L", "5", false,
     QObject::tr ("cross coupled gate transfer function low scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("cross coupled gate delay")
     +" ("+QObject::tr ("s")+")"));
 
@@ -59,42 +59,42 @@ Element * jkff_SR::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void jkff_SR::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-30,-40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-40, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 40,-30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-40, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 40,-30,-40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-10,-20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10,-20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-10,-20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10,-20,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  0,-50,  0,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 50,  0, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-50,  0,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 50,  0, 60,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(  -5, -50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  -5,  40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  -5, -50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  -5,  40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-25,-32, "J", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,  7, "K", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,-32, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,-39, "S", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,  7, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-32, "J", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,  7, "K", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,-32, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,-39, "S", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,  7, "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
-  Texts.push_back(Text( -5, 17, "R", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5, 17, "R", Qt::darkBlue, 12.0));
  
-  Ports.push_back(Port(  0,-60));  // S
-  Ports.push_back(Port(-50,-20));  // J
-  Ports.push_back(Port(-50, 0));   // CLK
-  Ports.push_back(Port(-50, 20));  // K
-  Ports.push_back(Port(  0, 60));  // R
-  Ports.push_back(Port( 50, 20));  // QB
-  Ports.push_back(Port( 50,-20));  // Q
+  Ports.push_back(qucs::Port(  0,-60));  // S
+  Ports.push_back(qucs::Port(-50,-20));  // J
+  Ports.push_back(qucs::Port(-50, 0));   // CLK
+  Ports.push_back(qucs::Port(-50, 20));  // K
+  Ports.push_back(qucs::Port(  0, 60));  // R
+  Ports.push_back(qucs::Port( 50, 20));  // QB
+  Ports.push_back(qucs::Port( 50,-20));  // Q
 
   x1 = -50; y1 = -60;
   x2 =  50; y2 =  60;

--- a/qucs/components/libcomp.cpp
+++ b/qucs/components/libcomp.cpp
@@ -32,14 +32,14 @@ LibComp::LibComp()
   Type = isComponent;   // both analog and digital
   Description = QObject::tr("Component taken from Qucs library");
 
-  Ports.push_back(Port(0,  0));  // dummy port because of being device
+  Ports.push_back(qucs::Port(0,  0));  // dummy port because of being device
 
   Model = "Lib";
   Name  = "X";
 
-  Props.push_back(Property("Lib", "", true,
+  Props.push_back(qucs::Property("Lib", "", true,
 		QObject::tr("name of qucs library file")));
-  Props.push_back(Property("Comp", "", true,
+  Props.push_back(qucs::Property("Comp", "", true,
 		QObject::tr("name of component in library")));
 }
 
@@ -66,10 +66,10 @@ void LibComp::createSymbol()
   }
   else {
     // only paint a rectangle
-    Lines.push_back(Line(-15, -15, 15, -15, QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 15, -15, 15,  15, QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,  15, 15,  15, QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15, -15,-15,  15, QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, -15, 15, -15, QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15, -15, 15,  15, QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,  15, 15,  15, QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, -15,-15,  15, QPen(Qt::darkBlue,2)));
 
     x1 = -18; y1 = -18;
     x2 =  18; y2 =  18;

--- a/qucs/components/log_amp.cpp
+++ b/qucs/components/log_amp.cpp
@@ -14,53 +14,53 @@ log_amp::log_amp()
 {
   Description = QObject::tr ("Logarithmic Amplifier verilog device");
 
-  Props.push_back (Property ("Kv", "1.0", false,
+  Props.push_back(qucs::Property ("Kv", "1.0", false,
     QObject::tr ("scale factor")));
-  Props.push_back (Property ("Dk", "0.3", false,
+  Props.push_back(qucs::Property ("Dk", "0.3", false,
     QObject::tr ("scale factor error")
     +" ("+QObject::tr ("%")+")"));
-  Props.push_back (Property ("Ib1", "5e-12", false,
+  Props.push_back(qucs::Property ("Ib1", "5e-12", false,
     QObject::tr ("input I1 bias current")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Ibr", "5e-12", false,
+  Props.push_back(qucs::Property ("Ibr", "5e-12", false,
     QObject::tr ("input reference bias current")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("M", "5", false,
+  Props.push_back(qucs::Property ("M", "5", false,
     QObject::tr ("number of decades")));
-  Props.push_back (Property ("N", "0.1", false,
+  Props.push_back(qucs::Property ("N", "0.1", false,
     QObject::tr ("conformity error")
     +" ("+QObject::tr ("%")+")"));
-  Props.push_back (Property ("Vosout", "3e-3", false,
+  Props.push_back(qucs::Property ("Vosout", "3e-3", false,
     QObject::tr ("output offset error")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Rinp", "1e6", false,
+  Props.push_back(qucs::Property ("Rinp", "1e6", false,
     QObject::tr ("amplifier input resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Fc", "1e3", false,
+  Props.push_back(qucs::Property ("Fc", "1e3", false,
     QObject::tr ("amplifier 3dB frequency")
     +" ("+QObject::tr ("Hz")+")"));
-  Props.push_back (Property ("Ro", "1e-3", false,
+  Props.push_back(qucs::Property ("Ro", "1e-3", false,
     QObject::tr ("amplifier output resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Ntc", "0.002", false,
+  Props.push_back(qucs::Property ("Ntc", "0.002", false,
     QObject::tr ("conformity error temperature coefficient")
     +" ("+QObject::tr ("%/Celsius")+")"));
-  Props.push_back (Property ("Vosouttc", "80e-6", false,
+  Props.push_back(qucs::Property ("Vosouttc", "80e-6", false,
     QObject::tr ("offset temperature coefficient")
     +" ("+QObject::tr ("V/Celsius")+")"));
-  Props.push_back (Property ("Dktc", "0.03", false,
+  Props.push_back(qucs::Property ("Dktc", "0.03", false,
     QObject::tr ("scale factor error temperature coefficient")
     +" ("+QObject::tr ("%/Celsius")+")"));
-  Props.push_back (Property ("Ib1tc", "0.5e-12", false,
+  Props.push_back(qucs::Property ("Ib1tc", "0.5e-12", false,
     QObject::tr ("input I1 bias current temperature coefficient")
     +" ("+QObject::tr ("A/Celsius")+")"));
-  Props.push_back (Property ("Ibrtc", "0.5e-12", false,
+  Props.push_back(qucs::Property ("Ibrtc", "0.5e-12", false,
     QObject::tr ("input reference bias current temperature coefficient")
     +" ("+QObject::tr ("A/Celsius")+")"));
-  Props.push_back (Property ("Tnom", "26.85", false,
+  Props.push_back(qucs::Property ("Tnom", "26.85", false,
     QObject::tr ("parameter measurement temperature")
     +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Temp", "26.85", false,
+  Props.push_back(qucs::Property ("Temp", "26.85", false,
     QObject::tr ("simulation temperature")));
 
   createSymbol ();
@@ -89,23 +89,23 @@ Element * log_amp::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void log_amp::createSymbol()
 {
-  Lines.push_back(Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-5, -10, -5, 10,QPen(Qt::red,2)));
-  Lines.push_back(Line(-5,  10,  5,  10,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-5, -10, -5, 10,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-5,  10,  5,  10,QPen(Qt::red,2)));
 
-  Texts.push_back(Text(-17, -26, QObject::tr("I"), Qt::black, 10.0, 1.0, 0.0));
-  Texts.push_back(Text(-17,  14, QObject::tr("R"), Qt::black, 10.0, 1.0, 0.0));
+  Texts.push_back(qucs::Text(-17, -26, QObject::tr("I"), Qt::black, 10.0, 1.0, 0.0));
+  Texts.push_back(qucs::Text(-17,  14, QObject::tr("R"), Qt::black, 10.0, 1.0, 0.0));
   
-  Ports.push_back(Port(-30,-20));
-  Ports.push_back(Port(-30, 20));
-  Ports.push_back(Port( 40,  0));
+  Ports.push_back(qucs::Port(-30,-20));
+  Ports.push_back(qucs::Port(-30, 20));
+  Ports.push_back(qucs::Port( 40,  0));
 
   x1 = -30; y1 = -38;
   x2 =  40; y2 =  38;

--- a/qucs/components/logic_0.cpp
+++ b/qucs/components/logic_0.cpp
@@ -23,7 +23,7 @@ logic_0::logic_0()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("logic 0 verilog device");
 
-  Props.push_back (Property ("LEVEL", "0", false,
+  Props.push_back(qucs::Property("LEVEL", "0", false,
     QObject::tr ("logic 0 voltage level")
     +" ("+QObject::tr ("V")+")"));
 
@@ -53,16 +53,16 @@ Element * logic_0::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void logic_0::createSymbol()
 {
-  Lines.push_back(Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
 
-  Texts.push_back(Text(-30,-12, "0", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-30,-12, "0", Qt::darkGreen, 12.0));
 
-  Ports.push_back(Port(  0,  0)); // L0
+  Ports.push_back(qucs::Port(  0,  0)); // L0
 
   x1 = -39; y1 = -14;
   x2 = 0;   y2 =  14;

--- a/qucs/components/logic_1.cpp
+++ b/qucs/components/logic_1.cpp
@@ -23,7 +23,7 @@ logic_1::logic_1()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("logic 1 verilog device");
 
- Props.push_back (Property ("LEVEL", "1", false,
+ Props.push_back(qucs::Property("LEVEL", "1", false,
     QObject::tr ("logic 1 voltage level")
     +" ("+QObject::tr ("V")+")"));
   createSymbol ();
@@ -54,16 +54,16 @@ Element * logic_1::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void logic_1::createSymbol()
 {
 
-  Lines.push_back(Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-10,  0,  0,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20,-10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-20, 10,-10,  0,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-20,-10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35, 10,-20, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-35,-10,-35, 10,QPen(Qt::darkGreen,2)));
 
-  Texts.push_back(Text(-30,-12, "1", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-30,-12, "1", Qt::darkGreen, 12.0));
 
-  Ports.push_back(Port(  0,  0)); // L1
+  Ports.push_back(qucs::Port(  0,  0)); // L1
 
   x1 = -39; y1 = -14;
   x2 = 0;   y2 =  14;

--- a/qucs/components/logical_buf.cpp
+++ b/qucs/components/logical_buf.cpp
@@ -26,15 +26,15 @@ Logical_Buf::Logical_Buf()
   Description = QObject::tr("logical buffer");
 
   // the list order must be preserved !!!
-  Props.push_back(Property("V", "1 V", false,
+  Props.push_back(qucs::Property("V", "1 V", false,
 		QObject::tr("voltage of high level")));
-  Props.push_back(Property("t", "0", false,
+  Props.push_back(qucs::Property("t", "0", false,
 		QObject::tr("delay time")));
-  Props.push_back(Property("TR", "10", false,
+  Props.push_back(qucs::Property("TR", "10", false,
 		QObject::tr("transfer function scaling factor")));
 
   // this must be the last property in the list !!!
-  Props.push_back(Property("Symbol", "old", false,
+  Props.push_back(qucs::Property("Symbol", "old", false,
 		QObject::tr("schematic symbol")+" [old, DIN40900]"));
 
   createSymbol();
@@ -64,7 +64,7 @@ QString Logical_Buf::vhdlCode(int NumPorts)
 QString Logical_Buf::verilogCode(int NumPorts)
 {
   bool synthesize = true;
-  Port &pp = port(0);
+  qucs::Port &pp = port(0);
   QString s ("");
 
   if (synthesize) {
@@ -90,26 +90,26 @@ void Logical_Buf::createSymbol()
   int xr;
 
   if(Props.back().Value.at(0) == 'D') {  // DIN symbol
-    Lines.push_back(Line( 15,-20, 15, 20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-20, 15,-20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15, 20, 15, 20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-20,-15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15,-20, 15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-20, 15,-20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, 20, 15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-20,-15, 20,QPen(Qt::darkBlue,2)));
 
-    Texts.push_back(Text(-11,-17, "1", Qt::darkBlue, 15.0));
+    Texts.push_back(qucs::Text(-11,-17, "1", Qt::darkBlue, 15.0));
     xr =  15;
   }
   else {   // old symbol
-    Lines.push_back(Line(-10,-20,-10,20, QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,-20, 40, 30,  0, 16*90,QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,-10, 40, 30,  0,-16*90,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 10,-5, 10, 5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-10,-20,-10,20, QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,-20, 40, 30,  0, 16*90,QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,-10, 40, 30,  0,-16*90,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 10,-5, 10, 5,QPen(Qt::darkBlue,2)));
     xr =  10;
   }
 
-  Lines.push_back(Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 0,-xr, 0, QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port( 30, 0));
-  Ports.push_back(Port(-30, 0));
+  Lines.push_back(qucs::Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 0,-xr, 0, QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
 
   x1 = -30; y1 = -23;
   x2 =  30; y2 =  23;

--- a/qucs/components/logical_inv.cpp
+++ b/qucs/components/logical_inv.cpp
@@ -26,15 +26,15 @@ Logical_Inv::Logical_Inv()
   Description = QObject::tr("logical inverter");
 
   // the list order must be preserved !!!
-  Props.push_back(Property("V", "1 V", false,
+  Props.push_back(qucs::Property("V", "1 V", false,
 		QObject::tr("voltage of high level")));
-  Props.push_back(Property("t", "0", false,
+  Props.push_back(qucs::Property("t", "0", false,
 		QObject::tr("delay time")));
-  Props.push_back(Property("TR", "10", false,
+  Props.push_back(qucs::Property("TR", "10", false,
 		QObject::tr("transfer function scaling factor")));
 
   // this must be the last property in the list !!!
-  Props.push_back(Property("Symbol", "old", false,
+  Props.push_back(qucs::Property("Symbol", "old", false,
 		QObject::tr("schematic symbol")+" [old, DIN40900]"));
 
   createSymbol();
@@ -64,7 +64,7 @@ QString Logical_Inv::vhdlCode(int NumPorts)
 QString Logical_Inv::verilogCode(int NumPorts)
 {
   bool synthesize = true;
-  Port &pp = port(0);
+  qucs::Port &pp = port(0);
   QString s ("");
 
   if (synthesize) {
@@ -104,29 +104,29 @@ void Logical_Inv::createSymbol()
   int xr;
 
   if(Props.back().Value.at(0) == 'D') {  // DIN symbol
-    Lines.push_back(Line( 15,-20, 15, 20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-20, 15,-20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15, 20, 15, 20,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15,-20,-15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15,-20, 15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-20, 15,-20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, 20, 15, 20,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,-20,-15, 20,QPen(Qt::darkBlue,2)));
 
-    Texts.push_back(Text(-11,-17, "1", Qt::darkBlue, 15.0));
+    Texts.push_back(qucs::Text(-11,-17, "1", Qt::darkBlue, 15.0));
     xr =  15;
   }
   else {   // old symbol
-    Lines.push_back(Line(-10,-20,-10,20, QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,-20, 40, 30,  0, 16*90,QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(-30,-10, 40, 30,  0,-16*90,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 10,-5, 10, 5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-10,-20,-10,20, QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,-20, 40, 30,  0, 16*90,QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-30,-10, 40, 30,  0,-16*90,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 10,-5, 10, 5,QPen(Qt::darkBlue,2)));
     xr =  10;
   }
 
-  Ellips.push_back(Area(xr,-4, 8, 8,
+  Ellips.push_back(qucs::Area(xr,-4, 8, 8,
                 QPen(Qt::darkBlue,0), QBrush(Qt::darkBlue)));
 
-  Lines.push_back(Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 0,-xr, 0, QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port( 30, 0));
-  Ports.push_back(Port(-30, 0));
+  Lines.push_back(qucs::Line( xr, 0, 30, 0, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 0,-xr, 0, QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
 
   x1 = -30; y1 = -23;
   x2 =  30; y2 =  23;

--- a/qucs/components/mod_amp.cpp
+++ b/qucs/components/mod_amp.cpp
@@ -14,40 +14,40 @@ mod_amp::mod_amp()
 {
   Description = QObject::tr ("Modular Operational Amplifier verilog device");
 
-  Props.push_back (Property ("GBP", "1e6", false,
-    QObject::tr ("Gain bandwidth product (Hz)")));
-  Props.push_back (Property ("AOLDC", "106.0", false,
-    QObject::tr ("Open-loop differential gain at DC (dB)")));
-  Props.push_back (Property ("FP2", "3e6", false,
-    QObject::tr ("Second pole frequency (Hz)")));
-  Props.push_back (Property ("RO", "75", false,
-    QObject::tr ("Output resistance (Ohm)")));
-  Props.push_back (Property ("CD", "1e-12", false,
-    QObject::tr ("Differential input capacitance (F)")));
-  Props.push_back (Property ("RD", "2e6", false,
-    QObject::tr ("Differential input resistance (Ohm)")));
-  Props.push_back (Property ("IOFF", "20e-9", false,
-    QObject::tr ("Input offset current (A)")));
-  Props.push_back (Property ("IB", "80e-9", false,
-    QObject::tr ("Input bias current (A)")));
-  Props.push_back (Property ("VOFF", "7e-4", false,
-    QObject::tr ("Input offset voltage (V)")));
-  Props.push_back (Property ("CMRRDC", "90.0", false,
-    QObject::tr ("Common-mode rejection ratio at DC (dB)")));
-  Props.push_back (Property ("FCM", "200.0", false,
-    QObject::tr ("Common-mode zero corner frequency (Hz)")));
-  Props.push_back (Property ("PSRT", "5e5", false,
-    QObject::tr ("Positive slew rate (V/s)")));
-  Props.push_back (Property ("NSRT", "5e5", false,
-    QObject::tr ("Negative slew rate (V/s)")));
-  Props.push_back (Property ("VLIMP", "14", false,
-    QObject::tr ("Positive output voltage limit (V)")));
-  Props.push_back (Property ("VLIMN", "-14", false,
-    QObject::tr ("Negative output voltage limit (V)")));
-  Props.push_back (Property ("ILMAX", "35e-3", false,
-    QObject::tr ("Maximum DC output current (A)")));
- Props.push_back (Property ("CSCALE", "50", false,
-    QObject::tr ("Current limit scale factor")));
+  Props.push_back(qucs::Property ("GBP", "1e6", false,
+    QObject::tr("Gain bandwidth product (Hz)")));
+  Props.push_back(qucs::Property ("AOLDC", "106.0", false,
+    QObject::tr("Open-loop differential gain at DC (dB)")));
+  Props.push_back(qucs::Property ("FP2", "3e6", false,
+    QObject::tr("Second pole frequency (Hz)")));
+  Props.push_back(qucs::Property ("RO", "75", false,
+    QObject::tr("Output resistance (Ohm)")));
+  Props.push_back(qucs::Property ("CD", "1e-12", false,
+    QObject::tr("Differential input capacitance (F)")));
+  Props.push_back(qucs::Property ("RD", "2e6", false,
+    QObject::tr("Differential input resistance (Ohm)")));
+  Props.push_back(qucs::Property ("IOFF", "20e-9", false,
+    QObject::tr("Input offset current (A)")));
+  Props.push_back(qucs::Property ("IB", "80e-9", false,
+    QObject::tr("Input bias current (A)")));
+  Props.push_back(qucs::Property ("VOFF", "7e-4", false,
+    QObject::tr("Input offset voltage (V)")));
+  Props.push_back(qucs::Property ("CMRRDC", "90.0", false,
+    QObject::tr("Common-mode rejection ratio at DC (dB)")));
+  Props.push_back(qucs::Property ("FCM", "200.0", false,
+    QObject::tr("Common-mode zero corner frequency (Hz)")));
+  Props.push_back(qucs::Property ("PSRT", "5e5", false,
+    QObject::tr("Positive slew rate (V/s)")));
+  Props.push_back(qucs::Property ("NSRT", "5e5", false,
+    QObject::tr("Negative slew rate (V/s)")));
+  Props.push_back(qucs::Property ("VLIMP", "14", false,
+    QObject::tr("Positive output voltage limit (V)")));
+  Props.push_back(qucs::Property ("VLIMN", "-14", false,
+    QObject::tr("Negative output voltage limit (V)")));
+  Props.push_back(qucs::Property ("ILMAX", "35e-3", false,
+    QObject::tr("Maximum DC output current (A)")));
+ Props.push_back(qucs::Property ("CSCALE", "50", false,
+    QObject::tr("Current limit scale factor")));
   createSymbol ();
   tx = x2 + 4;
   ty = y1 + 4;
@@ -75,26 +75,26 @@ Element * mod_amp::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void mod_amp::createSymbol()
 {
 
-  Lines.push_back(Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-16, 19, -9, 19,QPen(Qt::black,2)));
-  Lines.push_back(Line(-16,-19, -9,-19,QPen(Qt::red,2)));
-  Lines.push_back(Line(-13,-22,-13,-15,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-16, 19, -9, 19,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-16,-19, -9,-19,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-13,-22,-13,-15,QPen(Qt::red,2)));
 
-  Lines.push_back(Line(-10, -10, -10, 10,QPen(Qt::red,2)));
-  Lines.push_back(Line(-10, -10,  0,   0,QPen(Qt::red,2)));
-  Lines.push_back(Line(  0,  0,  10, -10,QPen(Qt::red,2)));
-  Lines.push_back(Line( 10, -10, 10,  10,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-10, -10, -10, 10,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-10, -10,  0,   0,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(  0,  0,  10, -10,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line( 10, -10, 10,  10,QPen(Qt::red,2)));
   
-  Ports.push_back(Port(-30,-20));
-  Ports.push_back(Port(-30, 20));
-  Ports.push_back(Port( 40,  0));
+  Ports.push_back(qucs::Port(-30,-20));
+  Ports.push_back(qucs::Port(-30, 20));
+  Ports.push_back(qucs::Port( 40,  0));
 
   x1 = -30; y1 = -38;
   x2 =  40; y2 =  38;

--- a/qucs/components/mosfet.cpp
+++ b/qucs/components/mosfet.cpp
@@ -83,36 +83,36 @@ Element* MOSFET::info_depl(QString& Name, char* &BitmapFile, bool getNewOne)
 // -------------------------------------------------------
 void MOSFET::createSymbol()
 {
-  Lines.push_back(Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  0,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  0,  0,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  0,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  0,  0,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
 
   if(prop(0).Value == "nfet") {
-    Lines.push_back(Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line( -1,  0, -6, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -1,  0, -6,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -1,  0, -6, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -1,  0, -6,  5,QPen(Qt::darkBlue,2)));
   }
 
   if((prop(1).Value.trimmed().at(0) == '-') ==
      (prop(0).Value == "nfet"))
-    Lines.push_back(Line(-10, -8,-10,  8,QPen(Qt::darkBlue,3)));
+    Lines.push_back(qucs::Line(-10, -8,-10,  8,QPen(Qt::darkBlue,3)));
   else
-    Lines.push_back(Line(-10, -4,-10,  4,QPen(Qt::darkBlue,3)));
+    Lines.push_back(qucs::Line(-10, -4,-10,  4,QPen(Qt::darkBlue,3)));
   
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 = -30;
   x2 =   4; y2 =  30;

--- a/qucs/components/mosfet_sub.cpp
+++ b/qucs/components/mosfet_sub.cpp
@@ -20,103 +20,103 @@
 Basic_MOSFET::Basic_MOSFET()
 {
   // these must be the first properties in the list !!!
-  Props.push_back(Property("Type", "nfet", false,
+  Props.push_back(qucs::Property("Type", "nfet", false,
 	QObject::tr("polarity")+" [nfet, pfet]"));
-  Props.push_back(Property("Vt0", "1.0 V", true,
+  Props.push_back(qucs::Property("Vt0", "1.0 V", true,
 	QObject::tr("zero-bias threshold voltage")));
 
-  Props.push_back(Property("Kp", "2e-5", true,
+  Props.push_back(qucs::Property("Kp", "2e-5", true,
 	QObject::tr("transconductance coefficient in A/V^2")));
-  Props.push_back(Property("Gamma", "0.0", false,
+  Props.push_back(qucs::Property("Gamma", "0.0", false,
 	QObject::tr("bulk threshold in sqrt(V)")));
-  Props.push_back(Property("Phi", "0.6 V", false,
+  Props.push_back(qucs::Property("Phi", "0.6 V", false,
 	QObject::tr("surface potential")));
-  Props.push_back(Property("Lambda", "0.0", true,
+  Props.push_back(qucs::Property("Lambda", "0.0", true,
 	QObject::tr("channel-length modulation parameter in 1/V")));
-  Props.push_back(Property("Rd", "0.0 Ohm", false,
+  Props.push_back(qucs::Property("Rd", "0.0 Ohm", false,
 	QObject::tr("drain ohmic resistance")));
-  Props.push_back(Property("Rs", "0.0 Ohm", false,
+  Props.push_back(qucs::Property("Rs", "0.0 Ohm", false,
 	QObject::tr("source ohmic resistance")));
-  Props.push_back(Property("Rg", "0.0 Ohm", false,
+  Props.push_back(qucs::Property("Rg", "0.0 Ohm", false,
 	QObject::tr("gate ohmic resistance")));
-  Props.push_back(Property("Is", "1e-14 A", false,
+  Props.push_back(qucs::Property("Is", "1e-14 A", false,
 	QObject::tr("bulk junction saturation current")));
-  Props.push_back(Property("N", "1.0", false,
+  Props.push_back(qucs::Property("N", "1.0", false,
 	QObject::tr("bulk junction emission coefficient")));
-  Props.push_back(Property("W", "1 um", false,
+  Props.push_back(qucs::Property("W", "1 um", false,
 	QObject::tr("channel width")));
-  Props.push_back(Property("L", "1 um", false,
+  Props.push_back(qucs::Property("L", "1 um", false,
 	QObject::tr("channel length")));
-  Props.push_back(Property("Ld", "0.0", false,
+  Props.push_back(qucs::Property("Ld", "0.0", false,
 	QObject::tr("lateral diffusion length")));
-  Props.push_back(Property("Tox", "0.1 um", false,
+  Props.push_back(qucs::Property("Tox", "0.1 um", false,
 	QObject::tr("oxide thickness")));
-  Props.push_back(Property("Cgso", "0.0", false,
+  Props.push_back(qucs::Property("Cgso", "0.0", false,
 	QObject::tr("gate-source overlap capacitance per meter of "
 		    "channel width in F/m")));
-  Props.push_back(Property("Cgdo", "0.0", false,
+  Props.push_back(qucs::Property("Cgdo", "0.0", false,
 	QObject::tr("gate-drain overlap capacitance per meter of "
 		    "channel width in F/m")));
-  Props.push_back(Property("Cgbo", "0.0", false,
+  Props.push_back(qucs::Property("Cgbo", "0.0", false,
 	QObject::tr("gate-bulk overlap capacitance per meter of "
 		    "channel length in F/m")));
-  Props.push_back(Property("Cbd", "0.0 F", false,
+  Props.push_back(qucs::Property("Cbd", "0.0 F", false,
 	QObject::tr("zero-bias bulk-drain junction capacitance")));
-  Props.push_back(Property("Cbs", "0.0 F", false,
+  Props.push_back(qucs::Property("Cbs", "0.0 F", false,
 	QObject::tr("zero-bias bulk-source junction capacitance")));
-  Props.push_back(Property("Pb", "0.8 V", false,
+  Props.push_back(qucs::Property("Pb", "0.8 V", false,
 	QObject::tr("bulk junction potential")));
-  Props.push_back(Property("Mj", "0.5", false,
+  Props.push_back(qucs::Property("Mj", "0.5", false,
 	QObject::tr("bulk junction bottom grading coefficient")));
-  Props.push_back(Property("Fc", "0.5", false,
+  Props.push_back(qucs::Property("Fc", "0.5", false,
 	QObject::tr("bulk junction forward-bias depletion capacitance "
 		    "coefficient")));
-  Props.push_back(Property("Cjsw", "0.0", false,
+  Props.push_back(qucs::Property("Cjsw", "0.0", false,
 	QObject::tr("zero-bias bulk junction periphery capacitance per meter "
 		    "of junction perimeter in F/m")));
-  Props.push_back(Property("Mjsw", "0.33", false,
+  Props.push_back(qucs::Property("Mjsw", "0.33", false,
 	QObject::tr("bulk junction periphery grading coefficient")));
-  Props.push_back(Property("Tt", "0.0 ps", false,
+  Props.push_back(qucs::Property("Tt", "0.0 ps", false,
 	QObject::tr("bulk transit time")));
-  Props.push_back(Property("Nsub", "0.0", false,
+  Props.push_back(qucs::Property("Nsub", "0.0", false,
 	QObject::tr("substrate bulk doping density in 1/cm^3")));
-  Props.push_back(Property("Nss", "0.0", false,
+  Props.push_back(qucs::Property("Nss", "0.0", false,
 	QObject::tr("surface state density in 1/cm^2")));
-  Props.push_back(Property("Tpg", "1", false,
+  Props.push_back(qucs::Property("Tpg", "1", false,
 	QObject::tr("gate material type: 0 = alumina; -1 = same as bulk; "
 		    "1 = opposite to bulk")));
-  Props.push_back(Property("Uo", "600.0", false,
+  Props.push_back(qucs::Property("Uo", "600.0", false,
 	QObject::tr("surface mobility in cm^2/Vs")));
-  Props.push_back(Property("Rsh", "0.0", false,
+  Props.push_back(qucs::Property("Rsh", "0.0", false,
 	QObject::tr("drain and source diffusion sheet resistance in "
 		    "Ohms/square")));
-  Props.push_back(Property("Nrd", "1", false,
+  Props.push_back(qucs::Property("Nrd", "1", false,
 	QObject::tr("number of equivalent drain squares")));
-  Props.push_back(Property("Nrs", "1", false,
+  Props.push_back(qucs::Property("Nrs", "1", false,
 	QObject::tr("number of equivalent source squares")));
-  Props.push_back(Property("Cj", "0.0", false,
+  Props.push_back(qucs::Property("Cj", "0.0", false,
 	QObject::tr("zero-bias bulk junction bottom capacitance per square "
 		    "meter of junction area in F/m^2")));
-  Props.push_back(Property("Js", "0.0", false,
+  Props.push_back(qucs::Property("Js", "0.0", false,
 	QObject::tr("bulk junction saturation current per square "
 		    "meter of junction area in A/m^2")));
-  Props.push_back(Property("Ad", "0.0", false,
+  Props.push_back(qucs::Property("Ad", "0.0", false,
 	QObject::tr("drain diffusion area in m^2")));
-  Props.push_back(Property("As", "0.0", false,
+  Props.push_back(qucs::Property("As", "0.0", false,
 	QObject::tr("source diffusion area in m^2")));
-  Props.push_back(Property("Pd", "0.0 m", false,
+  Props.push_back(qucs::Property("Pd", "0.0 m", false,
 	QObject::tr("drain junction perimeter")));
-  Props.push_back(Property("Ps", "0.0 m", false,
+  Props.push_back(qucs::Property("Ps", "0.0 m", false,
 	QObject::tr("source junction perimeter")));
-  Props.push_back(Property("Kf", "0.0", false,
+  Props.push_back(qucs::Property("Kf", "0.0", false,
 	QObject::tr("flicker noise coefficient")));
-  Props.push_back(Property("Af", "1.0", false,
+  Props.push_back(qucs::Property("Af", "1.0", false,
 	QObject::tr("flicker noise exponent")));
-  Props.push_back(Property("Ffe", "1.0", false,
+  Props.push_back(qucs::Property("Ffe", "1.0", false,
 	QObject::tr("flicker noise frequency exponent")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
 	QObject::tr("parameter measurement temperature")));
 
   Name  = "T";
@@ -187,39 +187,39 @@ Element* MOSFET_sub::info_depl(QString& Name,
 // -------------------------------------------------------
 void MOSFET_sub::createSymbol()
 {
-  Lines.push_back(Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 11,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  0, 20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-11,  0,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-11,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 11,  0, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 11,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  0, 20,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10,-16,-10, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-10,  7,-10, 16,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, 24,  4, 20,QPen(Qt::darkBlue,2)));
 
   if(prop(0).Value == "nfet") {
-    Lines.push_back(Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0, -4,  5,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line( -1,  0, -6, -5,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -1,  0, -6,  5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -1,  0, -6, -5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -1,  0, -6,  5,QPen(Qt::darkBlue,2)));
   }
 
   if((prop(1).Value.trimmed().at(0) == '-') ==
      (prop(0).Value == "nfet"))
-    Lines.push_back(Line(-10, -8,-10,  8,QPen(Qt::darkBlue,3)));
+    Lines.push_back(qucs::Line(-10, -8,-10,  8,QPen(Qt::darkBlue,3)));
   else
-    Lines.push_back(Line(-10, -4,-10,  4,QPen(Qt::darkBlue,3)));
+    Lines.push_back(qucs::Line(-10, -4,-10,  4,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port( 20,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port( 20,  0));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;

--- a/qucs/components/mscorner.cpp
+++ b/qucs/components/mscorner.cpp
@@ -22,17 +22,17 @@ MScorner::MScorner()
 {
   Description = QObject::tr("microstrip corner");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8,  8, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8, -8,  8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8,  8, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, -8,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port(  0,30));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port(  0,30));
 
   x1 = -30; y1 =-11;
   x2 =  11; y2 = 30;
@@ -42,9 +42,9 @@ MScorner::MScorner()
   Model = "MCORN";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of line")));
 }
 

--- a/qucs/components/mscoupled.cpp
+++ b/qucs/components/mscoupled.cpp
@@ -22,28 +22,28 @@ MScoupled::MScoupled()
 {
   Description = QObject::tr("coupled microstrip line");
 
-  Lines.push_back(Line(-30,-12,-16,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-12, 30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11,-20, 25,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-21, -4, 15, -4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11,-20,-21, -4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 25,-20, 15, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-12,-16,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-12, 30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11,-20, 25,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-21, -4, 15, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11,-20,-21, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 25,-20, 15, -4,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30, 12,-20, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16, 12, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15,  4, 21,  4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-25, 20, 11, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15,  4,-25, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 21,  4, 11, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 12,-20, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16, 12, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15,  4, 21,  4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25, 20, 11, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15,  4,-25, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 21,  4, 11, 20,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 =-33;
   x2 =  30; y2 = 33;
@@ -53,20 +53,20 @@ MScoupled::MScoupled()
   Model = "MCOUPLED";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 	QObject::tr("width of the line")));
-  Props.push_back(Property("L", "10 mm", true,
+  Props.push_back(qucs::Property("L", "10 mm", true,
 	QObject::tr("length of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 	QObject::tr("spacing between the lines")));
-  Props.push_back(Property("Model", "Kirschning", false,
+  Props.push_back(qucs::Property("Model", "Kirschning", false,
 	QObject::tr("microstrip model")+" [Kirschning, Hammerstad]"));
-  Props.push_back(Property("DispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("DispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+
 	" [Kirschning, Getsinger]"));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/mscross.cpp
+++ b/qucs/components/mscross.cpp
@@ -25,23 +25,23 @@ MScross::MScross()
   Model = "MCROSS";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("W1", "1 mm", true,
+  Props.push_back(qucs::Property("W1", "1 mm", true,
 		QObject::tr("width of line 1")));
-  Props.push_back(Property("W2", "2 mm", true,
+  Props.push_back(qucs::Property("W2", "2 mm", true,
 		QObject::tr("width of line 2")));
-  Props.push_back(Property("W3", "1 mm", true,
+  Props.push_back(qucs::Property("W3", "1 mm", true,
 		QObject::tr("width of line 3")));
-  Props.push_back(Property("W4", "2 mm", true,
+  Props.push_back(qucs::Property("W4", "2 mm", true,
 		QObject::tr("width of line 4")));
-  Props.push_back(Property("MSModel", "Hammerstad", false,
+  Props.push_back(qucs::Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 	" [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("MSDispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("MSDispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
-  Props.push_back(Property("Symbol", "showNumbers", false,
+  Props.push_back(qucs::Property("Symbol", "showNumbers", false,
 	QObject::tr("show port numbers in symbol or not")+
 	" [showNumbers, noNumbers]"));
 
@@ -68,38 +68,38 @@ Element* MScross::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 void MScross::createSymbol()
 {
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-30,  0,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0,-18,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18, -8, -8, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8, -8, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  8, -8, 18, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  8, 18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18, -8, 18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8, -8, 18, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  8, 18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18, -8, 18,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -8,-18, -8, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,-18,  8, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,-18,  8,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-18, -8, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,-18,  8, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,-18,  8,-18,QPen(Qt::darkBlue,2)));
 
   if(Props.back().Value.at(0) != 'n') {
-    Texts.push_back(Text(-26,  3, "1"));
-    Texts.push_back(Text(-10,-30, "2"));
-    Texts.push_back(Text( 21,-13, "3"));
-    Texts.push_back(Text(  4, 18, "4"));
+    Texts.push_back(qucs::Text(-26,  3, "1"));
+    Texts.push_back(qucs::Text(-10,-30, "2"));
+    Texts.push_back(qucs::Text( 21,-13, "3"));
+    Texts.push_back(qucs::Text(  4, 18, "4"));
   }
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(  0, 30));
 
   x1 = -30; y1 =-30;
   x2 =  30; y2 = 30;

--- a/qucs/components/msgap.cpp
+++ b/qucs/components/msgap.cpp
@@ -22,22 +22,22 @@ MSgap::MSgap()
 {
   Description = QObject::tr("microstrip gap");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,  0, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, -8, 23, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8,-10,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,  0, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, -8, 23, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8,-10,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  8, 13,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -8,-10,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, -8,  0,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -8,-10,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, -8,  0,  8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-11;
   x2 =  30; y2 = 11;
@@ -47,18 +47,18 @@ MSgap::MSgap()
   Model = "MGAP";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W1", "1 mm", true,
+  Props.push_back(qucs::Property("W1", "1 mm", true,
 	QObject::tr("width of the line 1")));
-  Props.push_back(Property("W2", "1 mm", true,
+  Props.push_back(qucs::Property("W2", "1 mm", true,
 	QObject::tr("width of the line 2")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 	QObject::tr("spacing between the microstrip ends")));
-  Props.push_back(Property("MSModel", "Hammerstad", false,
+  Props.push_back(qucs::Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 	" [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("MSDispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("MSDispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
 }

--- a/qucs/components/mslange.cpp
+++ b/qucs/components/mslange.cpp
@@ -22,20 +22,20 @@ MSlange::MSlange()
 {
   Description = QObject::tr("microstrip lange coupler");
 
-  Lines.push_back(Line(-30,-30,-30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 20,  0, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10, 30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-25,  0, 25,  0,QPen(Qt::darkBlue,2)));      
-  Lines.push_back(Line(-30,-10, 30,-10,QPen(Qt::darkBlue,2)));    
-  Lines.push_back(Line(  0,-20, 30,-20,QPen(Qt::darkBlue,2)));    
-  Lines.push_back(Line( 30,-30, 30,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-10, 30, 30,QPen(Qt::darkBlue,2)));          
+  Lines.push_back(qucs::Line(-30,-30,-30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 20,  0, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10, 30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,  0, 25,  0,QPen(Qt::darkBlue,2)));      
+  Lines.push_back(qucs::Line(-30,-10, 30,-10,QPen(Qt::darkBlue,2)));    
+  Lines.push_back(qucs::Line(  0,-20, 30,-20,QPen(Qt::darkBlue,2)));    
+  Lines.push_back(qucs::Line( 30,-30, 30,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-10, 30, 30,QPen(Qt::darkBlue,2)));          
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 =-33;
   x2 =  30; y2 = 33;
@@ -45,20 +45,20 @@ MSlange::MSlange()
   Model = "MLANGE";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 	QObject::tr("width of the line")));
-  Props.push_back(Property("L", "10 mm", true,
+  Props.push_back(qucs::Property("L", "10 mm", true,
 	QObject::tr("length of the line")));
-  Props.push_back(Property("S", "1 mm", true,
+  Props.push_back(qucs::Property("S", "1 mm", true,
 	QObject::tr("spacing between the lines")));
-  Props.push_back(Property("Model", "Kirschning", false,
+  Props.push_back(qucs::Property("Model", "Kirschning", false,
 	QObject::tr("microstrip model")+" [Kirschning, Hammerstad]"));
-  Props.push_back(Property("DispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("DispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+
 	" [Kirschning, Getsinger]"));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/msline.cpp
+++ b/qucs/components/msline.cpp
@@ -22,15 +22,15 @@ MSline::MSline()
 {
   Description = QObject::tr("microstrip line");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8, 23, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8, 13,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8, 23, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8, 13,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 23, -8, 13,  8,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-11;
   x2 =  30; y2 = 11;
@@ -40,19 +40,19 @@ MSline::MSline()
   Model = "MLIN";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 	QObject::tr("width of the line")));
-  Props.push_back(Property("L", "10 mm", true,
+  Props.push_back(qucs::Property("L", "10 mm", true,
 	QObject::tr("length of the line")));
-  Props.push_back(Property("Model", "Hammerstad", false,
+  Props.push_back(qucs::Property("Model", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 		    " [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("DispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("DispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/msmbend.cpp
+++ b/qucs/components/msmbend.cpp
@@ -22,18 +22,18 @@ MSmbend::MSmbend()
 {
   Description = QObject::tr("microstrip mitered bend");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8, -8, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, -8,  8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8, -8, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, -8,  8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port(  0,30));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port(  0,30));
 
   x1 = -30; y1 =-11;
   x2 =  11; y2 = 30;
@@ -43,9 +43,9 @@ MSmbend::MSmbend()
   Model = "MMBEND";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 		QObject::tr("width of line")));
 }
 

--- a/qucs/components/msopen.cpp
+++ b/qucs/components/msopen.cpp
@@ -22,13 +22,13 @@ MSopen::MSopen()
 {
   Description = QObject::tr("microstrip open");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8, 13, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-23,  8,  3,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 13, -8,  3,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8, 13, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-23,  8,  3,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, -8,-23,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 13, -8,  3,  8,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
 
   x1 = -30; y1 =-11;
   x2 =  16; y2 = 11;
@@ -38,17 +38,17 @@ MSopen::MSopen()
   Model = "MOPEN";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("W", "1 mm", true,
+  Props.push_back(qucs::Property("W", "1 mm", true,
 	QObject::tr("width of the line")));
-  Props.push_back(Property("MSModel", "Hammerstad", false,
+  Props.push_back(qucs::Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 	" [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("MSDispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("MSDispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
-  Props.push_back(Property("Model", "Kirschning", false,
+  Props.push_back(qucs::Property("Model", "Kirschning", false,
 	QObject::tr("microstrip open end model")+" [Kirschning, Hammerstad, "
 	"Alexopoulos]"));
 }

--- a/qucs/components/msrstub.cpp
+++ b/qucs/components/msrstub.cpp
@@ -21,14 +21,14 @@ MSrstub::MSrstub()
 {
   Description = QObject::tr("microstrip radial stub");
 
-  Arcs.push_back(Arc( -26, -26, 52, 52,16*45, 16*90,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -26, -26, 52, 52,16*45, 16*90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-5,   0,  5,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-5,   0,-18,-18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 5,   0, 18,-18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 0,   0,  0, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-5,   0,  5,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-5,   0,-18,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 5,   0, 18,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 0,   0,  0, 10,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(0, 10));
+  Ports.push_back(qucs::Port(0, 10));
 
   x1 = -22; y1 =-30;
   x2 =  22; y2 = 10;
@@ -38,13 +38,13 @@ MSrstub::MSrstub()
   Model = "MRSTUB";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("name of substrate definition")));
-  Props.push_back(Property("ri", "1 mm", false,
+  Props.push_back(qucs::Property("ri", "1 mm", false,
 	QObject::tr("inner radius")));
-  Props.push_back(Property("ro", "10 mm", true,
+  Props.push_back(qucs::Property("ro", "10 mm", true,
 	QObject::tr("outer radius")));
-  Props.push_back(Property("alpha", "90", true,
+  Props.push_back(qucs::Property("alpha", "90", true,
 	QObject::tr("stub angle")+" ("+QObject::tr ("degrees")+")"));
 }
 

--- a/qucs/components/msstep.cpp
+++ b/qucs/components/msstep.cpp
@@ -22,21 +22,21 @@ MSstep::MSstep()
 {
   Description = QObject::tr("microstrip impedance step");
 
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,-12,  0,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, 12,  0, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,-12,-18, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -7, 18, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  7, 18,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18, -7, 18,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-12,  0, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  7,  0, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,-12,  0,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, 12,  0, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,-12,-18, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -7, 18, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  7, 18,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18, -7, 18,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-12,  0, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  7,  0, 12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-22, -4,-26,  4,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-13;
   x2 =  30; y2 = 13;
@@ -46,16 +46,16 @@ MSstep::MSstep()
   Model = "MSTEP";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 	QObject::tr("substrate")));
-  Props.push_back(Property("W1", "2 mm", true,
+  Props.push_back(qucs::Property("W1", "2 mm", true,
 	QObject::tr("width 1 of the line")));
-  Props.push_back(Property("W2", "1 mm", true,
+  Props.push_back(qucs::Property("W2", "1 mm", true,
 	QObject::tr("width 2 of the line")));
-  Props.push_back(Property("MSModel", "Hammerstad", false,
+  Props.push_back(qucs::Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 		    " [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("MSDispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("MSDispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
 }

--- a/qucs/components/mstee.cpp
+++ b/qucs/components/mstee.cpp
@@ -34,23 +34,23 @@ MStee::MStee()
   Model = "MTEE";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("W1", "1 mm", true,
+  Props.push_back(qucs::Property("W1", "1 mm", true,
 		QObject::tr("width of line 1")));
-  Props.push_back(Property("W2", "1 mm", true,
+  Props.push_back(qucs::Property("W2", "1 mm", true,
 		QObject::tr("width of line 2")));
-  Props.push_back(Property("W3", "2 mm", true,
+  Props.push_back(qucs::Property("W3", "2 mm", true,
 		QObject::tr("width of line 3")));
-  Props.push_back(Property("MSModel", "Hammerstad", false,
+  Props.push_back(qucs::Property("MSModel", "Hammerstad", false,
 	QObject::tr("quasi-static microstrip model")+
 	" [Hammerstad, Wheeler, Schneider]"));
-  Props.push_back(Property("MSDispModel", "Kirschning", false,
+  Props.push_back(qucs::Property("MSDispModel", "Kirschning", false,
 	QObject::tr("microstrip dispersion model")+" [Kirschning, Kobayashi, "
 	"Yamashita, Hammerstad, Getsinger, Schneider, Pramanick]"));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("temperature in degree Celsius")));
-  Props.push_back(Property("Symbol", "showNumbers", false,
+  Props.push_back(qucs::Property("Symbol", "showNumbers", false,
 	QObject::tr("show port numbers in symbol or not")+
 	" [showNumbers, noNumbers]"));
 
@@ -83,17 +83,17 @@ void MStee::createSymbol()
   // get the small font size; use the screen-compatible metric
   QFontMetrics smallmetrics(Font, 0); 
   
-  Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8, 18, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  8, 18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18, -8, 18,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 18,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8, 18, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  8, -8,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  8, 18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -8,-18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18, -8, 18,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8,  8, -8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  8,  8,  8, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -8, 18,  8, 18,QPen(Qt::darkBlue,2)));
 
   if(Props.back().Value.at(0) != 'n') {
     QString stmp = "1";
@@ -101,12 +101,12 @@ void MStee::createSymbol()
     int d = smallmetrics.descent();
     int a = smallmetrics.ascent();
     
-    Texts.push_back(Text(-25-w, -d+6, stmp)); // right-aligned, top-aligned
-    Texts.push_back(Text( 25, -d+6, "2")); // left-aligned, top-aligned
-    Texts.push_back(Text(  5, 30-a-1, "3")); // bottom-aligned
+    Texts.push_back(qucs::Text(-25-w, -d+6, stmp)); // right-aligned, top-aligned
+    Texts.push_back(qucs::Text( 25, -d+6, "2")); // left-aligned, top-aligned
+    Texts.push_back(qucs::Text(  5, 30-a-1, "3")); // bottom-aligned
   }
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
-  Ports.push_back(Port(  0,30));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
+  Ports.push_back(qucs::Port(  0,30));
 }

--- a/qucs/components/msvia.cpp
+++ b/qucs/components/msvia.cpp
@@ -23,15 +23,15 @@ MSvia::MSvia()
 {
   Description = QObject::tr("microstrip via");
 
-  Arcs.push_back(Arc(-5,-4, 10,  7,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  0, -5,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  0, -5, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,  0,  5, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11, 14, 11, 14,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( -7, 20,  7, 20,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( -3, 26,  3, 26,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-5,-4, 10,  7,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  0, -5,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  0, -5, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,  0,  5, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11, 14, 11, 14,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -7, 20,  7, 20,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( -3, 26,  3, 26,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(-20,  0));
+  Ports.push_back(qucs::Port(-20,  0));
 
   x1 = -20; y1 = -7;
   x2 =  14; y2 = 30;
@@ -41,11 +41,11 @@ MSvia::MSvia()
   Model = "MVIA";
   Name  = "MS";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("substrate")));
-  Props.push_back(Property("D", "1 mm", true,
+  Props.push_back(qucs::Property("D", "1 mm", true,
 		QObject::tr("diameter of round via conductor")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/mutual.cpp
+++ b/qucs/components/mutual.cpp
@@ -22,29 +22,29 @@ Mutual::Mutual()
 {
   Description = QObject::tr("two mutual inductors");
 
-  Arcs.push_back(Arc(-16,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-18,-10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-30,-30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 18,-10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 30,-30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-18,-10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-30,-30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 18,-10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 30,-30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-21, -22, "1"));
-  Texts.push_back(Text( 15, -22, "2"));
-  Lines.push_back(Line(  0,-20,  0, 20,QPen(Qt::darkBlue,1,Qt::DashLine)));
+  Texts.push_back(qucs::Text(-21, -22, "1"));
+  Texts.push_back(qucs::Text( 15, -22, "2"));
+  Lines.push_back(qucs::Line(  0,-20,  0, 20,QPen(Qt::darkBlue,1,Qt::DashLine)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -33; y1 = -34;
   x2 =  33; y2 =  34;
@@ -54,11 +54,11 @@ Mutual::Mutual()
   Model = "MUT";
   Name  = "Tr";
 
-  Props.push_back(Property("L1", "1 mH", false,
+  Props.push_back(qucs::Property("L1", "1 mH", false,
 		QObject::tr("inductance of coil 1")));
-  Props.push_back(Property("L2", "1 mH", false,
+  Props.push_back(qucs::Property("L2", "1 mH", false,
 		QObject::tr("inductance of coil 2")));
-  Props.push_back(Property("k", "0.9", false,
+  Props.push_back(qucs::Property("k", "0.9", false,
 		QObject::tr("coupling factor between coil 1 and 2")));
 }
 

--- a/qucs/components/mutual2.cpp
+++ b/qucs/components/mutual2.cpp
@@ -34,42 +34,42 @@ Mutual2::Mutual2()
   int w;
   QString stmp;
 
-  Arcs.push_back(Arc(-16,-58,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,-46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,-34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 22,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-58,-10,-70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-70,-30,-70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 58,-10, 70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 70,-30, 70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-10,-30,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-22,-10,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,-30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,-10, 22,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-58,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 22,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-58,-10,-70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-70,-30,-70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 58,-10, 70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 70,-30, 70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-10,-30,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-22,-10,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,-30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,-10, 22,QPen(Qt::darkBlue,2)));
 
   stmp = "1"; w = smallmetrics.horizontalAdvance(stmp); // compute width to right-align
-  Texts.push_back(Text(-13-w,-61,stmp));
+  Texts.push_back(qucs::Text(-13-w,-61,stmp));
   stmp = "2"; w = smallmetrics.horizontalAdvance(stmp); // compute width to right-align
-  Texts.push_back(Text(-13-w, 18,stmp));
-  Texts.push_back(Text( 13,-22,"3")); // left-aligned, no need to compute width
+  Texts.push_back(qucs::Text(-13-w, 18,stmp));
+  Texts.push_back(qucs::Text( 13,-22,"3")); // left-aligned, no need to compute width
 
-  Lines.push_back(Line(  0,-57,  0, 57,QPen(Qt::darkBlue,1,Qt::DashLine)));
+  Lines.push_back(qucs::Line(  0,-57,  0, 57,QPen(Qt::darkBlue,1,Qt::DashLine)));
 
-  Ports.push_back(Port(-30,-70));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 70));
-  Ports.push_back(Port(-30, 10));
-  Ports.push_back(Port(-30,-10));
+  Ports.push_back(qucs::Port(-30,-70));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 70));
+  Ports.push_back(qucs::Port(-30, 10));
+  Ports.push_back(qucs::Port(-30,-10));
 
   x1 = -33; y1 = -74;
   x2 =  33; y2 =  74;
@@ -79,17 +79,17 @@ Mutual2::Mutual2()
   Model = "MUT2";
   Name  = "Tr";
 
-  Props.push_back(Property("L1", "1 mH", false,
+  Props.push_back(qucs::Property("L1", "1 mH", false,
 		QObject::tr("inductance of coil 1")));
-  Props.push_back(Property("L2", "1 mH", false,
+  Props.push_back(qucs::Property("L2", "1 mH", false,
 		QObject::tr("inductance of coil 2")));
-  Props.push_back(Property("L3", "1 mH", false,
+  Props.push_back(qucs::Property("L3", "1 mH", false,
 		QObject::tr("inductance of coil 3")));
-  Props.push_back(Property("k12", "0.9", false,
+  Props.push_back(qucs::Property("k12", "0.9", false,
 		QObject::tr("coupling factor between coil 1 and 2")));
-  Props.push_back(Property("k13", "0.9", false,
+  Props.push_back(qucs::Property("k13", "0.9", false,
 		QObject::tr("coupling factor between coil 1 and 3")));
-  Props.push_back(Property("k23", "0.9", false,
+  Props.push_back(qucs::Property("k23", "0.9", false,
 		QObject::tr("coupling factor between coil 2 and 3")));
 }
 

--- a/qucs/components/mutualx.cpp
+++ b/qucs/components/mutualx.cpp
@@ -31,11 +31,11 @@ MutualX::MutualX()
 
   const int init_coils=2; // initial number of coils
   // must be the first property!
-  Props.push_back(Property("coils", QString::number(init_coils), false,
+  Props.push_back(qucs::Property("coils", QString::number(init_coils), false,
                 QObject::tr("number of mutual inductances")));
 
   for (int i=1;i<=init_coils; i++) {
-      Props.push_back(Property("L"+QString::number(i), "1 mH", false,
+      Props.push_back(qucs::Property("L"+QString::number(i), "1 mH", false,
                                 QObject::tr("inductance of coil") + " " + QString::number(i)));
   }
 
@@ -43,7 +43,7 @@ MutualX::MutualX()
     for(int j = i+1; j <= init_coils; j++) {
        QString nam = "k" + QString::number(i) + QString::number(j);
        QString desc = QObject::tr("coupling factor between coil %1 and coil %2").arg(i).arg(j);
-       Props.push_back(Property(nam,"0.9",false,desc));
+       Props.push_back(qucs::Property(nam,"0.9",false,desc));
     }
 
   createSymbol();
@@ -180,7 +180,7 @@ void MutualX::createSymbol()
           assert(p != Props.end());
           ++p;
         }
-        Props.insert(p, Property("L"+QString::number(Num-i),
+        Props.insert(p, qucs::Property("L"+QString::number(Num-i),
 					      "1 mH", 
 					      false, 
 					      QObject::tr("inductance of coil") + " " + QString::number(Num-i)));
@@ -194,7 +194,7 @@ void MutualX::createSymbol()
                   assert(p != Props.end());
                   ++p;
                 }
-                Props.insert(p, Property("k", "0.9", false, " "));
+                Props.insert(p, qucs::Property("k", "0.9", false, " "));
             }
         }
 
@@ -221,7 +221,7 @@ void MutualX::createSymbol()
 
   // draw symbol
   int x = -10 * (Num-1);
-  Texts.push_back(Text(x-9,-22,"1"));
+  Texts.push_back(qucs::Text(x-9,-22,"1"));
 
   x1 = x-6;  y1 = -30;
   x2 = 10-x; y2 =  30;
@@ -231,16 +231,16 @@ void MutualX::createSymbol()
 
   x -= 6;
   for(int i=0; i<Num; i++) {
-    Arcs.push_back(Arc(x,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(x, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-    Arcs.push_back(Arc(x,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(x,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(x, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(x,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
 
     x += 6;
-    Lines.push_back(Line(x,-18,x,-30,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(x, 18,x, 30,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(x,-18,x,-30,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(x, 18,x, 30,QPen(Qt::darkBlue,2)));
 
-    Ports.push_back(Port(x,-30));
-    Ports.push_back(Port(x, 30));
+    Ports.push_back(qucs::Port(x,-30));
+    Ports.push_back(qucs::Port(x, 30));
     x += 14;
   }
 }

--- a/qucs/components/mux2to1.cpp
+++ b/qucs/components/mux2to1.cpp
@@ -24,9 +24,9 @@ mux2to1::mux2to1()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("2to1 multiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -57,40 +57,40 @@ Element * mux2to1::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void mux2to1::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -60, 30, 50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  50,-30, 50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  50,-30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -60, 30,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -60, 30, 50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  50,-30, 50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  50,-30,-60,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-20,-40,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-20,-40,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,  0,-30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 40,-30, 40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 30, 0, 50, 0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 0, 50, 0,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(-40, -25, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-40, -25, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-17,-55, "MUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-17,-55, "MUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-33, "En", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,-13, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-33, "En", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-13, "0", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-15,-15, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -1,-21, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 12,-22, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 12, -2, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-15,-15, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -1,-21, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 12,-22, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 12, -2, "1", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(11, 0, 23, 0, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(11, 0, 23, 0, QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-25,  7, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 27, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,  7, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 27, "1", Qt::darkBlue, 12.0));
 
-  Ports.push_back(Port(-50,-20));  // En
-  Ports.push_back(Port(-50,  0));  // A
-  Ports.push_back(Port(-50, 20));  // D0
-  Ports.push_back(Port(-50, 40));  // D1
-  Ports.push_back(Port( 50, 0 ));  // Y
+  Ports.push_back(qucs::Port(-50,-20));  // En
+  Ports.push_back(qucs::Port(-50,  0));  // A
+  Ports.push_back(qucs::Port(-50, 20));  // D0
+  Ports.push_back(qucs::Port(-50, 40));  // D1
+  Ports.push_back(qucs::Port( 50, 0 ));  // Y
 
   x1 = -50; y1 = -64;
   x2 =  50; y2 =  54;

--- a/qucs/components/mux4to1.cpp
+++ b/qucs/components/mux4to1.cpp
@@ -24,9 +24,9 @@ mux4to1::mux4to1()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4to1 multiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,49 +56,49 @@ Element * mux4to1::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void mux4to1::createSymbol()
 {
-  Lines.push_back(Line(-30, -80, 30,-80,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -80, 30, 100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  100,-30, 100,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 100,-30, -80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -80, 30,-80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -80, 30, 100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  100,-30, 100,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 100,-30, -80,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-40,-40,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50,-20,-30, -20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 0, -30, 0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 30, -30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 50,-30, 50,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 70, -30, 70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 90, -30, 90,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-40,-40,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-20,-30, -20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 0, -30, 0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 30, -30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 50,-30, 50,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 70, -30, 70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 90, -30, 90,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 10, 50, 10,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( -40, -45, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -40, -45, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-17,-75, "MUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-17,-75, "MUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-53, "En", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-14,-23, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-1, -28, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 12,-30, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 12,-10, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-53, "En", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-14,-23, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-1, -28, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 12,-30, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 12,-10, "3", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-31, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,-11, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-31, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-11, "1", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25, 17, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 37, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 57, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 77, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 17, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 37, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 57, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 77, "3", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(11, -8, 23, -8, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(11, -8, 23, -8, QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-50,-40));  // En
-  Ports.push_back(Port(-50,-20));  // A
-  Ports.push_back(Port(-50,  0));  // B
-  Ports.push_back(Port(-50, 30));  // D0
-  Ports.push_back(Port(-50, 50));  // D1
-  Ports.push_back(Port(-50, 70));  // D2
-  Ports.push_back(Port(-50, 90));  // D3
-  Ports.push_back(Port( 50, 10));  // Y
+  Ports.push_back(qucs::Port(-50,-40));  // En
+  Ports.push_back(qucs::Port(-50,-20));  // A
+  Ports.push_back(qucs::Port(-50,  0));  // B
+  Ports.push_back(qucs::Port(-50, 30));  // D0
+  Ports.push_back(qucs::Port(-50, 50));  // D1
+  Ports.push_back(qucs::Port(-50, 70));  // D2
+  Ports.push_back(qucs::Port(-50, 90));  // D3
+  Ports.push_back(qucs::Port( 50, 10));  // Y
 
   x1 = -50; y1 = -84;
   x2 =  50; y2 =  104;

--- a/qucs/components/mux8to1.cpp
+++ b/qucs/components/mux8to1.cpp
@@ -24,9 +24,9 @@ mux8to1::mux8to1()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("8to1 multiplexer verilog device");
 
-  Props.push_back (Property ("TR", "6", false,
+  Props.push_back(qucs::Property("TR", "6", false,
     QObject::tr ("transfer function high scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("output delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -56,63 +56,63 @@ Element * mux8to1::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void mux8to1::createSymbol()
 {
-  Lines.push_back(Line(-30, -80, 30,-80,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -80, 30, 190,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 190,-30, 190,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 190,-30, -80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -80, 30,-80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -80, 30, 190,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 190,-30, 190,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 190,-30, -80,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-40,-40,-40,QPen(Qt::darkBlue,2)));  //EN
-  Lines.push_back(Line(-50,-20,-30, -20,QPen(Qt::darkBlue,2))); //A
-  Lines.push_back(Line(-50, 0, -30, 0,QPen(Qt::darkBlue,2)));   //B
-  Lines.push_back(Line(-50, 20, -30, 20,QPen(Qt::darkBlue,2))); //C
+  Lines.push_back(qucs::Line(-50,-40,-40,-40,QPen(Qt::darkBlue,2)));  //EN
+  Lines.push_back(qucs::Line(-50,-20,-30, -20,QPen(Qt::darkBlue,2))); //A
+  Lines.push_back(qucs::Line(-50, 0, -30, 0,QPen(Qt::darkBlue,2)));   //B
+  Lines.push_back(qucs::Line(-50, 20, -30, 20,QPen(Qt::darkBlue,2))); //C
 
-  Lines.push_back(Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2))); //D0
-  Lines.push_back(Line(-50, 60, -30, 60,QPen(Qt::darkBlue,2))); //D1
-  Lines.push_back(Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2))); //D2
-  Lines.push_back(Line(-50, 100,-30,100,QPen(Qt::darkBlue,2))); //D3
-  Lines.push_back(Line(-50, 120,-30,120,QPen(Qt::darkBlue,2))); //D4
-  Lines.push_back(Line(-50, 140,-30,140,QPen(Qt::darkBlue,2))); //D5
-  Lines.push_back(Line(-50, 160,-30,160,QPen(Qt::darkBlue,2))); //D6
-  Lines.push_back(Line(-50, 180,-30,180,QPen(Qt::darkBlue,2))); //D7
-  Lines.push_back(Line( 30, 60, 50, 60,QPen(Qt::darkBlue,2)));  // Y
+  Lines.push_back(qucs::Line(-50, 40, -30, 40,QPen(Qt::darkBlue,2))); //D0
+  Lines.push_back(qucs::Line(-50, 60, -30, 60,QPen(Qt::darkBlue,2))); //D1
+  Lines.push_back(qucs::Line(-50, 80, -30, 80,QPen(Qt::darkBlue,2))); //D2
+  Lines.push_back(qucs::Line(-50, 100,-30,100,QPen(Qt::darkBlue,2))); //D3
+  Lines.push_back(qucs::Line(-50, 120,-30,120,QPen(Qt::darkBlue,2))); //D4
+  Lines.push_back(qucs::Line(-50, 140,-30,140,QPen(Qt::darkBlue,2))); //D5
+  Lines.push_back(qucs::Line(-50, 160,-30,160,QPen(Qt::darkBlue,2))); //D6
+  Lines.push_back(qucs::Line(-50, 180,-30,180,QPen(Qt::darkBlue,2))); //D7
+  Lines.push_back(qucs::Line( 30, 60, 50, 60,QPen(Qt::darkBlue,2)));  // Y
 
-  Arcs.push_back(Arc( -40, -45, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -40, -45, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
  
-  Texts.push_back(Text(-17,-75, "MUX", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-17,-75, "MUX", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-53, "En", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-14,-13, "G", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-1, -18, "}", Qt::darkBlue, 16.0));
-  Texts.push_back(Text( 12,-22, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 12, -2, "7", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-53, "En", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-14,-13, "G", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-1, -18, "}", Qt::darkBlue, 16.0));
+  Texts.push_back(qucs::Text( 12,-22, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 12, -2, "7", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25,-31, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,  7, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-31, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,  7, "2", Qt::darkBlue, 12.0));
 
-  Texts.push_back(Text(-25, 27, "0", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 47, "1", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 67, "2", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25, 87, "3", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,107, "4", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,127, "5", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,147, "6", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-25,167, "7", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 27, "0", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 47, "1", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 67, "2", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25, 87, "3", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,107, "4", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,127, "5", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,147, "6", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,167, "7", Qt::darkBlue, 12.0));
 
-  Lines.push_back(Line(11, 0, 23, 0, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(11, 0, 23, 0, QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-50,-40));  // En
-  Ports.push_back(Port(-50,-20));  // A
-  Ports.push_back(Port(-50,  0));  // B
-  Ports.push_back(Port(-50, 20));  // C
-  Ports.push_back(Port(-50, 40));  // D0
-  Ports.push_back(Port(-50, 60));  // D1
-  Ports.push_back(Port(-50, 80));  // D2
-  Ports.push_back(Port(-50,100));  // D3
-  Ports.push_back(Port(-50,120));  // D4
-  Ports.push_back(Port(-50,140));  // D5
-  Ports.push_back(Port(-50,160));  // D6
-  Ports.push_back(Port(-50,180));  // D7
-  Ports.push_back(Port( 50, 60));  // Y
+  Ports.push_back(qucs::Port(-50,-40));  // En
+  Ports.push_back(qucs::Port(-50,-20));  // A
+  Ports.push_back(qucs::Port(-50,  0));  // B
+  Ports.push_back(qucs::Port(-50, 20));  // C
+  Ports.push_back(qucs::Port(-50, 40));  // D0
+  Ports.push_back(qucs::Port(-50, 60));  // D1
+  Ports.push_back(qucs::Port(-50, 80));  // D2
+  Ports.push_back(qucs::Port(-50,100));  // D3
+  Ports.push_back(qucs::Port(-50,120));  // D4
+  Ports.push_back(qucs::Port(-50,140));  // D5
+  Ports.push_back(qucs::Port(-50,160));  // D6
+  Ports.push_back(qucs::Port(-50,180));  // D7
+  Ports.push_back(qucs::Port( 50, 60));  // Y
 
   x1 = -50; y1 = -84;
   x2 =  50; y2 =  194;

--- a/qucs/components/nigbt.cpp
+++ b/qucs/components/nigbt.cpp
@@ -14,58 +14,58 @@ nigbt::nigbt()
 {
   Description = QObject::tr ("NIGBT verilog device");
 
-  Props.push_back (Property ("Agd", "5.0e-6", false,
+  Props.push_back(qucs::Property("Agd", "5.0e-6", false,
     QObject::tr ("gate-drain overlap area")
     +" ("+QObject::tr ("m**2")+")"));
-  Props.push_back (Property ("Area", "1.0e-5", false,
+  Props.push_back(qucs::Property("Area", "1.0e-5", false,
     QObject::tr ("area of the device")
     +" ("+QObject::tr ("m**2")+")"));
-  Props.push_back (Property ("Kp", "0.38", false,
+  Props.push_back(qucs::Property("Kp", "0.38", false,
     QObject::tr ("MOS transconductance")
     +" ("+QObject::tr ("A/V**2")+")"));
-  Props.push_back (Property ("Tau", "7.1e-6", false,
+  Props.push_back(qucs::Property("Tau", "7.1e-6", false,
     QObject::tr ("ambipolar recombination lifetime")
     +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Wb", "9.0e-5", false,
+  Props.push_back(qucs::Property("Wb", "9.0e-5", false,
     QObject::tr ("metallurgical base width")
     +" ("+QObject::tr ("m")+")"));
-  Props.push_back (Property ("BVf", "1.0", false,
+  Props.push_back(qucs::Property("BVf", "1.0", false,
     QObject::tr ("avalanche uniformity factor")));
-  Props.push_back (Property ("BVn", "4.0", false,
+  Props.push_back(qucs::Property("BVn", "4.0", false,
     QObject::tr ("avalanche multiplication exponent")));
-  Props.push_back (Property ("Cgs", "1.24e-8", false,
+  Props.push_back(qucs::Property("Cgs", "1.24e-8", false,
     QObject::tr ("gate-source capacitance per unit area")
     +" ("+QObject::tr ("F/cm**2")+")"));
-  Props.push_back (Property ("Coxd", "3.5e-8", false,
+  Props.push_back(qucs::Property("Coxd", "3.5e-8", false,
     QObject::tr ("gate-drain oxide capacitance per unit area")
     +" ("+QObject::tr ("F/cm**2")+")"));
-  Props.push_back (Property ("Jsne", "6.5e-13", false,
+  Props.push_back(qucs::Property("Jsne", "6.5e-13", false,
     QObject::tr ("emitter saturation current density")
     +" ("+QObject::tr ("A/cm**2")+")"));
-  Props.push_back (Property ("Kf", "1.0", false,
+  Props.push_back(qucs::Property("Kf", "1.0", false,
     QObject::tr ("triode region factor")));
-  Props.push_back (Property ("Mun", "1.5e-3", false,
+  Props.push_back(qucs::Property("Mun", "1.5e-3", false,
     QObject::tr ("electron mobility")
     +" ("+QObject::tr ("cm**2/Vs")+")"));
-  Props.push_back (Property ("Mup", "4.5e-2", false,
+  Props.push_back(qucs::Property("Mup", "4.5e-2", false,
     QObject::tr ("hole mobility")
     +" ("+QObject::tr ("cm**2/Vs")+")"));
-  Props.push_back (Property ("Nb", "2.0e14", false,
+  Props.push_back(qucs::Property("Nb", "2.0e14", false,
     QObject::tr ("base doping")
     +" ("+QObject::tr ("1/cm**3")+")"));
-  Props.push_back (Property ("Theta", "0.02", false,
+  Props.push_back(qucs::Property("Theta", "0.02", false,
     QObject::tr ("transverse field factor")
     +" ("+QObject::tr ("1/V")+")"));
-  Props.push_back (Property ("Vt", "4.7", false,
+  Props.push_back(qucs::Property("Vt", "4.7", false,
     QObject::tr ("threshold voltage")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Vtd", "1.0e-3", false,
+  Props.push_back(qucs::Property("Vtd", "1.0e-3", false,
     QObject::tr ("gate-drain overlap depletion threshold")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
     QObject::tr ("parameter measurement temperature")
     +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
     QObject::tr ("simulation temperature")
     +" ("+QObject::tr ("Celsius")+")"));
 
@@ -96,24 +96,24 @@ Element * nigbt::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void nigbt::createSymbol()
 {
   // bipolar
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
 
   // mos gate
-  Lines.push_back(Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-14,-13,-14, 13,QPen(Qt::darkBlue,3)));
 
   // arrow
-  Lines.push_back(Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
 
   // terminal definitions
-  Ports.push_back(Port(  0,-30)); // collector
-  Ports.push_back(Port(-30,  0)); // gate
-  Ports.push_back(Port(  0, 30)); // emitter
+  Ports.push_back(qucs::Port(  0,-30)); // collector
+  Ports.push_back(qucs::Port(-30,  0)); // gate
+  Ports.push_back(qucs::Port(  0, 30)); // emitter
 
   // relative boundings
   x1 = -30; y1 = -30;

--- a/qucs/components/noise_ii.cpp
+++ b/qucs/components/noise_ii.cpp
@@ -23,41 +23,41 @@ Noise_ii::Noise_ii()
   Description = QObject::tr("correlated current sources");
 
   // left noise source
-  Arcs.push_back(Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
 
   // right noise source
-  Arcs.push_back(Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  7, 30, -7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 30, -6, 26,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 30, -6, 34,  0,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  7, 30, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 30, -6, 26,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 30, -6, 34,  0,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 36, 10, 33,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 23, -3, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  7, 35,  2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 26, -7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 42,  1, 29,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 36, 10, 33,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 23, -3, 20, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  7, 35,  2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 26, -7, 23,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 42,  1, 29,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -44; y1 = -30;
   x2 =  44; y2 =  30;
@@ -67,17 +67,17 @@ Noise_ii::Noise_ii()
   Model = "IInoise";
   Name  = "SRC";
 
-  Props.push_back(Property("i1", "1e-6", true,
+  Props.push_back(qucs::Property("i1", "1e-6", true,
 		QObject::tr("current power spectral density of source 1")));
-  Props.push_back(Property("i2", "1e-6", true,
+  Props.push_back(qucs::Property("i2", "1e-6", true,
 		QObject::tr("current power spectral density of source 2")));
-  Props.push_back(Property("C", "0.5", true,
+  Props.push_back(qucs::Property("C", "0.5", true,
 		QObject::tr("normalized correlation coefficient")));
-  Props.push_back(Property("e", "0", false,
+  Props.push_back(qucs::Property("e", "0", false,
 		QObject::tr("frequency exponent")));
-  Props.push_back(Property("c", "1", false,
+  Props.push_back(qucs::Property("c", "1", false,
 		QObject::tr("frequency coefficient")));
-  Props.push_back(Property("a", "0", false,
+  Props.push_back(qucs::Property("a", "0", false,
 		QObject::tr("additive frequency term")));
 }
 

--- a/qucs/components/noise_iv.cpp
+++ b/qucs/components/noise_iv.cpp
@@ -23,36 +23,36 @@ Noise_iv::Noise_iv()
   Description = QObject::tr("correlated current sources");
 
   // left noise source
-  Arcs.push_back(Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  7,-30, -7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30, -6,-34,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30, -6,-26,  0,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 10,-27,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-37, -3,-40, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  7,-25,  2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-34, -7,-37,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  1,-31,-12,QPen(Qt::darkBlue,2)));
 
   // right noise source
-  Arcs.push_back(Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -44; y1 = -30;
   x2 =  44; y2 =  30;
@@ -62,17 +62,17 @@ Noise_iv::Noise_iv()
   Model = "IVnoise";
   Name  = "SRC";
 
-  Props.push_back(Property("i1", "1e-6", true,
+  Props.push_back(qucs::Property("i1", "1e-6", true,
 		QObject::tr("current power spectral density of source 1")));
-  Props.push_back(Property("v2", "1e-6", true,
+  Props.push_back(qucs::Property("v2", "1e-6", true,
 		QObject::tr("voltage power spectral density of source 2")));
-  Props.push_back(Property("C", "0.5", true,
+  Props.push_back(qucs::Property("C", "0.5", true,
 		QObject::tr("normalized correlation coefficient")));
-  Props.push_back(Property("e", "0", false,
+  Props.push_back(qucs::Property("e", "0", false,
 		QObject::tr("frequency exponent")));
-  Props.push_back(Property("c", "1", false,
+  Props.push_back(qucs::Property("c", "1", false,
 		QObject::tr("frequency coefficient")));
-  Props.push_back(Property("a", "0", false,
+  Props.push_back(qucs::Property("a", "0", false,
 		QObject::tr("additive frequency term")));
 }
 

--- a/qucs/components/noise_vv.cpp
+++ b/qucs/components/noise_vv.cpp
@@ -23,31 +23,31 @@ Noise_vv::Noise_vv()
   Description = QObject::tr("correlated current sources");
 
   // left noise source
-  Arcs.push_back(Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-42,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-30,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-24, 10,-40, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  7,-37,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18,  2,-32,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-29, 12,-42, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-24, 10,-40, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  7,-37,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  2,-32,-12,QPen(Qt::darkBlue,2)));
 
   // right noise source
-  Arcs.push_back(Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 18,-12, 24, 24,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 30, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-30, 30,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 31, 12, 18, -1,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 36, 10, 20, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 40,  7, 23,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 42,  2, 28,-12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-18,  0, 18,  0,QPen(Qt::darkBlue,3)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -44; y1 = -30;
   x2 =  44; y2 =  30;
@@ -57,17 +57,17 @@ Noise_vv::Noise_vv()
   Model = "VVnoise";
   Name  = "SRC";
 
-  Props.push_back(Property("v1", "1e-6", true,
+  Props.push_back(qucs::Property("v1", "1e-6", true,
 		QObject::tr("voltage power spectral density of source 1")));
-  Props.push_back(Property("v2", "1e-6", true,
+  Props.push_back(qucs::Property("v2", "1e-6", true,
 		QObject::tr("voltage power spectral density of source 2")));
-  Props.push_back(Property("C", "0.5", true,
+  Props.push_back(qucs::Property("C", "0.5", true,
 		QObject::tr("normalized correlation coefficient")));
-  Props.push_back(Property("e", "0", false,
+  Props.push_back(qucs::Property("e", "0", false,
 		QObject::tr("frequency exponent")));
-  Props.push_back(Property("c", "1", false,
+  Props.push_back(qucs::Property("c", "1", false,
 		QObject::tr("frequency coefficient")));
-  Props.push_back(Property("a", "0", false,
+  Props.push_back(qucs::Property("a", "0", false,
 		QObject::tr("additive frequency term")));
 }
 

--- a/qucs/components/opamp.cpp
+++ b/qucs/components/opamp.cpp
@@ -22,21 +22,21 @@ OpAmp::OpAmp()
 {
   Description = QObject::tr("operational amplifier");
 
-  Lines.push_back(Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-20,-20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 40,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35,-20, 35,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-35, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 35, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-16, 19, -9, 19,QPen(Qt::black,1)));
-  Lines.push_back(Line(-16,-19, -9,-19,QPen(Qt::red,1)));
-  Lines.push_back(Line(-13,-22,-13,-15,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-16, 19, -9, 19,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line(-16,-19, -9,-19,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-13,-22,-13,-15,QPen(Qt::red,1)));
 
-  Ports.push_back(Port(-30, 20));
-  Ports.push_back(Port(-30,-20));
-  Ports.push_back(Port( 40,  0));
+  Ports.push_back(qucs::Port(-30, 20));
+  Ports.push_back(qucs::Port(-30,-20));
+  Ports.push_back(qucs::Port( 40,  0));
 
   x1 = -30; y1 = -38;
   x2 =  30; y2 =  38;
@@ -46,9 +46,9 @@ OpAmp::OpAmp()
   Model = "OpAmp";
   Name  = "OP";
 
-  Props.push_back(Property("G", "1e6", true,
+  Props.push_back(qucs::Property("G", "1e6", true,
 		QObject::tr("voltage gain")));
-  Props.push_back(Property("Umax", "15 V", false,
+  Props.push_back(qucs::Property("Umax", "15 V", false,
 	QObject::tr("absolute value of maximum and minimum output voltage")));
 }
 

--- a/qucs/components/opt_sim.cpp
+++ b/qucs/components/opt_sim.cpp
@@ -29,7 +29,7 @@ Optimize_Sim::Optimize_Sim()
 {
   Description = QObject::tr("Optimization");
 
-  Texts.push_back(Text(0, 0, Description, Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, Description, Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+128; y2 = y1+41;
@@ -39,8 +39,8 @@ Optimize_Sim::Optimize_Sim()
   Model = ".Opt";
   Name  = "Opt";
 
-  Props.push_back(Property("Sim", "", false, ""));
-  Props.push_back(Property("DE", "3|50|2|20|0.85|1|3|1e-6|10|100", false, ""));
+  Props.push_back(qucs::Property("Sim", "", false, ""));
+  Props.push_back(qucs::Property("DE", "3|50|2|20|0.85|1|3|1e-6|10|100", false, ""));
 }
 
 Optimize_Sim::~Optimize_Sim()

--- a/qucs/components/optimizedialog.cpp
+++ b/qucs/components/optimizedialog.cpp
@@ -803,7 +803,7 @@ void OptimizeDialog::slotApply()
       }
       ++pp;
     } else {
-      Comp->Props.push_back(Property("Var", Prop, false, ""));
+      Comp->Props.push_back(qucs::Property("Var", Prop, false, ""));
       changed = true;
     }
   }
@@ -839,7 +839,7 @@ void OptimizeDialog::slotApply()
       }
       ++pp;
     } else {
-      Comp->Props.push_back(Property("Goal", Prop, false, ""));
+      Comp->Props.push_back(qucs::Property("Goal", Prop, false, ""));
       changed = true;
     }
   }

--- a/qucs/components/pad2bit.cpp
+++ b/qucs/components/pad2bit.cpp
@@ -16,7 +16,7 @@ pad2bit::pad2bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("2bit pattern generator verilog device");
 
-  Props.push_back (Property ("Number", "0", false,
+  Props.push_back(qucs::Property("Number", "0", false,
     QObject::tr ("pad output value")));
 
   createSymbol ();
@@ -45,18 +45,18 @@ Element * pad2bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void pad2bit::createSymbol()
 {
-  Lines.push_back(Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30, -50, 30, 10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30,  10,-60, 10,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-60,  10,-60,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30, -50, 30, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30,  10,-60, 10,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60,  10,-60,-50,QPen(Qt::darkGreen,2)));
 
-  Lines.push_back(Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
-  Lines.push_back(Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
+  Lines.push_back(qucs::Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
+  Lines.push_back(qucs::Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
  
-  Texts.push_back(Text(-58,-33, " 0   1   2    3", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58,-33, " 0   1   2    3", Qt::darkGreen, 12.0));
 
-  Ports.push_back(Port(40,-10));  // B
-  Ports.push_back(Port(40,-30));  // A
+  Ports.push_back(qucs::Port(40,-10));  // B
+  Ports.push_back(qucs::Port(40,-30));  // A
 
   x1 = -64; y1 = -54;
   x2 =  40; y2 =  14;

--- a/qucs/components/pad3bit.cpp
+++ b/qucs/components/pad3bit.cpp
@@ -16,7 +16,7 @@ pad3bit::pad3bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("3bit pattern generator verilog device");
 
-  Props.push_back (Property ("Number", "0", false,
+  Props.push_back(qucs::Property("Number", "0", false,
     QObject::tr ("pad output value")));
  
   createSymbol ();
@@ -45,21 +45,21 @@ Element * pad3bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void pad3bit::createSymbol()
 {
-  Lines.push_back(Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30, -50, 30, 30,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30,  30,-60, 30,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-60,  30,-60,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30, -50, 30, 30,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30,  30,-60, 30,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60,  30,-60,-50,QPen(Qt::darkGreen,2)));
 
-  Lines.push_back(Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
-  Lines.push_back(Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
-  Lines.push_back(Line( 40, 10, 30, 10,QPen(Qt::darkGreen,2))); // C
+  Lines.push_back(qucs::Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
+  Lines.push_back(qucs::Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
+  Lines.push_back(qucs::Line( 40, 10, 30, 10,QPen(Qt::darkGreen,2))); // C
 
-  Texts.push_back(Text(-58,-33, " 0   1   2    3", Qt::darkGreen, 12.0));
-  Texts.push_back(Text(-58, -8, " 4   5   6    7", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58,-33, " 0   1   2    3", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58, -8, " 4   5   6    7", Qt::darkGreen, 12.0));
 
-  Ports.push_back(Port(40, 10));  // C
-  Ports.push_back(Port(40,-10));  // B
-  Ports.push_back(Port(40,-30));  // A
+  Ports.push_back(qucs::Port(40, 10));  // C
+  Ports.push_back(qucs::Port(40,-10));  // B
+  Ports.push_back(qucs::Port(40,-30));  // A
 
   x1 = -64; y1 = -54;
   x2 =  40; y2 =  34;

--- a/qucs/components/pad4bit.cpp
+++ b/qucs/components/pad4bit.cpp
@@ -16,7 +16,7 @@ pad4bit::pad4bit()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("4bit pattern generator verilog device");
 
-  Props.push_back (Property ("Number", "0", false,
+  Props.push_back(qucs::Property("Number", "0", false,
     QObject::tr ("pad output value")));
 
   createSymbol ();
@@ -45,25 +45,25 @@ Element * pad4bit::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void pad4bit::createSymbol()
 {
-  Lines.push_back(Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30, -50, 30, 50,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line( 30,  50,-60, 50,QPen(Qt::darkGreen,2)));
-  Lines.push_back(Line(-60,  50,-60,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60, -50, 30,-50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30, -50, 30, 50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line( 30,  50,-60, 50,QPen(Qt::darkGreen,2)));
+  Lines.push_back(qucs::Line(-60,  50,-60,-50,QPen(Qt::darkGreen,2)));
 
-  Lines.push_back(Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
-  Lines.push_back(Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
-  Lines.push_back(Line( 40, 10, 30, 10,QPen(Qt::darkGreen,2))); // C
-  Lines.push_back(Line( 40, 30, 30, 30,QPen(Qt::darkGreen,2))); // D
+  Lines.push_back(qucs::Line( 40,-30, 30,-30,QPen(Qt::darkGreen,2)));  // A
+  Lines.push_back(qucs::Line( 40,-10, 30,-10,QPen(Qt::darkGreen,2)));  // B
+  Lines.push_back(qucs::Line( 40, 10, 30, 10,QPen(Qt::darkGreen,2))); // C
+  Lines.push_back(qucs::Line( 40, 30, 30, 30,QPen(Qt::darkGreen,2))); // D
  
-  Texts.push_back(Text(-58,-46, " 0   1   2    3", Qt::darkGreen, 12.0));
-  Texts.push_back(Text(-58,-23, " 4   5   6    7", Qt::darkGreen, 12.0));
-  Texts.push_back(Text(-58,  0, " 8   9  10 11", Qt::darkGreen, 12.0));
-  Texts.push_back(Text(-58, 23, "12 13 14 15", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58,-46, " 0   1   2    3", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58,-23, " 4   5   6    7", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58,  0, " 8   9  10 11", Qt::darkGreen, 12.0));
+  Texts.push_back(qucs::Text(-58, 23, "12 13 14 15", Qt::darkGreen, 12.0));
  
-  Ports.push_back(Port(40, 30));  // D
-  Ports.push_back(Port(40, 10));  // C
-  Ports.push_back(Port(40,-10));  // B
-  Ports.push_back(Port(40,-30));  // A
+  Ports.push_back(qucs::Port(40, 30));  // D
+  Ports.push_back(qucs::Port(40, 10));  // C
+  Ports.push_back(qucs::Port(40,-10));  // B
+  Ports.push_back(qucs::Port(40,-30));  // A
 
   x1 = -64; y1 = -54;
   x2 =  40; y2 =  54;

--- a/qucs/components/param_sweep.cpp
+++ b/qucs/components/param_sweep.cpp
@@ -26,9 +26,9 @@ Param_Sweep::Param_Sweep()
   int a = s.lastIndexOf(" ");
   if (a != -1) s[a] = '\n';    // break line
 
-  Texts.push_back(Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
   if (a != -1)
-    Texts.push_back(Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+104; y2 = y1+59;
@@ -39,17 +39,17 @@ Param_Sweep::Param_Sweep()
   Name  = "SW";
 
   // The index of the first 6 properties must not changed. Used in recreate().
-  Props.push_back(Property("Sim", "", true,
+  Props.push_back(qucs::Property("Sim", "", true,
 		QObject::tr("simulation to perform parameter sweep on")));
-  Props.push_back(Property("Type", "lin", true,
+  Props.push_back(qucs::Property("Type", "lin", true,
 		QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.push_back(Property("Param", "R1", true,
+  Props.push_back(qucs::Property("Param", "R1", true,
 		QObject::tr("parameter to sweep")));
-  Props.push_back(Property("Start", "5 Ohm", true,
+  Props.push_back(qucs::Property("Start", "5 Ohm", true,
 		QObject::tr("start value for sweep")));
-  Props.push_back(Property("Stop", "50 Ohm", true,
+  Props.push_back(qucs::Property("Stop", "50 Ohm", true,
 		QObject::tr("stop value for sweep")));
-  Props.push_back(Property("Points", "20", true,
+  Props.push_back(qucs::Property("Points", "20", true,
 		QObject::tr("number of simulation steps")));
 }
 

--- a/qucs/components/phaseshifter.cpp
+++ b/qucs/components/phaseshifter.cpp
@@ -22,18 +22,18 @@ Phaseshifter::Phaseshifter()
 {
   Description = QObject::tr("phase shifter");
 
-  Lines.push_back(Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -9, -9, 17, 17, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10, 10,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14, 14,-14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, 14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14,-14,-14, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,-14, 14, 14,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -9, -9, 17, 17, 0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10, 10,-10,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-14,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -17;
   x2 =  30; y2 =  17;
@@ -43,9 +43,9 @@ Phaseshifter::Phaseshifter()
   Model = "PShift";
   Name  = "X";
 
-  Props.push_back(Property("phi", "90", true,
+  Props.push_back(qucs::Property("phi", "90", true,
 		QObject::tr("phase shift in degree")));
-  Props.push_back(Property("Zref", "50 Ohm", false,
+  Props.push_back(qucs::Property("Zref", "50 Ohm", false,
 		QObject::tr("reference impedance")));
 }
 

--- a/qucs/components/photodiode.cpp
+++ b/qucs/components/photodiode.cpp
@@ -12,67 +12,67 @@
 
 photodiode::photodiode()
 {
-  Description = QObject::tr ("Photodiode verilog device");
+  Description = QObject::tr("Photodiode verilog device");
 
-  Props.push_back (Property ("N", "1.35", false,
-    QObject::tr ("photodiode emission coefficient")));
-  Props.push_back (Property ("Rseries", "1e-3", false,
-    QObject::tr ("series lead resistance")
-    +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Is", "0.34e-12", false,
-    QObject::tr ("diode dark current")
-    +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Bv", "60", false,
-    QObject::tr ("reverse breakdown voltage")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Ibv", "1e-3", false,
-    QObject::tr ("current at reverse breakdown voltage")
-    +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Vj", "0.7", false,
-    QObject::tr ("junction potential")
-    +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Cj0", "60e-12", false,
-    QObject::tr ("zero-bias junction capacitance")
-    +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("M", "0.5", false,
-    QObject::tr ("grading coefficient")));
-  Props.push_back (Property ("Area", "1.0", false,
-    QObject::tr ("diode relative area")));
-  Props.push_back (Property ("Tnom", "26.85", false,
-    QObject::tr ("parameter measurement temperature")
-    +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Fc", "0.5", false,
-    QObject::tr ("forward-bias depletion capacitance coefficient")));
-  Props.push_back (Property ("Tt", "10e-9", false,
-    QObject::tr ("transit time")
-    +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Xti", "3.0", false,
-    QObject::tr ("saturation current temperature exponent")));
-  Props.push_back (Property ("Eg", "1.16", false,
-    QObject::tr ("energy gap")
-    +" ("+QObject::tr ("eV")+")"));
-  Props.push_back (Property ("Responsivity", "0.5", false,
-    QObject::tr ("responsivity")
-    +" ("+QObject::tr ("A/W")+")"));
-  Props.push_back (Property ("Rsh", "5e8", false,
-    QObject::tr ("shunt resistance")
-    +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("QEpercent", "80", false,
-    QObject::tr ("quantum efficiency")
-    +" ("+QObject::tr ("%")+")"));
-  Props.push_back (Property ("Lambda", "900", false,
-    QObject::tr ("light wavelength")
-    +" ("+QObject::tr ("nm")+")"));
-  Props.push_back (Property ("LEVEL", "1", false,
-    QObject::tr ("responsivity calculator selector")));
-  Props.push_back (Property ("Kf", "1e-12", false,
-    QObject::tr ("flicker noise coefficient")));
-  Props.push_back (Property ("Af", "1.0", false,
-    QObject::tr ("flicker noise exponent")));
-  Props.push_back (Property ("Ffe", "1.0", false,
-    QObject::tr ("flicker noise frequency exponent")));
-  Props.push_back (Property ("Temp", "26.85", false,
-    QObject::tr ("simulation temperature")));
+  Props.push_back(qucs::Property("N", "1.35", false,
+    QObject::tr("photodiode emission coefficient")));
+  Props.push_back(qucs::Property("Rseries", "1e-3", false,
+    QObject::tr("series lead resistance")
+    +" ("+QObject::tr("Ohm")+")"));
+  Props.push_back(qucs::Property("Is", "0.34e-12", false,
+    QObject::tr("diode dark current")
+    +" ("+QObject::tr("A")+")"));
+  Props.push_back(qucs::Property("Bv", "60", false,
+    QObject::tr("reverse breakdown voltage")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Ibv", "1e-3", false,
+    QObject::tr("current at reverse breakdown voltage")
+    +" ("+QObject::tr("A")+")"));
+  Props.push_back(qucs::Property("Vj", "0.7", false,
+    QObject::tr("junction potential")
+    +" ("+QObject::tr("V")+")"));
+  Props.push_back(qucs::Property("Cj0", "60e-12", false,
+    QObject::tr("zero-bias junction capacitance")
+    +" ("+QObject::tr("F")+")"));
+  Props.push_back(qucs::Property("M", "0.5", false,
+    QObject::tr("grading coefficient")));
+  Props.push_back(qucs::Property("Area", "1.0", false,
+    QObject::tr("diode relative area")));
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
+    QObject::tr("parameter measurement temperature")
+    +" ("+QObject::tr("Celsius")+")"));
+  Props.push_back(qucs::Property("Fc", "0.5", false,
+    QObject::tr("forward-bias depletion capacitance coefficient")));
+  Props.push_back(qucs::Property("Tt", "10e-9", false,
+    QObject::tr("transit time")
+    +" ("+QObject::tr("s")+")"));
+  Props.push_back(qucs::Property("Xti", "3.0", false,
+    QObject::tr("saturation current temperature exponent")));
+  Props.push_back(qucs::Property("Eg", "1.16", false,
+    QObject::tr("energy gap")
+    +" ("+QObject::tr("eV")+")"));
+  Props.push_back(qucs::Property("Responsivity", "0.5", false,
+    QObject::tr("responsivity")
+    +" ("+QObject::tr("A/W")+")"));
+  Props.push_back(qucs::Property("Rsh", "5e8", false,
+    QObject::tr("shunt resistance")
+    +" ("+QObject::tr("Ohm")+")"));
+  Props.push_back(qucs::Property("QEpercent", "80", false,
+    QObject::tr("quantum efficiency")
+    +" ("+QObject::tr("%")+")"));
+  Props.push_back(qucs::Property("Lambda", "900", false,
+    QObject::tr("light wavelength")
+    +" ("+QObject::tr("nm")+")"));
+  Props.push_back(qucs::Property("LEVEL", "1", false,
+    QObject::tr("responsivity calculator selector")));
+  Props.push_back(qucs::Property("Kf", "1e-12", false,
+    QObject::tr("flicker noise coefficient")));
+  Props.push_back(qucs::Property("Af", "1.0", false,
+    QObject::tr("flicker noise exponent")));
+  Props.push_back(qucs::Property("Ffe", "1.0", false,
+    QObject::tr("flicker noise frequency exponent")));
+  Props.push_back(qucs::Property("Temp", "26.85", false,
+    QObject::tr("simulation temperature")));
 
   createSymbol ();
   tx = x2 + 4;
@@ -100,17 +100,17 @@ Element * photodiode::info(QString& Name, char * &BitmapFile, bool getNewOne)
 
 void photodiode::createSymbol()
 {
-  Arcs.push_back(Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::red,2)));
-  Lines.push_back(Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, -9, -6,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  6, -9,  6,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  0,  6, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 12,  0,  30,QPen(Qt::green,2)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24, 0, 16*360,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, -9, -6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6, -9,  6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  0,  6, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  0,  6,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 12,  0,  30,QPen(Qt::green,2)));
 
-  Ports.push_back(Port( 30, 0));
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 0, 30));
+  Ports.push_back(qucs::Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 0, 30));
 
   x1 = -30; y1 = -20;
   x2 =  30; y2 =  30;

--- a/qucs/components/phototransistor.cpp
+++ b/qucs/components/phototransistor.cpp
@@ -14,80 +14,80 @@ phototransistor::phototransistor()
 {
   Description = QObject::tr ("Phototransistor verilog device");
 
-  Props.push_back (Property ("Bf", "100", false,
+  Props.push_back(qucs::Property("Bf", "100", false,
     QObject::tr ("forward beta")));
-  Props.push_back (Property ("Br", "0.1", false,
+  Props.push_back(qucs::Property("Br", "0.1", false,
     QObject::tr ("reverse beta")));
-  Props.push_back (Property ("Is", "1e-10", false,
+  Props.push_back(qucs::Property("Is", "1e-10", false,
     QObject::tr ("dark current")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Nf", "1", false,
+  Props.push_back(qucs::Property("Nf", "1", false,
     QObject::tr ("forward emission coefficient")));
-  Props.push_back (Property ("Nr", "1", false,
+  Props.push_back(qucs::Property("Nr", "1", false,
     QObject::tr ("reverse emission coefficient")));
-  Props.push_back (Property ("Vaf", "100", false,
+  Props.push_back(qucs::Property("Vaf", "100", false,
     QObject::tr ("forward early voltage")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Var", "100", false,
+  Props.push_back(qucs::Property("Var", "100", false,
     QObject::tr ("reverse early voltage")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Mje", "0.33", false,
+  Props.push_back(qucs::Property("Mje", "0.33", false,
     QObject::tr ("base-emitter junction exponential factor")));
-  Props.push_back (Property ("Vje", "0.75", false,
+  Props.push_back(qucs::Property("Vje", "0.75", false,
     QObject::tr ("base-emitter junction built-in potential")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Cje", "1e-12", false,
+  Props.push_back(qucs::Property("Cje", "1e-12", false,
     QObject::tr ("base-emitter zero-bias depletion capacitance")
     +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("Mjc", "0.33", false,
+  Props.push_back(qucs::Property("Mjc", "0.33", false,
     QObject::tr ("base-collector junction exponential factor")));
-  Props.push_back (Property ("Vjc", "0.75", false,
+  Props.push_back(qucs::Property("Vjc", "0.75", false,
     QObject::tr ("base-collector junction built-in potential")
     +" ("+QObject::tr ("V")+")"));
-  Props.push_back (Property ("Cjc", "2e-12", false,
+  Props.push_back(qucs::Property("Cjc", "2e-12", false,
     QObject::tr ("base-collector zero-bias depletion capacitance")
     +" ("+QObject::tr ("F")+")"));
-  Props.push_back (Property ("Tr", "100n", false,
+  Props.push_back(qucs::Property("Tr", "100n", false,
     QObject::tr ("ideal reverse transit time")
     +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Tf", "0.1n", false,
+  Props.push_back(qucs::Property("Tf", "0.1n", false,
     QObject::tr ("ideal forward transit time")
     +" ("+QObject::tr ("s")+")"));
-  Props.push_back (Property ("Ikf", "10", false,
+  Props.push_back(qucs::Property("Ikf", "10", false,
     QObject::tr ("high current corner for forward beta")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Ikr", "10", false,
+  Props.push_back(qucs::Property("Ikr", "10", false,
     QObject::tr ("high current corner for reverse beta")
     +" ("+QObject::tr ("A")+")"));
-  Props.push_back (Property ("Rc", "10", false,
+  Props.push_back(qucs::Property("Rc", "10", false,
     QObject::tr ("collector series resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Re", "1", false,
+  Props.push_back(qucs::Property("Re", "1", false,
     QObject::tr ("emitter series resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Rb", "100", false,
+  Props.push_back(qucs::Property("Rb", "100", false,
     QObject::tr ("base series resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Kf", "1e-12", false,
+  Props.push_back(qucs::Property("Kf", "1e-12", false,
     QObject::tr ("flicker noise coefficient")));
-  Props.push_back (Property ("Ffe", "1", false,
+  Props.push_back(qucs::Property("Ffe", "1", false,
     QObject::tr ("flicker noise coefficient")));
-  Props.push_back (Property ("Af", "1", false,
+  Props.push_back(qucs::Property("Af", "1", false,
     QObject::tr ("flicker noise exponent")));
-  Props.push_back (Property ("Responsivity", "1.5", false,
+  Props.push_back(qucs::Property("Responsivity", "1.5", false,
     QObject::tr ("responsivity at relative selectivity=100%")
     +" ("+QObject::tr ("A/W")+")"));
-  Props.push_back (Property ("P0", "2.6122e3", false,
+  Props.push_back(qucs::Property("P0", "2.6122e3", false,
     QObject::tr ("relative selectivity polynomial coefficient")));
-  Props.push_back (Property ("P1", "-1.489e1", false,
+  Props.push_back(qucs::Property("P1", "-1.489e1", false,
     QObject::tr ("relative selectivity polynomial coefficient")));
-  Props.push_back (Property ("P2", "3.0332e-2", false,
+  Props.push_back(qucs::Property("P2", "3.0332e-2", false,
     QObject::tr ("relative selectivity polynomial coefficient")));
-  Props.push_back (Property ("P3", "-2.5708e-5", false,
+  Props.push_back(qucs::Property("P3", "-2.5708e-5", false,
     QObject::tr ("relative selectivity polynomial coefficient")));
-  Props.push_back (Property ("P4", "7.6923e-9", false,
+  Props.push_back(qucs::Property("P4", "7.6923e-9", false,
     QObject::tr ("relative selectivity polynomial coefficient")));
-  Props.push_back (Property ("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
     QObject::tr ("simulation temperature")));
 
   createSymbol ();
@@ -116,42 +116,42 @@ Element * phototransistor::info(QString& Name, char * &BitmapFile, bool getNewOn
 
 void phototransistor::createSymbol()
 {
-  Arcs.push_back(Arc(-25,-20, 40, 40,  0,16*360,QPen(Qt::red,2)));
-  Lines.push_back(Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-25,-20, 40, 40,  0,16*360,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-10,-15,-10, 15,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-30,  0,-10,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, -5,  0,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-15,  0,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  5,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 15,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, 15,  0, 15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  9,  0, 15,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50, -50, -40, -50,QPen(Qt::green,2)));
-  Lines.push_back(Line(-40, -50, -40, -30,QPen(Qt::green,2)));
-  Lines.push_back(Line(-40, -30, -50, -30,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-50, -50, -40, -50,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-40, -50, -40, -30,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-40, -30, -50, -30,QPen(Qt::green,2)));
 
   // green arrow
-  Lines.push_back(Line(-40, -40, -16, -16,QPen(Qt::green,2)));
-  Lines.push_back(Line(-16, -16, -16, -23,QPen(Qt::green,2)));
-  Lines.push_back(Line(-16, -16, -23, -16,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-40, -40, -16, -16,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-16, -16, -16, -23,QPen(Qt::green,2)));
+  Lines.push_back(qucs::Line(-16, -16, -23, -16,QPen(Qt::green,2)));
 
   // P
-  Lines.push_back(Line(-60, -55, -60, -65,QPen(Qt::black,2)));
-  Lines.push_back(Line(-60, -65, -55, -65,QPen(Qt::black,2)));
-  Lines.push_back(Line(-55, -65, -55, -60,QPen(Qt::black,2)));
-  Lines.push_back(Line(-60, -60, -55, -60,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-60, -55, -60, -65,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-60, -65, -55, -65,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-55, -65, -55, -60,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-60, -60, -55, -60,QPen(Qt::black,2)));
 
   // W
-  Lines.push_back(Line(-63, -40, -60, -35,QPen(Qt::black,2)));
-  Lines.push_back(Line(-60, -35, -57, -40,QPen(Qt::black,2)));
-  Lines.push_back(Line(-57, -40, -54, -35,QPen(Qt::black,2)));
-  Lines.push_back(Line(-54, -35, -51, -40,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-63, -40, -60, -35,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-60, -35, -57, -40,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-57, -40, -54, -35,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-54, -35, -51, -40,QPen(Qt::black,2)));
 
-  Ports.push_back(Port(  0,-30)); // Collector
-  Ports.push_back(Port(-30,  0)); // Base
-  Ports.push_back(Port(  0, 30)); // Emitter
-  Ports.push_back(Port(-50,-50)); // Power
-  Ports.push_back(Port(-50,-30)); // Wavelength
+  Ports.push_back(qucs::Port(  0,-30)); // Collector
+  Ports.push_back(qucs::Port(-30,  0)); // Base
+  Ports.push_back(qucs::Port(  0, 30)); // Emitter
+  Ports.push_back(qucs::Port(-50,-50)); // Power
+  Ports.push_back(qucs::Port(-50,-30)); // Wavelength
 
   x1 = -50; y1 = -60;
   x2 =  20; y2 =  30;

--- a/qucs/components/pm_modulator.cpp
+++ b/qucs/components/pm_modulator.cpp
@@ -22,23 +22,23 @@ PM_Modulator::PM_Modulator()
 {
   Description = QObject::tr("ac voltage source with phase modulator");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,-18, 11,-18,QPen(Qt::red,1)));
-  Lines.push_back(Line(  8,-21,  8,-15,QPen(Qt::red,1)));
-  Lines.push_back(Line(  5, 18, 11, 18,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -7, -4,  7,  7,     0, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  0, -4,  7,  7,16*180, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 30,  0, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,-18, 11,-18,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(  8,-21,  8,-15,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(  5, 18, 11, 18,QPen(Qt::black,1)));
 
-  Lines.push_back(Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text(-30,-22, QObject::tr("PM"), Qt::black, 10.0,1.0,0.0));
+  Lines.push_back(qucs::Line(-12,  0,-30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  0,-17,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  0,-17, -5,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text(-30,-22, QObject::tr("PM"), Qt::black, 10.0,1.0,0.0));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -30;
   x2 =  14; y2 =  30;
@@ -48,13 +48,13 @@ PM_Modulator::PM_Modulator()
   Model = "PM_Mod";
   Name  = "V";
 
-  Props.push_back(Property("U", "1 V", true,
+  Props.push_back(qucs::Property("U", "1 V", true,
 		QObject::tr("peak voltage in Volts")));
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("Phase", "0", false,
+  Props.push_back(qucs::Property("Phase", "0", false,
 		QObject::tr("initial phase in degrees")));
-  Props.push_back(Property("M", "1.0", false,
+  Props.push_back(qucs::Property("M", "1.0", false,
 		QObject::tr("modulation index")));
 }
 

--- a/qucs/components/potentiometer.cpp
+++ b/qucs/components/potentiometer.cpp
@@ -14,35 +14,35 @@ potentiometer::potentiometer()
 {
   Description = QObject::tr ("Potentiometer verilog device");
 
-  Props.push_back (Property ("R_pot", "1e4", false,
-    QObject::tr ("nominal device resistance")
+  Props.push_back(qucs::Property ("R_pot", "1e4", false,
+    QObject::tr("nominal device resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Rotation", "120", false,
-    QObject::tr ("shaft/wiper arm rotation")
+  Props.push_back(qucs::Property ("Rotation", "120", false,
+    QObject::tr("shaft/wiper arm rotation")
     +" ("+QObject::tr ("degrees")+")"));
-  Props.push_back (Property ("Taper_Coeff", "0", false,
-    QObject::tr ("resistive law taper coefficient")));
-  Props.push_back (Property ("LEVEL", "1", false,
-    QObject::tr ("device type selector")+" [1, 2, 3]"));
-  Props.push_back (Property ("Max_Rotation", "240.0", false,
-    QObject::tr ("maximum shaft/wiper rotation")
+  Props.push_back(qucs::Property ("Taper_Coeff", "0", false,
+    QObject::tr("resistive law taper coefficient")));
+  Props.push_back(qucs::Property ("LEVEL", "1", false,
+    QObject::tr("device type selector")+" [1, 2, 3]"));
+  Props.push_back(qucs::Property ("Max_Rotation", "240.0", false,
+    QObject::tr("maximum shaft/wiper rotation")
     +" ("+QObject::tr ("degrees")+")"));
-  Props.push_back (Property ("Conformity", "0.2", false,
-    QObject::tr ("conformity error")
+  Props.push_back(qucs::Property ("Conformity", "0.2", false,
+    QObject::tr("conformity error")
     +" ("+QObject::tr ("%")+")"));
-  Props.push_back (Property ("Linearity", "0.2", false,
-    QObject::tr ("linearity error")
+  Props.push_back(qucs::Property ("Linearity", "0.2", false,
+    QObject::tr("linearity error")
     +" ("+QObject::tr ("%")+")"));
-  Props.push_back (Property ("Contact_Res", "1", false,
-    QObject::tr ("wiper arm contact resistance")
+  Props.push_back(qucs::Property ("Contact_Res", "1", false,
+    QObject::tr("wiper arm contact resistance")
     +" ("+QObject::tr ("Ohm")+")"));
-  Props.push_back (Property ("Temp_Coeff", "100", false,
-    QObject::tr ("resistance temperature coefficient")
+  Props.push_back(qucs::Property ("Temp_Coeff", "100", false,
+    QObject::tr("resistance temperature coefficient")
     +" ("+QObject::tr ("PPM/Celsius")+")"));
-  Props.push_back (Property ("Tnom", "26.85", false,
-    QObject::tr ("parameter measurement temperature")
+  Props.push_back(qucs::Property ("Tnom", "26.85", false,
+    QObject::tr("parameter measurement temperature")
     +" ("+QObject::tr ("Celsius")+")"));
-  Props.push_back (Property ("Temp", "26.85", false,
+  Props.push_back(qucs::Property ("Temp", "26.85", false,
     QObject::tr ("simulation temperature")));
 
   createSymbol ();
@@ -72,36 +72,36 @@ Element * potentiometer::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void potentiometer::createSymbol()
 {
   // frame
-  Lines.push_back(Line(-30,-13,-30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10, 30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 10, 30,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-13,-30,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-13,-30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10, 30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 10, 30,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-13,-30,-13,QPen(Qt::darkBlue,2)));
 
   // resistor
-  Lines.push_back(Line(-40,  0, -25, 0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-25,  0, -20,-5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, -5, -15, 0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15,  0, -10,-5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, -5, -5,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  0,  0, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -5,  5,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,  0, 10, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, -5, 15,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 15,  0, 20, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20, -5, 25,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 25,  0, 40,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-40,  0, -25, 0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-25,  0, -20,-5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, -5, -15, 0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15,  0, -10,-5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, -5, -5,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  0,  0, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -5,  5,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,  0, 10, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, -5, 15,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 15,  0, 20, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20, -5, 25,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 25,  0, 40,  0,QPen(Qt::darkBlue,2)));
 
   // arrow
-  Lines.push_back(Line( -4, -9,  0, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4, -9,  0, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -5,  0,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, -9,  0, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4, -9,  0, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -5,  0,-20,QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-23,   0, QObject::tr("B"), Qt::black, 6.0, 1.0, 0.0));
-  Texts.push_back(Text( 18,   0, QObject::tr("T"), Qt::black, 6.0, 1.0, 0.0));
+  Texts.push_back(qucs::Text(-23,   0, QObject::tr("B"), Qt::black, 6.0, 1.0, 0.0));
+  Texts.push_back(qucs::Text( 18,   0, QObject::tr("T"), Qt::black, 6.0, 1.0, 0.0));
 
-  Ports.push_back(Port(-40,   0)); // B
-  Ports.push_back(Port(  0, -20)); // M
-  Ports.push_back(Port( 40,   0)); // T
+  Ports.push_back(qucs::Port(-40,   0)); // B
+  Ports.push_back(qucs::Port(  0, -20)); // M
+  Ports.push_back(qucs::Port( 40,   0)); // T
 
   x1 = -40; y1 = -20;
   x2 =  40; y2 =  15;

--- a/qucs/components/rectline.cpp
+++ b/qucs/components/rectline.cpp
@@ -21,22 +21,22 @@ RectLine::RectLine()
 {
   Description = QObject::tr("Rectangular Waveguide");
 
-  Lines.push_back(Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-14, -7, 18, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, -7,-14, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 11, 18, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18, -7, 18, 11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-13, 12,-13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-13,-20,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, -7, 18, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, -7,-14, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 11, 18, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18, -7, 18, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-13, 12,-13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-13,-20,  5,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-20,-13,-14, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 12,-13, 18, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  5,-14, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-13,-14, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12,-13, 18, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  5,-14, 11,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-16;
   x2 =  30; y2 = 14;
@@ -46,23 +46,23 @@ RectLine::RectLine()
   Model = "RECTLINE";
   Name  = "Line";
 
-  Props.push_back(Property("a", "2.95 mm", true,
+  Props.push_back(qucs::Property("a", "2.95 mm", true,
 		QObject::tr("widest side")));
-  Props.push_back(Property("b", "0.9 mm", true,
+  Props.push_back(qucs::Property("b", "0.9 mm", true,
 		QObject::tr("shortest side")));
-  Props.push_back(Property("L", "1500 mm", true,
+  Props.push_back(qucs::Property("L", "1500 mm", true,
 		QObject::tr("mechanical length of the line")));
-  Props.push_back(Property("er", "1", false,
+  Props.push_back(qucs::Property("er", "1", false,
 		QObject::tr("relative permittivity of dielectric")));
-  Props.push_back(Property("mur", "1", false,
+  Props.push_back(qucs::Property("mur", "1", false,
 		QObject::tr("relative permeability of conductor")));
-  Props.push_back(Property("tand", "0", false,
+  Props.push_back(qucs::Property("tand", "0", false,
 		QObject::tr("loss tangent")));
-  Props.push_back(Property("rho", "0.022e-6", false,
+  Props.push_back(qucs::Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of conductor")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Material", "unspecified", false,
+  Props.push_back(qucs::Property("Material", "unspecified", false,
 		QObject::tr("material parameter for temperature model")+
 			    " [unspecified, Copper, StainlessSteel, Gold]"));
 }

--- a/qucs/components/relais.cpp
+++ b/qucs/components/relais.cpp
@@ -22,31 +22,31 @@ Relais::Relais()
 {
   Description = QObject::tr("relay");
 
-  Lines.push_back(Line(-30,-30,-30, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  8,-30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-45, -8,-15, -8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-45,  8,-15,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-45, -8,-45,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15, -8,-15,  8,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-45,  8,-15, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-30, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  8,-30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-45, -8,-15, -8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-45,  8,-15,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-45, -8,-45,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15, -8,-15,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-45,  8,-15, -8,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-43, -3,-37, -3,QPen(Qt::red,1)));
-  Lines.push_back(Line(-40, -6,-40,  0,QPen(Qt::red,1)));
-  Lines.push_back(Line(-23,  3,-17,  3,QPen(Qt::black,1)));  
+  Lines.push_back(qucs::Line(-43, -3,-37, -3,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-40, -6,-40,  0,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-23,  3,-17,  3,QPen(Qt::black,1)));  
 
-  Lines.push_back(Line(-15,  0, 35,  0,QPen(Qt::darkBlue,1,Qt::DotLine)));
+  Lines.push_back(qucs::Line(-15,  0, 35,  0,QPen(Qt::darkBlue,1,Qt::DotLine)));
 
-  Lines.push_back(Line( 30,-30, 30,-18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 15, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 15, 45,-15,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 27,-18, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.push_back(Area( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
+  Lines.push_back(qucs::Line( 30,-30, 30,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 15, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 15, 45,-15,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 27,-18, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellips.push_back(qucs::Area( 27, 12, 6, 6, QPen(Qt::darkBlue,2),
                          QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -48; y1 = -30;
   x2 =  45; y2 =  30;
@@ -56,15 +56,15 @@ Relais::Relais()
   Model = "Relais";
   Name  = "S";
 
-  Props.push_back(Property("Vt", "0.5 V", false,
+  Props.push_back(qucs::Property("Vt", "0.5 V", false,
 		QObject::tr("threshold voltage in Volts")));
-  Props.push_back(Property("Vh", "0.1 V", false,
+  Props.push_back(qucs::Property("Vh", "0.1 V", false,
 		QObject::tr("hysteresis voltage in Volts")));
-  Props.push_back(Property("Ron", "0", false,
+  Props.push_back(qucs::Property("Ron", "0", false,
 		QObject::tr("resistance of \"on\" state in Ohms")));
-  Props.push_back(Property("Roff", "1e12", false,
+  Props.push_back(qucs::Property("Roff", "1e12", false,
 		QObject::tr("resistance of \"off\" state in Ohms")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/resistor.cpp
+++ b/qucs/components/resistor.cpp
@@ -23,19 +23,19 @@ Resistor::Resistor(bool european)
 {
   Description = QObject::tr("resistor");
 
-  Props.push_back(Property("R", "50 Ohm", true,
+  Props.push_back(qucs::Property("R", "50 Ohm", true,
 	QObject::tr("ohmic resistance in Ohms")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Tc1", "0.0", false,
+  Props.push_back(qucs::Property("Tc1", "0.0", false,
 	QObject::tr("first order temperature coefficient")));
-  Props.push_back(Property("Tc2", "0.0", false,
+  Props.push_back(qucs::Property("Tc2", "0.0", false,
 	QObject::tr("second order temperature coefficient")));
-  Props.push_back(Property("Tnom", "26.85", false,
+  Props.push_back(qucs::Property("Tnom", "26.85", false,
 	QObject::tr("temperature at which parameters were extracted")));
 
   // this must be the last property in the list !!!
-  Props.push_back(Property("Symbol", "european", false,
+  Props.push_back(qucs::Property("Symbol", "european", false,
 		QObject::tr("schematic symbol")+" [european, US]"));
   if(!european)  Props.back().Value = "US";
 
@@ -56,27 +56,27 @@ Component* Resistor::newOne()
 void Resistor::createSymbol()
 {
   if(Props.back().Value != "US") {
-    Lines.push_back(Line(-18, -9, 18, -9,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 18, -9, 18,  9,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 18,  9,-18,  9,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-18,  9,-18, -9,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-18, -9, 18, -9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 18, -9, 18,  9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 18,  9,-18,  9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-18,  9,-18, -9,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-18,  0,-15, -7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-15, -7, -9,  7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -9,  7, -3, -7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( -3, -7,  3,  7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(  3,  7,  9, -7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(  9, -7, 15,  7,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 15,  7, 18,  0,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-30,  0,-18,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-18,  0,-15, -7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15, -7, -9,  7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  7, -3, -7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -3, -7,  3,  7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(  3,  7,  9, -7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(  9, -7, 15,  7,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 15,  7, 18,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
   }
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30; y1 = -11;
   x2 =  30; y2 =  11;

--- a/qucs/components/rfedd.cpp
+++ b/qucs/components/rfedd.cpp
@@ -29,22 +29,22 @@ RFedd::RFedd()
   Name  = "RF";
 
   // first properties !!!
-  Props.push_back(Property("Type", "Y", false,
+  Props.push_back(qucs::Property("Type", "Y", false,
 		QObject::tr("type of parameters")+" [Y, Z, S]"));
-  Props.push_back(Property("Ports", "2", false,
+  Props.push_back(qucs::Property("Ports", "2", false,
 		QObject::tr("number of ports")));
-  Props.push_back(Property("duringDC", "open", false,
+  Props.push_back(qucs::Property("duringDC", "open", false,
 		QObject::tr("representation during DC analysis")+
 			    " [open, short, unspecified, zerofrequency]"));
 
   // last properties
-  Props.push_back(Property("P11", "0", false,
+  Props.push_back(qucs::Property("P11", "0", false,
 		QObject::tr("parameter equation") + " 11"));
-  Props.push_back(Property("P12", "0", false,
+  Props.push_back(qucs::Property("P12", "0", false,
 		QObject::tr("parameter equation") + " 12"));
-  Props.push_back(Property("P21", "0", false,
+  Props.push_back(qucs::Property("P21", "0", false,
 		QObject::tr("parameter equation") + " 21"));
-  Props.push_back(Property("P22", "0", false,
+  Props.push_back(qucs::Property("P22", "0", false,
 		QObject::tr("parameter equation") + " 22"));
 
   createSymbol();
@@ -129,7 +129,7 @@ void RFedd::createSymbol()
     }
     for(i = NumProps; i < No * No; i++) {
       tmp=QString::number((i)/No+1)+QString::number((i)%No+1);
-      Props.push_back(Property("P"+tmp, "0", false,
+      Props.push_back(qucs::Property("P"+tmp, "0", false,
 		QObject::tr("parameter equation") + " " +tmp));
     }
   } else { // number of ports was decreased, remove properties
@@ -146,33 +146,33 @@ void RFedd::createSymbol()
   // draw symbol
   #define HALFWIDTH  17
   int h = 30*((No-1)/2) + 15;
-  Lines.push_back(Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
 
   // component text name, centered
   tmp = QObject::tr("RF");
   w = smallmetrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(-w/2, -fHeight/2, tmp)); // text centered in box
+  Texts.push_back(qucs::Text(-w/2, -fHeight/2, tmp)); // text centered in box
 
   i = 0;
   int y = 15-h;
   while(i<No) { // add ports lines and numbers
     // left side
-    Lines.push_back(Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30,  y));
+    Lines.push_back(qucs::Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30,  y));
     tmp = QString::number(i+1);
     w = smallmetrics.horizontalAdvance(tmp);
-    Texts.push_back(Text(-25-w, y-fHeight-2, tmp)); // text right-aligned
+    Texts.push_back(qucs::Text(-25-w, y-fHeight-2, tmp)); // text right-aligned
     i++;
 
     if(i == No) break; // if odd number of ports there will be one port less on the right side
     // right side
-    Lines.push_back(Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30,  y));
+    Lines.push_back(qucs::Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30,  y));
     tmp = QString::number(i+1);
-    Texts.push_back(Text(25, y-fHeight-2, tmp)); // text left-aligned
+    Texts.push_back(qucs::Text(25, y-fHeight-2, tmp)); // text left-aligned
     y += 60;
     i++;
   }

--- a/qucs/components/rfedd2p.cpp
+++ b/qucs/components/rfedd2p.cpp
@@ -30,20 +30,20 @@ RFedd2P::RFedd2P()
   Name  = "RF";
 
   // first properties !!!
-  Props.push_back(Property("Type", "Y", false,
+  Props.push_back(qucs::Property("Type", "Y", false,
 		QObject::tr("type of parameters")+" [Y, Z, S, H, G, A, T]"));
-  Props.push_back(Property("duringDC", "open", false,
+  Props.push_back(qucs::Property("duringDC", "open", false,
 		QObject::tr("representation during DC analysis")+
 			    " [open, short, unspecified, zerofrequency]"));
 
   // last properties
-  Props.push_back(Property("P11", "0", false,
+  Props.push_back(qucs::Property("P11", "0", false,
 		QObject::tr("parameter equation") + " 11"));
-  Props.push_back(Property("P12", "0", false,
+  Props.push_back(qucs::Property("P12", "0", false,
 		QObject::tr("parameter equation") + " 12"));
-  Props.push_back(Property("P21", "0", false,
+  Props.push_back(qucs::Property("P21", "0", false,
 		QObject::tr("parameter equation") + " 21"));
-  Props.push_back(Property("P22", "0", false,
+  Props.push_back(qucs::Property("P22", "0", false,
 		QObject::tr("parameter equation") + " 22"));
 
   createSymbol();
@@ -113,30 +113,30 @@ void RFedd2P::createSymbol()
   // draw symbol
   #define HALFWIDTH  17
   int h = 15;
-  Lines.push_back(Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
 
   // component text name
   tmp = prop(0).Value;
   w = smallmetrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(-w/2, -fHeight/2, tmp)); // text centered in the box
+  Texts.push_back(qucs::Text(-w/2, -fHeight/2, tmp)); // text centered in the box
 
   // add port numbers text
   i = 0;
   int y = 15-h;
-  Lines.push_back(Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port(-30,  y));
+  Lines.push_back(qucs::Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port(-30,  y));
   tmp = QString::number(i+1);
   w = smallmetrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(-25-w, y-fHeight-2, tmp)); // text right-aligned
+  Texts.push_back(qucs::Text(-25-w, y-fHeight-2, tmp)); // text right-aligned
   i++;
 
-  Lines.push_back(Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port( 30,  y));
+  Lines.push_back(qucs::Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port( 30,  y));
   tmp = QString::number(i+1);
-  Texts.push_back(Text(25, y-fHeight-2, tmp)); // text left-aligned
+  Texts.push_back(qucs::Text(25, y-fHeight-2, tmp)); // text left-aligned
   y += 60;
   i++;
 

--- a/qucs/components/rlcg.cpp
+++ b/qucs/components/rlcg.cpp
@@ -23,17 +23,17 @@ RLCG::RLCG()
 {
   Description = QObject::tr("RLCG transmission line");
 
-  Lines.push_back(Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-28,  7, 28,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-28,  7, 28,  7,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-28, 14,-21,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-21, 14,-14,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, -7,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7, 14,  0,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 14,  7,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, 14, 14,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14, 14, 21,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 21, 14, 28,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-28, 14,-21,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-21, 14,-14,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, -7,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7, 14,  0,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 14,  7,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, 14, 14,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14, 14, 21,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 21, 14, 28,  7,QPen(Qt::darkBlue,2)));
 
   QFont Font(QucsSettings.font); // default application font
   // symbol text is smaller (10 pt default)
@@ -43,10 +43,10 @@ RLCG::RLCG()
   int fHeight = smallmetrics.lineSpacing();
   QString tmp = QObject::tr("RLCG");
   int w = smallmetrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(w/-2, -fHeight, tmp));
+  Texts.push_back(qucs::Text(w/-2, -fHeight, tmp));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 = -fHeight;
   x2 =  30; y2 = 16;
@@ -56,17 +56,17 @@ RLCG::RLCG()
   Model = "RLCG";
   Name  = "Line";
 
-  Props.push_back(Property("R", "0.0", false,
+  Props.push_back(qucs::Property("R", "0.0", false,
 		QObject::tr("resistive load")+" ("+QObject::tr ("Ohm/m")+")"));
-  Props.push_back(Property("L", "0.6e-6", true,
+  Props.push_back(qucs::Property("L", "0.6e-6", true,
 		QObject::tr("inductive load")+" ("+QObject::tr ("H/m")+")"));
-  Props.push_back(Property("C", "240e-12", true,
+  Props.push_back(qucs::Property("C", "240e-12", true,
 		QObject::tr("capacitive load")+" ("+QObject::tr ("F/m")+")"));
-  Props.push_back(Property("G", "0.0", false,
+  Props.push_back(qucs::Property("G", "0.0", false,
 		QObject::tr("conductive load")+" ("+QObject::tr ("S/m")+")"));
-  Props.push_back(Property("Length", "1 mm", true,
+  Props.push_back(qucs::Property("Length", "1 mm", true,
 		QObject::tr("electrical length of the line")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/rs_flipflop.cpp
+++ b/qucs/components/rs_flipflop.cpp
@@ -23,28 +23,28 @@ RS_FlipFlop::RS_FlipFlop()
   Type = isDigitalComponent;
   Description = QObject::tr("RS flip flop");
 
-  Props.push_back(Property("t", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("t", "0", false, QObject::tr("delay time")));
 
-  Lines.push_back(Line(-20,-20, 20,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 20, 20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-20,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-20, 20,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 20, 20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-20,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-20, 20, 20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-10,-20,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10,-20, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-10, 20,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 10, 20, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-10,-20,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10,-20, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-10, 20,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 10, 20, 10,QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-18,-21, "R", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(-18, -1, "S", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  6,-21, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text(  6, -1, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-18,-21, "R", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-18, -1, "S", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  6,-21, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(  6, -1, "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
 
-  Ports.push_back(Port(-30,-10));  // R
-  Ports.push_back(Port(-30, 10));  // S
-  Ports.push_back(Port( 30,-10));  // Q
-  Ports.push_back(Port( 30, 10));  // nQ
+  Ports.push_back(qucs::Port(-30,-10));  // R
+  Ports.push_back(qucs::Port(-30, 10));  // S
+  Ports.push_back(qucs::Port( 30,-10));  // Q
+  Ports.push_back(qucs::Port( 30, 10));  // nQ
 
   x1 = -30; y1 = -24;
   x2 =  30; y2 =  24;

--- a/qucs/components/source_ac.cpp
+++ b/qucs/components/source_ac.cpp
@@ -22,29 +22,29 @@ Source_ac::Source_ac()
 {
   Description = QObject::tr("ac power source");
 
-  Lines.push_back(Line(-22,-11, 22,-11,QPen(Qt::darkGray,0)));
-  Lines.push_back(Line(-22, 11, 22, 11,QPen(Qt::darkGray,0)));
-  Lines.push_back(Line(-22,-11,-22, 11,QPen(Qt::darkGray,0)));
-  Lines.push_back(Line( 22,-11, 22, 11,QPen(Qt::darkGray,0)));
+  Lines.push_back(qucs::Line(-22,-11, 22,-11,QPen(Qt::darkGray,0)));
+  Lines.push_back(qucs::Line(-22, 11, 22, 11,QPen(Qt::darkGray,0)));
+  Lines.push_back(qucs::Line(-22,-11,-22, 11,QPen(Qt::darkGray,0)));
+  Lines.push_back(qucs::Line( 22,-11, 22, 11,QPen(Qt::darkGray,0)));
 
-  Arcs.push_back(Arc(-19, -9, 18, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-13, -6,  6,  6,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-13,  0,  6,  6, 16*90, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-19,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 19,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -1,  0,  3,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-19, -9, 18, 18,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-13, -6,  6,  6,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-13,  0,  6,  6, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-19,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 19,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -1,  0,  3,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  3, -5, 19, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  3,  5, 19,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  3, -5,  3,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 19, -5, 19,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  3, -5, 19, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  3,  5, 19,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  3, -5,  3,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 19, -5, 19,  5,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( 25,  5, 25, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 28,  8, 22,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-25,  5,-25, 11,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line( 25,  5, 25, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 28,  8, 22,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-25,  5,-25, 11,QPen(Qt::black,1)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -55,15 +55,15 @@ Source_ac::Source_ac()
   Name  = "P";
 
   // This property must be the first one !
-  Props.push_back(Property("Num", "1", true,
+  Props.push_back(qucs::Property("Num", "1", true,
 		QObject::tr("number of the port")));
-  Props.push_back(Property("Z", "50 Ohm", true,
+  Props.push_back(qucs::Property("Z", "50 Ohm", true,
 		QObject::tr("port impedance")));
-  Props.push_back(Property("P", "0 dBm", false,
+  Props.push_back(qucs::Property("P", "0 dBm", false,
 		QObject::tr("(available) ac power in Watts")));
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -30,9 +30,9 @@ SP_Sim::SP_Sim()
   }
   if (b != -1) s[b] = '\n';
 
-  Texts.push_back(Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(b), Qt::darkBlue, QucsSettings.largeFontSize));
   if (b != -1)
-    Texts.push_back(Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(b+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+121; y2 = y1+59;
@@ -43,25 +43,25 @@ SP_Sim::SP_Sim()
   Name  = "SP";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.push_back(Property("Type", "lin", true,
+  Props.push_back(qucs::Property("Type", "lin", true,
 	QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.push_back(Property("Start", "1 GHz", true,
+  Props.push_back(qucs::Property("Start", "1 GHz", true,
 	QObject::tr("start frequency in Hertz")));
-  Props.push_back(Property("Stop", "10 GHz", true,
+  Props.push_back(qucs::Property("Stop", "10 GHz", true,
 	QObject::tr("stop frequency in Hertz")));
-  Props.push_back(Property("Points", "19", true,
+  Props.push_back(qucs::Property("Points", "19", true,
 	QObject::tr("number of simulation steps")));
-  Props.push_back(Property("Noise", "no", false,
+  Props.push_back(qucs::Property("Noise", "no", false,
 	QObject::tr("calculate noise parameters")+
 	" [yes, no]"));
-  Props.push_back(Property("NoiseIP", "1", false,
+  Props.push_back(qucs::Property("NoiseIP", "1", false,
 	QObject::tr("input port for noise figure")));
-  Props.push_back(Property("NoiseOP", "2", false,
+  Props.push_back(qucs::Property("NoiseOP", "2", false,
 	QObject::tr("output port for noise figure")));
-  Props.push_back(Property("saveCVs", "no", false,
+  Props.push_back(qucs::Property("saveCVs", "no", false,
 	QObject::tr("put characteristic values into dataset")+
 	" [yes, no]"));
-  Props.push_back(Property("saveAll", "no", false,
+  Props.push_back(qucs::Property("saveAll", "no", false,
 	QObject::tr("save subcircuit characteristic values into dataset")+
 	" [yes, no]"));
 }
@@ -86,7 +86,7 @@ Element* SP_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 void SP_Sim::recreate(Schematic*)
 {
-  Property &pp = Props.front();
+  qucs::Property &pp = Props.front();
   if((pp.Value == "list") || (pp.Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.
     prop(1).Name = "Symbol";

--- a/qucs/components/spdeembed.cpp
+++ b/qucs/components/spdeembed.cpp
@@ -36,18 +36,18 @@ SPDeEmbed::SPDeEmbed()
   Name  = "XD";
 
   // must be the first property !!!
-  Props.push_back(Property("File", "test.s2p", true,
+  Props.push_back(qucs::Property("File", "test.s2p", true,
 		QObject::tr("name of the s parameter file")));
-  Props.push_back(Property("Data", "rectangular", false,
+  Props.push_back(qucs::Property("Data", "rectangular", false,
 		QObject::tr("data type")+" [rectangular, polar]"));
-  Props.push_back(Property("Interpolator", "linear", false,
+  Props.push_back(qucs::Property("Interpolator", "linear", false,
 		QObject::tr("interpolation type")+" [linear, cubic]"));
-  Props.push_back(Property("duringDC", "open", false,
+  Props.push_back(qucs::Property("duringDC", "open", false,
 		QObject::tr("representation during DC analysis")+
 			    " [open, short, shortall, unspecified]"));
 
   // must be the last property !!!
-  Props.push_back(Property("Ports", "2", false,
+  Props.push_back(qucs::Property("Ports", "2", false,
 		QObject::tr("number of ports")));
 
   createSymbol();
@@ -168,35 +168,35 @@ void SPDeEmbed::createSymbol()
   // draw symbol outline
   int h = (PortDistance/2)*((Num-1)/2) + 15;
   QPen pen(Qt::darkBlue, 2, Qt::DashLine);
-  Lines.push_back(Line(-15, -h, 15, -h, pen));
-  Lines.push_back(Line( 15, -h, 15,  h, pen));
-  Lines.push_back(Line(-15,  h, 15,  h, pen));
-  Lines.push_back(Line(-15, -h,-15,  h, pen));
+  Lines.push_back(qucs::Line(-15, -h, 15, -h, pen));
+  Lines.push_back(qucs::Line( 15, -h, 15,  h, pen));
+  Lines.push_back(qucs::Line(-15,  h, 15,  h, pen));
+  Lines.push_back(qucs::Line(-15, -h,-15,  h, pen));
   stmp = QObject::tr("file");
   w = smallmetrics.horizontalAdvance(stmp); // compute text size to center it
-  Texts.push_back(Text(-w/2, -fHeight/2, stmp));
+  Texts.push_back(qucs::Text(-w/2, -fHeight/2, stmp));
 
   int i=0, y = 15-h;
   while(i<Num) { // add ports lines and numbers
     i++;
-    Lines.push_back(Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30, y));
+    Lines.push_back(qucs::Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30, y));
     stmp = QString::number(i);
     w = smallmetrics.horizontalAdvance(stmp);
-    Texts.push_back(Text(-25-w, y-fHeight-2, stmp)); // text right-aligned
+    Texts.push_back(qucs::Text(-25-w, y-fHeight-2, stmp)); // text right-aligned
 
     if(i == Num) break; // if odd number of ports there will be one port less on the right side
     i++;
-    Lines.push_back(Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30, y));
+    Lines.push_back(qucs::Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30, y));
     stmp = QString::number(i);
-    Texts.push_back(Text(25, y-fHeight-2, stmp)); // text left-aligned
+    Texts.push_back(qucs::Text(25, y-fHeight-2, stmp)); // text left-aligned
     y += PortDistance;
   }
 
-  Lines.push_back(Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text( 4, h,"Ref"));
-  Ports.push_back(Port( 0,h+15));    // 'Ref' port
+  Lines.push_back(qucs::Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text( 4, h,"Ref"));
+  Ports.push_back(qucs::Port( 0,h+15));    // 'Ref' port
 
   x1 = -30; y1 = -h-2;
   x2 =  30; y2 =  h+15;

--- a/qucs/components/spembed.cpp
+++ b/qucs/components/spembed.cpp
@@ -30,18 +30,18 @@ SPEmbed::SPEmbed()
   Name  = "X";
 
   // must be the first property !!!
-  Props.push_back(Property("File", "test.s1p", true,
+  Props.push_back(qucs::Property("File", "test.s1p", true,
 		QObject::tr("name of the s parameter file")));
-  Props.push_back(Property("Data", "rectangular", false,
+  Props.push_back(qucs::Property("Data", "rectangular", false,
 		QObject::tr("data type")+" [rectangular, polar]"));
-  Props.push_back(Property("Interpolator", "linear", false,
+  Props.push_back(qucs::Property("Interpolator", "linear", false,
 		QObject::tr("interpolation type")+" [linear, cubic]"));
-  Props.push_back(Property("duringDC", "open", false,
+  Props.push_back(qucs::Property("duringDC", "open", false,
 		QObject::tr("representation during DC analysis")+
 			    " [open, short, shortall, unspecified]"));
 
   // must be the last property !!!
-  Props.push_back(Property("Ports", "1", false,
+  Props.push_back(qucs::Property("Ports", "1", false,
 		QObject::tr("number of ports")));
 
   createSymbol();
@@ -154,35 +154,35 @@ void SPEmbed::createSymbol()
 
   // draw symbol outline
   int h = (PortDistance/2)*((Num-1)/2) + 15;
-  Lines.push_back(Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2)));
   stmp = QObject::tr("file");
   w = smallmetrics.horizontalAdvance(stmp); // compute text size to center it
-  Texts.push_back(Text(-w/2, -fHeight/2, stmp));
+  Texts.push_back(qucs::Text(-w/2, -fHeight/2, stmp));
 
   int i=0, y = 15-h;
   while(i<Num) { // add ports lines and numbers
     i++;
-    Lines.push_back(Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30, y));
+    Lines.push_back(qucs::Line(-30, y,-15, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30, y));
     stmp = QString::number(i);
     w = smallmetrics.horizontalAdvance(stmp);
-    Texts.push_back(Text(-25-w, y-fHeight-2, stmp)); // text right-aligned
+    Texts.push_back(qucs::Text(-25-w, y-fHeight-2, stmp)); // text right-aligned
 
     if(i == Num) break; // if odd number of ports there will be one port less on the right side
     i++;
-    Lines.push_back(Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30, y));
+    Lines.push_back(qucs::Line( 15, y, 30, y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30, y));
     stmp = QString::number(i);
-    Texts.push_back(Text(25, y-fHeight-2, stmp)); // text left-aligned
+    Texts.push_back(qucs::Text(25, y-fHeight-2, stmp)); // text left-aligned
     y += PortDistance;
   }
 
-  Lines.push_back(Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text( 4, h,"Ref"));
-  Ports.push_back(Port( 0,h+15));    // 'Ref' port
+  Lines.push_back(qucs::Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text( 4, h,"Ref"));
+  Ports.push_back(qucs::Port( 0,h+15));    // 'Ref' port
 
   x1 = -30; y1 = -h-2;
   x2 =  30; y2 =  h+15;

--- a/qucs/components/spicedialog.cpp
+++ b/qucs/components/spicedialog.cpp
@@ -156,7 +156,7 @@ SpiceDialog::SpiceDialog(QucsApp* App_, const std::shared_ptr<SpiceFile> &c, Sch
   changed = false;
 
   // insert all properties into the ListBox
-  Property &pp = Comp->prop(0);
+  qucs::Property &pp = Comp->prop(0);
   FileEdit->setText(pp.Value);
   FileCheck->setChecked(pp.display);
   SimCheck->setChecked(Comp->prop(2).Value == "yes");
@@ -460,7 +460,7 @@ bool SpiceDialog::loadSpiceNetList(const QString& s)
       QMessageBox::critical(this, tr("QucsConv Error"), Error);
   }
 
-  Property &pp = Comp->prop(1);
+  qucs::Property &pp = Comp->prop(1);
   if(!pp.Value.isEmpty())
   {
     PortsList->clear();

--- a/qucs/components/spicefile.cpp
+++ b/qucs/components/spicefile.cpp
@@ -41,10 +41,10 @@ SpiceFile::SpiceFile()
 {
   Description = QObject::tr("SPICE netlist file");
   // Property descriptions not needed, but must not be empty !
-  Props.push_back(Property("File", "", true, QString("x")));
-  Props.push_back(Property("Ports", "", false, QString("x")));
-  Props.push_back(Property("Sim", "yes", false, QString("x")));
-  Props.push_back(Property("Preprocessor", "none", false, QString("x")));
+  Props.push_back(qucs::Property("File", "", true, QString("x")));
+  Props.push_back(qucs::Property("Ports", "", false, QString("x")));
+  Props.push_back(qucs::Property("Sim", "yes", false, QString("x")));
+  Props.push_back(qucs::Property("Preprocessor", "none", false, QString("x")));
   withSim = false;
 
   Model = "SPICE";
@@ -52,7 +52,7 @@ SpiceFile::SpiceFile()
   changed = false;
 
   // Do NOT call createSymbol() here. But create port to let it rotate.
-  Ports.push_back(Port(0, 0));
+  Ports.push_back(qucs::Port(0, 0));
 }
 
 // -------------------------------------------------------
@@ -94,45 +94,45 @@ void SpiceFile::createSymbol()
   // draw symbol outline
   #define HALFWIDTH  17
   int h = 30*((No-1)/2) + 15;
-  Lines.push_back(Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
 
   int w, i = fHeight/2;
   if(withSim) {
     i = fHeight - 2;
     tmp = QObject::tr("sim");
     w = smallmetrics.horizontalAdvance(tmp);
-    Texts.push_back(Text(w/-2, 0, tmp, Qt::red));
+    Texts.push_back(qucs::Text(w/-2, 0, tmp, Qt::red));
   }
   tmp = QObject::tr("spice");
   w = smallmetrics.boundingRect(tmp).width();
-  Texts.push_back(Text(w/-2, -i, tmp));
+  Texts.push_back(qucs::Text(w/-2, -i, tmp));
 
   i = 0;
   int y = 15-h;
   while(i<No) { // add ports lines and numbers
-    Lines.push_back(Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30,  y));
+    Lines.push_back(qucs::Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30,  y));
     tmp = PortNames.section(',', i, i).mid(4);
     w = smallmetrics.horizontalAdvance(tmp);
-    Texts.push_back(Text(-20-w, y-fHeight-2, tmp)); // text right-aligned
+    Texts.push_back(qucs::Text(-20-w, y-fHeight-2, tmp)); // text right-aligned
     i++;
 
     if(i == No) break; // if odd number of ports there will be one port less on the right side
-    Lines.push_back(Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30,  y));
+    Lines.push_back(qucs::Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30,  y));
     tmp = PortNames.section(',', i, i).mid(4);
-    Texts.push_back(Text( 20, y-fHeight-2, tmp)); // text left-aligned
+    Texts.push_back(qucs::Text( 20, y-fHeight-2, tmp)); // text left-aligned
     y += 60;
     i++;
   }
 
   if(No > 0) {
-    Lines.push_back(Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
-    Texts.push_back(Text( 4, h,"Ref"));
-    Ports.push_back(Port( 0, h+15));    // 'Ref' port
+    Lines.push_back(qucs::Line( 0, h, 0,h+15,QPen(Qt::darkBlue,2)));
+    Texts.push_back(qucs::Text( 4, h,"Ref"));
+    Ports.push_back(qucs::Port( 0, h+15));    // 'Ref' port
   }
 
   x1 = -30; y1 = -h-2;

--- a/qucs/components/spiralinductor.cpp
+++ b/qucs/components/spiralinductor.cpp
@@ -29,17 +29,17 @@ spiralinductor::spiralinductor()
   Description = QObject::tr("Planar spiral inductor");
 
   //Spiral
-  Arcs.push_back(Arc(-5, 0, 10, 10, -16*90, 16*180,QPen(Qt::darkBlue,3)));
-  Arcs.push_back(Arc(-10, -10, 20, 20, 16*90, 16*180,QPen(Qt::darkBlue,3)));
-  Arcs.push_back(Arc(-15, -10, 30, 30, -16*90, 16*180,QPen(Qt::darkBlue,3)));
-  Arcs.push_back(Arc(-20, -20, 40, 40, 16*90, 16*180,QPen(Qt::darkBlue,3)));
-  Arcs.push_back(Arc(-20, -20, 40, 40, 0, 16*90,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-5, 0, 10, 10, -16*90, 16*180,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-10, -10, 20, 20, 16*90, 16*180,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-15, -10, 30, 30, -16*90, 16*180,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-20, -20, 40, 40, 16*90, 16*180,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(-20, -20, 40, 40, 0, 16*90,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-30,  0, 0,  0,QPen(Qt::black,4)));
-  Lines.push_back(Line( 20,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0, 0,  0,QPen(Qt::black,4)));
+  Lines.push_back(qucs::Line( 20,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-25;
   x2 =  30; y2 = 25;
@@ -49,20 +49,20 @@ spiralinductor::spiralinductor()
   Model = "SPIRALIND";
   Name  = "SPIRALIND";
 
-  Props.push_back(Property("Subst", "Subst1", true,
+  Props.push_back(qucs::Property("Subst", "Subst1", true,
 		QObject::tr("Substrate")));
-  Props.push_back(Property("Geometry", "Circular", true,
+  Props.push_back(qucs::Property("Geometry", "Circular", true,
 		QObject::tr("Spiral type")+
 +		"[Circular, Square, Hexagonal, Octogonal]"));
-  Props.push_back(Property("W", "25 um", false,
+  Props.push_back(qucs::Property("W", "25 um", false,
 		QObject::tr("Width of line")));
-  Props.push_back(Property("Di", "200 um", false,
+  Props.push_back(qucs::Property("Di", "200 um", false,
 		QObject::tr("Inner diameter")));
-  Props.push_back(Property("S", "25 um", false,
+  Props.push_back(qucs::Property("S", "25 um", false,
 		QObject::tr("Spacing between turns")));
-  Props.push_back(Property("N", "3", false,
+  Props.push_back(qucs::Property("N", "3", false,
 		QObject::tr("Number of turns")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 
 }

--- a/qucs/components/subcircuit.cpp
+++ b/qucs/components/subcircuit.cpp
@@ -33,14 +33,14 @@ Subcircuit::Subcircuit()
   Type = isComponent;   // both analog and digital
   Description = QObject::tr("subcircuit");
 
-  Props.push_back(Property("File", "", false,
+  Props.push_back(qucs::Property("File", "", false,
 		QObject::tr("name of qucs schematic file")));
 
   Model = "Sub";
   Name  = "SUB";
 
   // Do NOT call createSymbol() here. But create port to let it rotate.
-  Ports.push_back(Port(0, 0, false));
+  Ports.push_back(qucs::Port(0, 0, false));
 }
 
 // ---------------------------------------------------------------------
@@ -102,24 +102,24 @@ void Subcircuit::createSymbol()
 void Subcircuit::remakeSymbol(int No)
 {
   int h = 30*((No-1)/2) + 15;
-  Lines.push_back(Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2)));
-  Texts.push_back(Text(-10, -6,"sub"));
+  Lines.push_back(qucs::Line(-15, -h, 15, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 15, -h, 15,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15,  h, 15,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-15, -h,-15,  h,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text(-10, -6,"sub"));
 
   int i=0, y = 15-h;
   while(i<No) {
     i++;
-    Lines.push_back(Line(-30,  y,-15,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30,  y));
-    Texts.push_back(Text(-25,y-14,QString::number(i)));
+    Lines.push_back(qucs::Line(-30,  y,-15,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30,  y));
+    Texts.push_back(qucs::Text(-25,y-14,QString::number(i)));
 
     if(i == No) break;
     i++;
-    Lines.push_back(Line( 15,  y, 30,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30,  y));
-    Texts.push_back(Text( 19,y-14,QString::number(i)));
+    Lines.push_back(qucs::Line( 15,  y, 30,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30,  y));
+    Texts.push_back(qucs::Text( 19,y-14,QString::number(i)));
     y += 60;
   }
 

--- a/qucs/components/subcirport.cpp
+++ b/qucs/components/subcirport.cpp
@@ -25,10 +25,10 @@ SubCirPort::SubCirPort()
   Description = QObject::tr("port of a subcircuit");
 
   // This property must be the first one !
-  Props.push_back(Property("Num", "1", true,
+  Props.push_back(qucs::Property("Num", "1", true,
 		QObject::tr("number of the port within the subcircuit")));
   // This property must be the second one !
-  Props.push_back(Property("Type", "analog", false,
+  Props.push_back(qucs::Property("Type", "analog", false,
 		QObject::tr("type of the port (for digital simulation only)")
 		+" [analog, in, out, inout]"));
 
@@ -46,39 +46,39 @@ void SubCirPort::createSymbol()
   x2 =   0; y2 =  8;
 
   if(prop(1).Value.at(0) == 'a') {
-    Arcs.push_back(Arc(-25, -6, 12, 12,  0, 16*360,QPen(Qt::darkBlue,2)));
-    Lines.push_back(Line(-13,  0,  0,  0,QPen(Qt::darkBlue,2)));
+    Arcs.push_back(qucs::Arc(-25, -6, 12, 12,  0, 16*360,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-13,  0,  0,  0,QPen(Qt::darkBlue,2)));
   }
   else {
-    Lines.push_back(Line( -9,  0,  0,  0,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line( -9,  0,  0,  0,QPen(Qt::darkBlue,2)));
     if(prop(1).Value == "out") {
-      Lines.push_back(Line(-20, -5,-25,  0,QPen(Qt::red,2)));
-      Lines.push_back(Line(-20,  5,-25,  0,QPen(Qt::red,2)));
-      Lines.push_back(Line(-20, -5, -9, -5,QPen(Qt::red,2)));
-      Lines.push_back(Line(-20,  5, -9,  5,QPen(Qt::red,2)));
-      Lines.push_back(Line( -9, -5, -9,  5,QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(-20, -5,-25,  0,QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(-20,  5,-25,  0,QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(-20, -5, -9, -5,QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(-20,  5, -9,  5,QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line( -9, -5, -9,  5,QPen(Qt::red,2)));
     }
     else {
-      Lines.push_back(Line(-14, -5, -9,  0,QPen(Qt::darkGreen,2)));
-      Lines.push_back(Line(-14,  5, -9,  0,QPen(Qt::darkGreen,2)));
+      Lines.push_back(qucs::Line(-14, -5, -9,  0,QPen(Qt::darkGreen,2)));
+      Lines.push_back(qucs::Line(-14,  5, -9,  0,QPen(Qt::darkGreen,2)));
       if(prop(1).Value == "in") {
-        Lines.push_back(Line(-25, -5,-14, -5,QPen(Qt::darkGreen,2)));
-        Lines.push_back(Line(-25,  5,-14,  5,QPen(Qt::darkGreen,2)));
-        Lines.push_back(Line(-25, -5,-25,  5,QPen(Qt::darkGreen,2)));
+        Lines.push_back(qucs::Line(-25, -5,-14, -5,QPen(Qt::darkGreen,2)));
+        Lines.push_back(qucs::Line(-25,  5,-14,  5,QPen(Qt::darkGreen,2)));
+        Lines.push_back(qucs::Line(-25, -5,-25,  5,QPen(Qt::darkGreen,2)));
       }
       else {
         x1 = -30;
-        Lines.push_back(Line(-18, -5,-14, -5,QPen(Qt::darkGreen,2)));
-        Lines.push_back(Line(-18,  5,-14,  5,QPen(Qt::darkGreen,2)));
-        Lines.push_back(Line(-23, -5,-28,  0,QPen(Qt::red,2)));
-        Lines.push_back(Line(-23,  5,-28,  0,QPen(Qt::red,2)));
-        Lines.push_back(Line(-23, -5,-18, -5,QPen(Qt::red,2)));
-        Lines.push_back(Line(-23,  5,-18,  5,QPen(Qt::red,2)));
+        Lines.push_back(qucs::Line(-18, -5,-14, -5,QPen(Qt::darkGreen,2)));
+        Lines.push_back(qucs::Line(-18,  5,-14,  5,QPen(Qt::darkGreen,2)));
+        Lines.push_back(qucs::Line(-23, -5,-28,  0,QPen(Qt::red,2)));
+        Lines.push_back(qucs::Line(-23,  5,-28,  0,QPen(Qt::red,2)));
+        Lines.push_back(qucs::Line(-23, -5,-18, -5,QPen(Qt::red,2)));
+        Lines.push_back(qucs::Line(-23,  5,-18,  5,QPen(Qt::red,2)));
       }
     }
   }
 
-  Ports.push_back(Port(  0,  0));
+  Ports.push_back(qucs::Port(  0,  0));
 }
 
 // -------------------------------------------------------

--- a/qucs/components/substrate.cpp
+++ b/qucs/components/substrate.cpp
@@ -22,30 +22,30 @@ Substrate::Substrate()
 {
   Description = QObject::tr("substrate definition");
 
-  Lines.push_back(Line(-30,-16, 30,-16,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-12, 30,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 16, 30, 16,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 12, 30, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,-16,-30, 16,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-16, 30, 16,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-16, 30,-16,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-12, 30,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 16, 30, 16,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 12, 30, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-16,-30, 16,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-16, 30, 16,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-16, 16,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-16, 80,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-12, 80,-36,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 12, 80,-16,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 16, 80,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-40, 80,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 80,-40, 80,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-16, 16,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-16, 80,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-12, 80,-36,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 12, 80,-16,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 16, 80,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-40, 80,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 80,-40, 80,-12,QPen(Qt::darkBlue,2)));
   
-  Lines.push_back(Line(-30,  0,-18,-12,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-22, 12,  2,-12,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( -2, 12, 22,-12,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 18, 12, 30,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-30,  0,-18,-12,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-22, 12,  2,-12,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -2, 12, 22,-12,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 18, 12, 30,  0,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line( 30,  1, 37,  8,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 37,-15, 52,  0,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 52,-22, 66, -8,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 66,-30, 80,-16,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 30,  1, 37,  8,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 37,-15, 52,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 52,-22, 66, -8,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 66,-30, 80,-16,QPen(Qt::darkBlue,1)));
 
   x1 = -34; y1 =-44;
   x2 =  84; y2 = 20;
@@ -55,17 +55,17 @@ Substrate::Substrate()
   Model = "SUBST";
   Name  = "Subst";
 
-  Props.push_back(Property("er", "9.8", true,
+  Props.push_back(qucs::Property("er", "9.8", true,
 		QObject::tr("relative permittivity")));
-  Props.push_back(Property("h", "1 mm", true,
+  Props.push_back(qucs::Property("h", "1 mm", true,
 		QObject::tr("thickness in meters")));
-  Props.push_back(Property("t", "35 um", true,
+  Props.push_back(qucs::Property("t", "35 um", true,
 		QObject::tr("thickness of metalization")));
-  Props.push_back(Property("tand", "2e-4", true,
+  Props.push_back(qucs::Property("tand", "2e-4", true,
 		QObject::tr("loss tangent")));
-  Props.push_back(Property("rho", "0.022e-6", true,
+  Props.push_back(qucs::Property("rho", "0.022e-6", true,
 		QObject::tr("specific resistance of metal")));
-  Props.push_back(Property("D", "0.15e-6", true,
+  Props.push_back(qucs::Property("D", "0.15e-6", true,
 		QObject::tr("rms substrate roughness")));
 }
 

--- a/qucs/components/switch.cpp
+++ b/qucs/components/switch.cpp
@@ -23,19 +23,19 @@ Switch::Switch()
 {
   Description = QObject::tr("switch (time controlled)");
 
-  Props.push_back(Property("init", "off", false,
+  Props.push_back(qucs::Property("init", "off", false,
 		QObject::tr("initial state")+" [on, off]"));
-  Props.push_back(Property("time", "1 ms", false,
+  Props.push_back(qucs::Property("time", "1 ms", false,
 		QObject::tr("time when state changes (semicolon separated list possible, even numbered lists are repeated)")));
-  Props.push_back(Property("Ron", "0", false,
+  Props.push_back(qucs::Property("Ron", "0", false,
 		QObject::tr("resistance of \"on\" state in ohms")));
-  Props.push_back(Property("Roff", "1e12", false,
+  Props.push_back(qucs::Property("Roff", "1e12", false,
 		QObject::tr("resistance of \"off\" state in ohms")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("MaxDuration", "1e-6", false,
+  Props.push_back(qucs::Property("MaxDuration", "1e-6", false,
 		QObject::tr("Max possible switch transition time (transition time 1/100 smallest value in 'time', or this number)")));
-  Props.push_back(Property("Transition", "spline", false,
+  Props.push_back(qucs::Property("Transition", "spline", false,
 		QObject::tr("Resistance transition shape")+" [abrupt, linear, spline]"));
 
   createSymbol();
@@ -86,22 +86,22 @@ QString Switch::netlist()
 void Switch::createSymbol()
 {
   if(Props.front().Value != "on") {
-    Lines.push_back(Line(-15,  0, 15,-15,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,  0, 15,-15,QPen(Qt::darkBlue,2)));
     y1 = -17;
   }
   else {
-    Lines.push_back(Line(-15,  0, 16,-5,QPen(Qt::darkBlue,2)));
+    Lines.push_back(qucs::Line(-15,  0, 16,-5,QPen(Qt::darkBlue,2)));
     y1 = -7;
   }
 
-  Lines.push_back(Line(-30,  0,-15,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 12, -3, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
-  Ellips.push_back(Area(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
+  Lines.push_back(qucs::Line(-30,  0,-15,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 17,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 12, -3, 5, 5, 0, 16*360,QPen(Qt::darkBlue,2)));
+  Ellips.push_back(qucs::Area(-18, -3, 6, 6, QPen(Qt::darkBlue,2),
                 QBrush(Qt::darkBlue, Qt::SolidPattern)));
 
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
   x1 = -30;
   x2 =  30; y2 =   7;

--- a/qucs/components/symtrafo.cpp
+++ b/qucs/components/symtrafo.cpp
@@ -34,48 +34,48 @@ symTrafo::symTrafo()
   int w;
   QString stmp;
 
-  Arcs.push_back(Arc(-16,-58,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,-46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,-34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, 22,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-58,-10,-70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-70,-30,-70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 58,-10, 70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 70,-30, 70,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-10,-30,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-22,-10,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,-30, 10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 10,-10, 22,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-58,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,-34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 46,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 34,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, 22,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-58,-10,-70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-70,-30,-70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 58,-10, 70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 70,-30, 70,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-10,-30,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-22,-10,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,-30, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 10,-10, 22,QPen(Qt::darkBlue,2)));
 
   // core lines
-  Lines.push_back(Line( -1,-57, -1, 57,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(  1,-57,  1, 57,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -1,-57, -1, 57,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(  1,-57,  1, 57,QPen(Qt::darkBlue,1)));
 
   stmp = "T1"; w = smallmetrics.horizontalAdvance(stmp); // compute width to right-align
-  Texts.push_back(Text(-13-w,-57,stmp));
+  Texts.push_back(qucs::Text(-13-w,-57,stmp));
   stmp = "T2"; w = smallmetrics.horizontalAdvance(stmp); // compute width to right-align
-  Texts.push_back(Text(-13-w, 22,stmp));
+  Texts.push_back(qucs::Text(-13-w, 22,stmp));
 
   // mark the turn direction
-  Arcs.push_back(Arc(-21,-64,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-21, 15,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 15,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-21,-64,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-21, 15,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 15,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,-70));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 70));
-  Ports.push_back(Port(-30, 10));
-  Ports.push_back(Port(-30,-10));
+  Ports.push_back(qucs::Port(-30,-70));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 70));
+  Ports.push_back(qucs::Port(-30, 10));
+  Ports.push_back(qucs::Port(-30,-10));
 
   x1 = -33; y1 = -74;
   x2 =  33; y2 =  74;
@@ -85,9 +85,9 @@ symTrafo::symTrafo()
   Model = "sTr";
   Name  = "Tr";
 
-  Props.push_back(Property("T1", "1", true,
+  Props.push_back(qucs::Property("T1", "1", true,
 		QObject::tr("voltage transformation ratio of coil 1")));
-  Props.push_back(Property("T2", "1", true,
+  Props.push_back(qucs::Property("T2", "1", true,
 		QObject::tr("voltage transformation ratio of coil 2")));
 }
 

--- a/qucs/components/taperedline.cpp
+++ b/qucs/components/taperedline.cpp
@@ -28,18 +28,18 @@ taperedline::taperedline()
   Description = QObject::tr("Exponential Tapered line");
 
   //Lines connection device and ports
-  Lines.push_back(Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-17,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  0, 30,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-17,  -6,-17, 6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(18,  -12,18, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-17,  -6,-17, 6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(18,  -12,18, 12,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-17,  6, 18, 12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-17,  -6,18, -12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-17,  6, 18, 12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-17,  -6,18, -12,QPen(Qt::darkBlue,2)));
 
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 =-16;
   x2 =  30; y2 = 14;
@@ -49,20 +49,20 @@ taperedline::taperedline()
   Model = "TAPEREDLINE";
   Name  = "Line";
 
-  Props.push_back(Property("Z1", "50 Ohm", true,
+  Props.push_back(qucs::Property("Z1", "50 Ohm", true,
 		QObject::tr("Characteristic impedance at port 1")));
-  Props.push_back(Property("Z2", "100 Ohm", true,
+  Props.push_back(qucs::Property("Z2", "100 Ohm", true,
 		QObject::tr("Characteristic impedance at port 2")));
-  Props.push_back(Property("L", "75 mm", true,
+  Props.push_back(qucs::Property("L", "75 mm", true,
 		QObject::tr("Line length")));
-  Props.push_back(Property("Weighting", "Exponential", true,
+  Props.push_back(qucs::Property("Weighting", "Exponential", true,
 		QObject::tr("Taper weighting")+
 		" [Exponential, Linear, Triangular, Klopfenstein]"));
-  Props.push_back(Property("Gamma_max", "0.1", false,
+  Props.push_back(qucs::Property("Gamma_max", "0.1", false,
 		QObject::tr("Maximum ripple (Klopfenstein taper only) ")));
-  Props.push_back(Property("Alpha", "0 dB", false,
+  Props.push_back(qucs::Property("Alpha", "0 dB", false,
 		QObject::tr("attenuation factor per length in 1/m")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 taperedline::~taperedline()

--- a/qucs/components/tff_SR.cpp
+++ b/qucs/components/tff_SR.cpp
@@ -24,11 +24,11 @@ tff_SR::tff_SR()
   Type = isComponent; // Analogue and digital component.
   Description = QObject::tr ("T flip flop with set and reset verilog device");
 
-  Props.push_back (Property ("TR_H", "6", false,
+  Props.push_back(qucs::Property("TR_H", "6", false,
     QObject::tr ("cross coupled gate transfer function high scaling factor")));
-  Props.push_back (Property ("TR_L", "5", false,
+  Props.push_back(qucs::Property("TR_L", "5", false,
     QObject::tr ("cross coupled gate transfer function low scaling factor")));
-  Props.push_back (Property ("Delay", "1 ns", false,
+  Props.push_back(qucs::Property("Delay", "1 ns", false,
     QObject::tr ("cross coupled gate delay")
     +" ("+QObject::tr ("s")+")"));
  
@@ -59,38 +59,38 @@ Element * tff_SR::info(QString& Name, char * &BitmapFile, bool getNewOne)
 void tff_SR::createSymbol()
 {
   // put in here symbol drawing code and terminal definitions
-  Lines.push_back(Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, -40, 30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  40,-30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, -40, 30,-40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, -40, 30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  40,-30, 40,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  40,-30,-40,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50,-20,-30,-20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-50, 20,-30, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30, 20, 50, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,-20, 50,-20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -30, 10,-20, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -30, 30,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -30, 10,-20, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -30, 30,-20, 20,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(  0, -50,  0,-60,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  50,  0, 60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -50,  0,-60,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  50,  0, 60,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( -5, -50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -5,  40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -5, -50, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -5,  40, 10, 10, 0, 16*360, QPen(Qt::darkBlue,2)));
 
-  Texts.push_back(Text(-25,-32, "T", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,-32, "Q", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( -5,-39, "S", Qt::darkBlue, 12.0));
-  Texts.push_back(Text( 11,  7, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text(-25,-32, "T", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,-32, "Q", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5,-39, "S", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( 11,  7, "Q", Qt::darkBlue, 12.0));
   Texts.back().over=true;
-  Texts.push_back(Text( -5, 17, "R", Qt::darkBlue, 12.0));
+  Texts.push_back(qucs::Text( -5, 17, "R", Qt::darkBlue, 12.0));
  
-  Ports.push_back(Port(  0,-60));  // S
-  Ports.push_back(Port(-50,-20));  // T
-  Ports.push_back(Port(-50, 20));  // CLK
-  Ports.push_back(Port(  0, 60));  // R
-  Ports.push_back(Port( 50, 20));  // QB
-  Ports.push_back(Port( 50,-20));  // Q
+  Ports.push_back(qucs::Port(  0,-60));  // S
+  Ports.push_back(qucs::Port(-50,-20));  // T
+  Ports.push_back(qucs::Port(-50, 20));  // CLK
+  Ports.push_back(qucs::Port(  0, 60));  // R
+  Ports.push_back(qucs::Port( 50, 20));  // QB
+  Ports.push_back(qucs::Port( 50,-20));  // Q
 
   x1 = -50; y1 = -60;
   x2 =  50; y2 =  60;

--- a/qucs/components/thyristor.cpp
+++ b/qucs/components/thyristor.cpp
@@ -22,18 +22,18 @@ Thyristor::Thyristor()
 {
   Description = QObject::tr("silicon controlled rectifier (SCR)");
 
-  Lines.push_back(Line(  0,-30,  0, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  6,  9,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9, -6,  9, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  6, -9, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0,  6,  9, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  6,  9,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9, -6,  9, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  6, -9, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,  6,  9, -6,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line( -9, 10, -5,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 10, -9, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9, 10, -5,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 10, -9, 10,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port(-20, 10));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port(-20, 10));
 
   x1 = -20; y1 = -30;
   x2 =  11; y2 =  30;
@@ -43,21 +43,21 @@ Thyristor::Thyristor()
   Model = "SCR";
   Name  = "D";
 
-  Props.push_back(Property("Vbo", "400 V", false,
+  Props.push_back(qucs::Property("Vbo", "400 V", false,
 	QObject::tr("breakover voltage")));
-  Props.push_back(Property("Igt", "50 uA", true,
+  Props.push_back(qucs::Property("Igt", "50 uA", true,
 	QObject::tr("gate trigger current")));
-  Props.push_back(Property("Cj0", "10 pF", false,
+  Props.push_back(qucs::Property("Cj0", "10 pF", false,
 	QObject::tr("parasitic capacitance")));
-  Props.push_back(Property("Is", "1e-10 A", false,
+  Props.push_back(qucs::Property("Is", "1e-10 A", false,
 	QObject::tr("saturation current")));
-  Props.push_back(Property("N", "2", false,
+  Props.push_back(qucs::Property("N", "2", false,
 	QObject::tr("emission coefficient")));
-  Props.push_back(Property("Ri", "10 Ohm", false,
+  Props.push_back(qucs::Property("Ri", "10 Ohm", false,
 	QObject::tr("intrinsic junction resistance")));
-  Props.push_back(Property("Rg", "5 Ohm", false,
+  Props.push_back(qucs::Property("Rg", "5 Ohm", false,
 	QObject::tr("gate resistance")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature")));
 }
 

--- a/qucs/components/tline.cpp
+++ b/qucs/components/tline.cpp
@@ -22,20 +22,20 @@ TLine::TLine()
 {
   Description = QObject::tr("ideal transmission line");
 
-  Lines.push_back(Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-28,  7, 28,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-28,  7, 28,  7,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-28, 14,-21,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-21, 14,-14,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-14, 14, -7,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7, 14,  0,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 14,  7,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7, 14, 14,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 14, 14, 21,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 21, 14, 28,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-28, 14,-21,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-21, 14,-14,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-14, 14, -7,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7, 14,  0,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 14,  7,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7, 14, 14,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 14, 14, 21,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 21, 14, 28,  7,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 = -4;
   x2 =  30; y2 = 16;
@@ -45,13 +45,13 @@ TLine::TLine()
   Model = "TLIN";
   Name  = "Line";
 
-  Props.push_back(Property("Z", "50 Ohm", true,
+  Props.push_back(qucs::Property("Z", "50 Ohm", true,
 		QObject::tr("characteristic impedance")));
-  Props.push_back(Property("L", "1 mm", true,
+  Props.push_back(qucs::Property("L", "1 mm", true,
 		QObject::tr("electrical length of the line")));
-  Props.push_back(Property("Alpha", "0 dB", false,
+  Props.push_back(qucs::Property("Alpha", "0 dB", false,
 		QObject::tr("attenuation factor per length in 1/m")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/tline_4port.cpp
+++ b/qucs/components/tline_4port.cpp
@@ -22,24 +22,24 @@ TLine_4Port::TLine_4Port()
 {
   Description = QObject::tr("ideal 4-terminal transmission line");
 
-  Arcs.push_back(Arc(-28,-40, 18, 38,16*232, 16*33,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-28,  2, 18, 38, 16*95, 16*33,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-28,-40, 18, 38,16*232, 16*33,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-28,  2, 18, 38, 16*95, 16*33,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line(-20,-2, 20,-2,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 2, 20, 2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-2, 20,-2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 2, 20, 2,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc( 10,-40, 18, 38,16*270, 16*40,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( 10,  2, 18, 38, 16*50, 16*40,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( 10,-40, 18, 38,16*270, 16*40,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( 10,  2, 18, 38, 16*50, 16*40,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc(-38,-10, 16, 28, 16*45, 16*45,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-38,-18, 16, 28,16*270, 16*45,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( 22,-10, 16, 28, 16*90, 16*45,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( 22,-18, 16, 28,16*225, 16*45,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-38,-10, 16, 28, 16*45, 16*45,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-38,-18, 16, 28,16*270, 16*45,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( 22,-10, 16, 28, 16*90, 16*45,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( 22,-18, 16, 28,16*225, 16*45,QPen(Qt::darkBlue,1)));
 
-  Ports.push_back(Port(-30,-10));
-  Ports.push_back(Port( 30,-10));
-  Ports.push_back(Port( 30, 10));
-  Ports.push_back(Port(-30, 10));
+  Ports.push_back(qucs::Port(-30,-10));
+  Ports.push_back(qucs::Port( 30,-10));
+  Ports.push_back(qucs::Port( 30, 10));
+  Ports.push_back(qucs::Port(-30, 10));
 
   x1 = -30; y1 =-12;
   x2 =  30; y2 = 12;
@@ -49,13 +49,13 @@ TLine_4Port::TLine_4Port()
   Model = "TLIN4P";
   Name  = "Line";
 
-  Props.push_back(Property("Z", "50 Ohm", true,
+  Props.push_back(qucs::Property("Z", "50 Ohm", true,
 		QObject::tr("characteristic impedance")));
-  Props.push_back(Property("L", "1 mm", true,
+  Props.push_back(qucs::Property("L", "1 mm", true,
 		QObject::tr("electrical length of the line")));
-  Props.push_back(Property("Alpha", "0 dB", false,
+  Props.push_back(qucs::Property("Alpha", "0 dB", false,
 		QObject::tr("attenuation factor per length in 1/m")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/tr_sim.cpp
+++ b/qucs/components/tr_sim.cpp
@@ -26,9 +26,9 @@ TR_Sim::TR_Sim()
   int a = s.indexOf(" ");
   if (a != -1) s[a] = '\n';
 
-  Texts.push_back(Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
+  Texts.push_back(qucs::Text(0, 0, s.left(a), Qt::darkBlue, QucsSettings.largeFontSize));
   if (a != -1)
-    Texts.push_back(Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
+    Texts.push_back(qucs::Text(0, 0, s.mid(a+1), Qt::darkBlue, QucsSettings.largeFontSize));
 
   x1 = -10; y1 = -9;
   x2 = x1+104; y2 = y1+59;
@@ -39,47 +39,47 @@ TR_Sim::TR_Sim()
   Name  = "TR";
 
   // The index of the first 4 properties must not changed. Used in recreate().
-  Props.push_back(Property("Type", "lin", true,
+  Props.push_back(qucs::Property("Type", "lin", true,
 	QObject::tr("sweep type")+" [lin, log, list, const]"));
-  Props.push_back(Property("Start", "0", true,
+  Props.push_back(qucs::Property("Start", "0", true,
 	QObject::tr("start time in seconds")));
-  Props.push_back(Property("Stop", "1 ms", true,
+  Props.push_back(qucs::Property("Stop", "1 ms", true,
 	QObject::tr("stop time in seconds")));
-  Props.push_back(Property("Points", "11", false,
+  Props.push_back(qucs::Property("Points", "11", false,
 	QObject::tr("number of simulation time steps")));
-  Props.push_back(Property("IntegrationMethod", "Trapezoidal", false,
+  Props.push_back(qucs::Property("IntegrationMethod", "Trapezoidal", false,
 	QObject::tr("integration method")+
 	" [Euler, Trapezoidal, Gear, AdamsMoulton]"));
-  Props.push_back(Property("Order", "2", false,
+  Props.push_back(qucs::Property("Order", "2", false,
 	QObject::tr("order of integration method")+" (1-6)"));
-  Props.push_back(Property("InitialStep", "1 ns", false,
+  Props.push_back(qucs::Property("InitialStep", "1 ns", false,
 	QObject::tr("initial step size in seconds")));
-  Props.push_back(Property("MinStep", "1e-16", false,
+  Props.push_back(qucs::Property("MinStep", "1e-16", false,
 	QObject::tr("minimum step size in seconds")));
-  Props.push_back(Property("MaxIter", "150", false,
+  Props.push_back(qucs::Property("MaxIter", "150", false,
 	QObject::tr("maximum number of iterations until error")));
-  Props.push_back(Property("reltol", "0.001", false,
+  Props.push_back(qucs::Property("reltol", "0.001", false,
 	QObject::tr("relative tolerance for convergence")));
-  Props.push_back(Property("abstol", "1 pA", false,
+  Props.push_back(qucs::Property("abstol", "1 pA", false,
 	QObject::tr("absolute tolerance for currents")));
-  Props.push_back(Property("vntol", "1 uV", false,
+  Props.push_back(qucs::Property("vntol", "1 uV", false,
 	QObject::tr("absolute tolerance for voltages")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("LTEreltol", "1e-3", false,
+  Props.push_back(qucs::Property("LTEreltol", "1e-3", false,
 	QObject::tr("relative tolerance of local truncation error")));
-  Props.push_back(Property("LTEabstol", "1e-6", false,
+  Props.push_back(qucs::Property("LTEabstol", "1e-6", false,
 	QObject::tr("absolute tolerance of local truncation error")));
-  Props.push_back(Property("LTEfactor", "1", false,
+  Props.push_back(qucs::Property("LTEfactor", "1", false,
 	QObject::tr("overestimation of local truncation error")));
-  Props.push_back(Property("Solver", "CroutLU", false,
+  Props.push_back(qucs::Property("Solver", "CroutLU", false,
 	QObject::tr("method for solving the circuit matrix")+
 	" [CroutLU, DoolittleLU, HouseholderQR, HouseholderLQ, GolubSVD]"));
-  Props.push_back(Property("relaxTSR", "no", false,
+  Props.push_back(qucs::Property("relaxTSR", "no", false,
 	QObject::tr("relax time step raster")+" [no, yes]"));
-  Props.push_back(Property("initialDC", "yes", false,
+  Props.push_back(qucs::Property("initialDC", "yes", false,
 	QObject::tr("perform an initial DC analysis")+" [yes, no]"));
-  Props.push_back(Property("MaxStep", "0", false,
+  Props.push_back(qucs::Property("MaxStep", "0", false,
 	QObject::tr("maximum step size in seconds")));
 }
 
@@ -103,7 +103,7 @@ Element* TR_Sim::info(QString& Name, char* &BitmapFile, bool getNewOne)
 
 void TR_Sim::recreate(Schematic*)
 {
-  Property &pp = prop(0);
+  qucs::Property &pp = prop(0);
   if((pp.Value == "list") || (pp.Value == "const")) {
     // Call them "Symbol" to omit them in the netlist.
     prop(1).Name = "Symbol";

--- a/qucs/components/transformer.cpp
+++ b/qucs/components/transformer.cpp
@@ -22,32 +22,32 @@ Transformer::Transformer()
 {
   Description = QObject::tr("ideal transformer");
 
-  Arcs.push_back(Arc(-16,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-16,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-18,-10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,-30,-30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 18,-10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10, 30,-30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -1,-20, -1, 20,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(  1,-20,  1, 20,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-16,-18,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16, -6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-16,  6,12,12, 16*270,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,-18,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4, -6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(  4,  6,12,12,  16*90,16*180, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-18,-10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,-30,-30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-18, 10,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 18,-10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10, 30,-30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 18, 10, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -1,-20, -1, 20,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(  1,-20,  1, 20,QPen(Qt::darkBlue,1)));
 
-  Texts.push_back(Text(-21, -18,"T"));
-  Arcs.push_back(Arc(-21,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 15,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Texts.push_back(qucs::Text(-21, -18,"T"));
+  Arcs.push_back(qucs::Arc(-21,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 15,-24,  5,  5,  0, 16*360,QPen(Qt::darkBlue,2)));
 
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -33; y1 = -34;
   x2 =  33; y2 =  34;
@@ -57,7 +57,7 @@ Transformer::Transformer()
   Model = "Tr";
   Name  = "Tr";
 
-  Props.push_back(Property("T", "1", true,
+  Props.push_back(qucs::Property("T", "1", true,
 		QObject::tr("voltage transformation ratio")));
 }
 

--- a/qucs/components/triac.cpp
+++ b/qucs/components/triac.cpp
@@ -22,22 +22,22 @@ Triac::Triac()
 {
   Description = QObject::tr("triac (bidirectional thyristor)");
 
-  Lines.push_back(Line(  0,-30,  0, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, 30,  0,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0,-30,  0, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, 30,  0,  6,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-18,  6, 18,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-18, -6, 18, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  6,-18, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -9,  6,  0, -6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  9, -6,  0,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  9, -6, 18,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18,  6, 18,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-18, -6, 18, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  6,-18, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -9,  6,  0, -6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  9, -6,  0,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  9, -6, 18,  6,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-13, 10, -9,  6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 10,-13, 10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13, 10, -9,  6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 10,-13, 10,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(  0,-30));
-  Ports.push_back(Port(  0, 30));
-  Ports.push_back(Port(-30, 10));
+  Ports.push_back(qucs::Port(  0,-30));
+  Ports.push_back(qucs::Port(  0, 30));
+  Ports.push_back(qucs::Port(-30, 10));
 
   x1 = -30; y1 = -30;
   x2 =  20; y2 =  30;
@@ -47,21 +47,21 @@ Triac::Triac()
   Model = "Triac";
   Name  = "D";
 
-  Props.push_back(Property("Vbo", "400 V", false,
+  Props.push_back(qucs::Property("Vbo", "400 V", false,
 	QObject::tr("(bidirectional) breakover voltage")));
-  Props.push_back(Property("Igt", "50 uA", true,
+  Props.push_back(qucs::Property("Igt", "50 uA", true,
 	QObject::tr("(bidirectional) gate trigger current")));
-  Props.push_back(Property("Cj0", "10 pF", false,
+  Props.push_back(qucs::Property("Cj0", "10 pF", false,
 	QObject::tr("parasitic capacitance")));
-  Props.push_back(Property("Is", "1e-10 A", false,
+  Props.push_back(qucs::Property("Is", "1e-10 A", false,
 	QObject::tr("saturation current")));
-  Props.push_back(Property("N", "2", false,
+  Props.push_back(qucs::Property("N", "2", false,
 	QObject::tr("emission coefficient")));
-  Props.push_back(Property("Ri", "10 Ohm", false,
+  Props.push_back(qucs::Property("Ri", "10 Ohm", false,
 	QObject::tr("intrinsic junction resistance")));
-  Props.push_back(Property("Rg", "5 Ohm", false,
+  Props.push_back(qucs::Property("Rg", "5 Ohm", false,
 	QObject::tr("gate resistance")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature")));
 }
 

--- a/qucs/components/tunneldiode.cpp
+++ b/qucs/components/tunneldiode.cpp
@@ -18,51 +18,51 @@ TunnelDiode::TunnelDiode()
 {
   Description = QObject::tr("resonance tunnel diode");
 
-  Props.push_back(Property("Ip", "4 mA", true,
+  Props.push_back(qucs::Property("Ip", "4 mA", true,
 	QObject::tr("peak current")));
-  Props.push_back(Property("Iv", "0.6 mA", true,
+  Props.push_back(qucs::Property("Iv", "0.6 mA", true,
 	QObject::tr("valley current")));
-  Props.push_back(Property("Vv", "0.8 V", true,
+  Props.push_back(qucs::Property("Vv", "0.8 V", true,
 	QObject::tr("valley voltage")));
-  Props.push_back(Property("Wr", "2.7e-20", false,
+  Props.push_back(qucs::Property("Wr", "2.7e-20", false,
 	QObject::tr("resonance energy in Ws")));
-  Props.push_back(Property("eta", "1e-20", false,
+  Props.push_back(qucs::Property("eta", "1e-20", false,
 	QObject::tr("Fermi energy in Ws")));
-  Props.push_back(Property("dW", "4.5e-21", false,
+  Props.push_back(qucs::Property("dW", "4.5e-21", false,
 	QObject::tr("resonance width in Ws")));
-  Props.push_back(Property("Tmax", "0.95", false,
+  Props.push_back(qucs::Property("Tmax", "0.95", false,
 	QObject::tr("maximum of transmission")));
-  Props.push_back(Property("de", "0.9", false,
+  Props.push_back(qucs::Property("de", "0.9", false,
 	QObject::tr("fitting factor for electron density")));
-  Props.push_back(Property("dv", "2.0", false,
+  Props.push_back(qucs::Property("dv", "2.0", false,
 	QObject::tr("fitting factor for voltage drop")));
-  Props.push_back(Property("nv", "16", false,
+  Props.push_back(qucs::Property("nv", "16", false,
 	QObject::tr("fitting factor for diode current")));
 
-  Props.push_back(Property("Cj0", "80 fF", false,
+  Props.push_back(qucs::Property("Cj0", "80 fF", false,
 	QObject::tr("zero-bias depletion capacitance")));
-  Props.push_back(Property("M", "0.5", false,
+  Props.push_back(qucs::Property("M", "0.5", false,
 	QObject::tr("grading coefficient")));
-  Props.push_back(Property("Vj", "0.5 V", false,
+  Props.push_back(qucs::Property("Vj", "0.5 V", false,
 	QObject::tr("junction potential")));
-  Props.push_back(Property("te", "0.6 ps", false,
+  Props.push_back(qucs::Property("te", "0.6 ps", false,
 	QObject::tr("life-time of electrons")));
 
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 	QObject::tr("simulation temperature in degree Celsius")));
-  Props.push_back(Property("Area", "1.0", false,
+  Props.push_back(qucs::Property("Area", "1.0", false,
 	QObject::tr("default area for diode")));
 
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 12,  0, 30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, -9,-12,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  0, -9,  0,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 12, -9, 12,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, -9, 12,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12,  9, 12, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12,  0, 30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, -9,-12,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  0, -9,  0,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 12, -9, 12,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, -9, 12,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  9, 12, -9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30, 0));
-  Ports.push_back(Port( 30, 0));
+  Ports.push_back(qucs::Port(-30, 0));
+  Ports.push_back(qucs::Port( 30, 0));
 
   x1 = -30; y1 = -11;
   x2 =  30; y2 =  11;

--- a/qucs/components/twistedpair.cpp
+++ b/qucs/components/twistedpair.cpp
@@ -22,30 +22,30 @@ TwistedPair::TwistedPair()
 {
   Description = QObject::tr("twisted pair transmission line");
 
-  Arcs.push_back(Arc(-25,-36, 18, 38,16*230, 16*68,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-25, -2, 18, 38, 16*62, 16*68,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-25,-36, 18, 38,16*230, 16*68,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-25, -2, 18, 38, 16*62, 16*68,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc(-17,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(-17, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-17,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(-17, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc( -9,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( -9, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -9,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -9, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc( -1,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc( -1, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -1,-36, 18, 38,16*242, 16*56,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc( -1, -2, 18, 38, 16*62, 16*56,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc(  7,-36, 18, 38,16*242, 16*68,QPen(Qt::darkBlue,1)));
-  Arcs.push_back(Arc(  7, -2, 18, 38, 16*50, 16*68,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  7,-36, 18, 38,16*242, 16*68,QPen(Qt::darkBlue,1)));
+  Arcs.push_back(qucs::Arc(  7, -2, 18, 38, 16*50, 16*68,QPen(Qt::darkBlue,1)));
 
-  Arcs.push_back(Arc(-40,-10, 20, 33, 16*32, 16*58,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc(-40,-23, 20, 33,16*270, 16*58,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 20,-10, 20, 33, 16*90, 16*58,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( 20,-23, 20, 33,16*212, 16*58,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-40,-10, 20, 33, 16*32, 16*58,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-40,-23, 20, 33,16*270, 16*58,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 20,-10, 20, 33, 16*90, 16*58,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( 20,-23, 20, 33,16*212, 16*58,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port(-30,-10));
-  Ports.push_back(Port( 30,-10));
-  Ports.push_back(Port( 30, 10));
-  Ports.push_back(Port(-30, 10));
+  Ports.push_back(qucs::Port(-30,-10));
+  Ports.push_back(qucs::Port( 30,-10));
+  Ports.push_back(qucs::Port( 30, 10));
+  Ports.push_back(qucs::Port(-30, 10));
 
   x1 = -30; y1 =-12;
   x2 =  30; y2 = 12;
@@ -55,23 +55,23 @@ TwistedPair::TwistedPair()
   Model = "TWIST";
   Name  = "Line";
 
-  Props.push_back(Property("d", "0.5 mm", true,
+  Props.push_back(qucs::Property("d", "0.5 mm", true,
 		QObject::tr("diameter of conductor")));
-  Props.push_back(Property("D", "0.8 mm", true,
+  Props.push_back(qucs::Property("D", "0.8 mm", true,
 		QObject::tr("diameter of wire (conductor and insulator)")));
-  Props.push_back(Property("L", "1.5", true,
+  Props.push_back(qucs::Property("L", "1.5", true,
 		QObject::tr("physical length of the line")));
-  Props.push_back(Property("T", "100", false,
+  Props.push_back(qucs::Property("T", "100", false,
 		QObject::tr("twists per length in 1/m")));
-  Props.push_back(Property("er", "4", false,
+  Props.push_back(qucs::Property("er", "4", false,
 		QObject::tr("dielectric constant of insulator")));
-  Props.push_back(Property("mur", "1", false,
+  Props.push_back(qucs::Property("mur", "1", false,
 		QObject::tr("relative permeability of conductor")));
-  Props.push_back(Property("rho", "0.022e-6", false,
+  Props.push_back(qucs::Property("rho", "0.022e-6", false,
 		QObject::tr("specific resistance of conductor")));
-  Props.push_back(Property("tand", "4e-4", false,
+  Props.push_back(qucs::Property("tand", "4e-4", false,
 		QObject::tr("loss tangent")));
-  Props.push_back(Property("Temp", "26.85", false,
+  Props.push_back(qucs::Property("Temp", "26.85", false,
 		QObject::tr("simulation temperature in degree Celsius")));
 }
 

--- a/qucs/components/vacomponent.cpp
+++ b/qucs/components/vacomponent.cpp
@@ -75,7 +75,7 @@ vacomponent::vacomponent(QString filename)
 
       /// \todo what if there are no properties?
 
-      Props.push_back (Property (name, value, show, desc));
+      Props.push_back(qucs::Property(name, value, show, desc));
     }
   }
 
@@ -200,7 +200,7 @@ void vacomponent::createSymbol(QString filename)
       thick = getDouble(entry, "thick");
       style = getString(entry, "style");
 
-      Lines.push_back (Line (x1, y1, x2, y2,
+      Lines.push_back(qucs::Line (x1, y1, x2, y2,
                         QPen (QColor (color), thick, penMap.value(style))));
     }
 
@@ -215,7 +215,7 @@ void vacomponent::createSymbol(QString filename)
       colorfill = getString(entry, "colorfill");
       stylefill = getString(entry, "stylefill");
 
-      Rects.push_back (Area (x, y, w, h,
+      Rects.push_back(qucs::Area (x, y, w, h,
                         QPen (QColor (color), thick, penMap.value(style)),
                         QBrush(QColor (colorfill), brushMap.value(stylefill))
                         ));
@@ -232,7 +232,7 @@ void vacomponent::createSymbol(QString filename)
       colorfill = getString(entry, "colorfill");
       stylefill = getString(entry, "stylefill");
 
-      Ellips.push_back (Area (x, y, w, h,
+      Ellips.push_back(qucs::Area (x, y, w, h,
                          QPen (QColor (color), thick, penMap.value(style)),
                          QBrush(QColor (colorfill), brushMap.value(stylefill))
                          ));
@@ -249,14 +249,14 @@ void vacomponent::createSymbol(QString filename)
       thick = getDouble(entry, "thick");
       style = getString(entry, "style");
 
-      Arcs.push_back (Arc (x, y, w, h, angle, arclen,
+      Arcs.push_back(qucs::Arc(x, y, w, h, angle, arclen,
                        QPen (QColor (color), thick, penMap.value(style))));
     }
 
     if (!type.compare("portsymbol")) {
       x = getDouble(entry, "x");
       y = getDouble(entry, "y");
-      Ports.push_back (Port (x, y));
+      Ports.push_back(qucs::Port(x, y));
     }
 
     if (!type.compare("graphictext")) {
@@ -267,7 +267,7 @@ void vacomponent::createSymbol(QString filename)
       size = getDouble(entry, "size");
       cos = getDouble(entry, "cos");
       sin = getDouble(entry, "sin");
-      Texts.push_back (Text (x, y, s,
+      Texts.push_back(qucs::Text (x, y, s,
                               QColor (color), size, cos, sin));
     }
 
@@ -279,7 +279,7 @@ void vacomponent::createSymbol(QString filename)
       color = getString(entry, "color");
       thick = getDouble(entry, "thick");
       style = getString(entry, "style");
-      Lines.push_back (Line (x1, y1, x2, y2,
+      Lines.push_back(qucs::Line (x1, y1, x2, y2,
                         QPen (QColor (color), thick, penMap.value(style))));
      }
   }

--- a/qucs/components/vccs.cpp
+++ b/qucs/components/vccs.cpp
@@ -22,34 +22,34 @@ VCCS::VCCS()
 {
   Description = QObject::tr("voltage controlled current source");
 
-  Arcs.push_back(Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
+  Arcs.push_back(qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, -7, 11,  7,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 11,  6, 15,  1,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line( 11,  6,  7,  1,QPen(Qt::darkBlue,3)));
 
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -59,9 +59,9 @@ VCCS::VCCS()
   Model = "VCCS";
   Name  = "SRC";
 
-  Props.push_back(Property("G", "1 S", true,
+  Props.push_back(qucs::Property("G", "1 S", true,
 		QObject::tr("forward transconductance")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 }
 
 VCCS::~VCCS()

--- a/qucs/components/vcresistor.cpp
+++ b/qucs/components/vcresistor.cpp
@@ -23,39 +23,39 @@ vcresistor::vcresistor()
   Description = QObject::tr("voltage controlled resistor");
 
   // The resistor shape
-  Lines.push_back(Line(5, 18, 5, -18, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(17, 18, 17, -18, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(5, 18, 17, 18, QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(5, -18, 17, -18, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(5, 18, 5, -18, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(17, 18, 17, -18, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(5, 18, 17, 18, QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(5, -18, 17, -18, QPen(Qt::darkBlue,2)));
 
   // horizontal lines on top and bottom of left hand side
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
   // horizontal lines on top and bottom of right hand side
-  Lines.push_back(Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
   // vertical lines on top and bottom of left hand side
-  Lines.push_back(Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
   // vertical lines on top and bottom of right hand side
-  Lines.push_back(Line( 11,-30, 11,-18,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 11, 18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 11,-18,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 11, 18,QPen(Qt::darkBlue,2)));
 
   // downward pointing arrow
-  Lines.push_back(Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
 
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port(-30, 30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port(-30, 30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
 
 
   x1 = -30; y1 = -30;
@@ -66,7 +66,7 @@ vcresistor::vcresistor()
   Model = "vcresistor";
   Name  = "VCR";
 
-  Props.push_back(Property("gain", "1", true,
+  Props.push_back(qucs::Property("gain", "1", true,
 		QObject::tr("resistance gain")));
 }
 

--- a/qucs/components/vcvs.cpp
+++ b/qucs/components/vcvs.cpp
@@ -22,35 +22,35 @@ VCVS::VCVS()
 {
   Description = QObject::tr("voltage controlled voltage source");
 
-  Arcs.push_back(Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(0,-11, 22, 22,  0, 16*360,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,-30,-12,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30, 30,-12, 30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 30,-30,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 30, 30,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,-30,-12,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12, 30,-12, 23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,-30, 11,-11,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11, 30, 11, 11,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12,-18,-12, 18,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18,-17,  9,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-12, 18, -7,  9,QPen(Qt::darkBlue,1)));
 
-  Lines.push_back(Line( 19,-21, 19,-15,QPen(Qt::red,1)));
-  Lines.push_back(Line( 16,-18, 22,-18,QPen(Qt::red,1)));
-  Lines.push_back(Line( 16, 18, 22, 18,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line( 19,-21, 19,-15,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 16,-18, 22,-18,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 16, 18, 22, 18,QPen(Qt::black,1)));
 
-  Lines.push_back(Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
-  Lines.push_back(Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25,-27, 25,-27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25,-27, 25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line( 25, 27,-25, 27,QPen(Qt::darkGray,1)));
+  Lines.push_back(qucs::Line(-25, 27,-25,-27,QPen(Qt::darkGray,1)));
 
-  Ports.push_back(Port(-30,-30));
-  Ports.push_back(Port( 30,-30));
-  Ports.push_back(Port( 30, 30));
-  Ports.push_back(Port(-30, 30));
+  Ports.push_back(qucs::Port(-30,-30));
+  Ports.push_back(qucs::Port( 30,-30));
+  Ports.push_back(qucs::Port( 30, 30));
+  Ports.push_back(qucs::Port(-30, 30));
 
   x1 = -30; y1 = -30;
   x2 =  30; y2 =  30;
@@ -60,9 +60,9 @@ VCVS::VCVS()
   Model = "VCVS";
   Name  = "SRC";
 
-  Props.push_back(Property("G", "1", true,
+  Props.push_back(qucs::Property("G", "1", true,
 		QObject::tr("forward transfer factor")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 }
 
 VCVS::~VCVS()

--- a/qucs/components/verilogfile.cpp
+++ b/qucs/components/verilogfile.cpp
@@ -30,14 +30,14 @@ Verilog_File::Verilog_File()
   Type = isDigitalComponent;
   Description = QObject::tr("Verilog file");
 
-  Props.push_back(Property("File", "sub.v", false,
+  Props.push_back(qucs::Property("File", "sub.v", false,
 		QObject::tr("Name of Verilog file")));
 
   Model = "Verilog";
   Name  = "X";
 
   // Do NOT call createSymbol() here. But create port to let it rotate.
-  Ports.push_back(Port(0, 0));
+  Ports.push_back(qucs::Port(0, 0));
 }
 
 // -------------------------------------------------------
@@ -125,30 +125,30 @@ void Verilog_File::createSymbol()
 
   #define HALFWIDTH  24
   int h = 30*((No-1)/2) + 15;
-  Lines.push_back(Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
 
   tmp = QObject::tr("verilog");
   int w = metrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(w/-2, fHeight/-2, tmp));
+  Texts.push_back(qucs::Text(w/-2, fHeight/-2, tmp));
 
 
   int y = 15-h, i = 0;
   while(i<No) {
-    Lines.push_back(Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port(-30,  y));
+    Lines.push_back(qucs::Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port(-30,  y));
     tmp = PortNames.section(',', i, i);
     w = metrics.horizontalAdvance(tmp);
-    Texts.push_back(Text(-26-w, y-fHeight-2, tmp));
+    Texts.push_back(qucs::Text(-26-w, y-fHeight-2, tmp));
     i++;
 
     if(i == No) break;
-    Lines.push_back(Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
-    Ports.push_back(Port( 30,  y));
+    Lines.push_back(qucs::Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
+    Ports.push_back(qucs::Port( 30,  y));
     tmp = PortNames.section(',', i, i);
-    Texts.push_back(Text( 27, y-fHeight-2, tmp));
+    Texts.push_back(qucs::Text( 27, y-fHeight-2, tmp));
     y += 60;
     i++;
   }

--- a/qucs/components/vexp.cpp
+++ b/qucs/components/vexp.cpp
@@ -23,27 +23,27 @@ vExp::vExp()
   Description = QObject::tr("exponential voltage source");
 
   // normal voltage source symbol
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
   // write 'Exp' inside voltage source symbol
-  Lines.push_back(Line( -3,  -7, -3, -4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,  -7, 5, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 1,  -7, 1, -4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 5,  -7, 5, -4,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,  -1, 1, 3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 1,  -1, -3, 3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 1,  6, -5, 6,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 1,  6, 1, 9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,  6, -3, 9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 1,  9, -3, 9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,  -7, -3, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,  -7, 5, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 1,  -7, 1, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 5,  -7, 5, -4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,  -1, 1, 3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 1,  -1, -3, 3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 1,  6, -5, 6,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 1,  6, 1, 9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,  6, -3, 9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 1,  9, -3, 9,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -53,17 +53,17 @@ vExp::vExp()
   Model = "Vexp";
   Name  = "V";
 
-  Props.push_back(Property("U1", "0 V", true,
+  Props.push_back(qucs::Property("U1", "0 V", true,
 		QObject::tr("voltage before rising edge")));
-  Props.push_back(Property("U2", "1 V", true,
+  Props.push_back(qucs::Property("U2", "1 V", true,
 		QObject::tr("maximum voltage of the pulse")));
-  Props.push_back(Property("T1", "0", true,
+  Props.push_back(qucs::Property("T1", "0", true,
 		QObject::tr("start time of the exponentially rising edge")));
-  Props.push_back(Property("T2", "1 ms", true,
+  Props.push_back(qucs::Property("T2", "1 ms", true,
 		QObject::tr("start of exponential decay")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the rising edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("fall time of the falling edge")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/vfile.cpp
+++ b/qucs/components/vfile.cpp
@@ -23,25 +23,25 @@ vFile::vFile()
 {
   Description = QObject::tr("file based voltage source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
-  Lines.push_back(Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,-17, -6,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -8,-17, -8,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-10,-17,-10,-21,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( -3,-15, -3,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-13,-15,-13,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,-23,-13,-23,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -3,-15,-13,-15,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -51,14 +51,14 @@ vFile::vFile()
   Model = "Vfile";
   Name  = "V";
 
-  Props.push_back(Property("File", "vfile.dat", true,
+  Props.push_back(qucs::Property("File", "vfile.dat", true,
 		QObject::tr("name of the sample file")));
-  Props.push_back(Property("Interpolator", "linear", false,
+  Props.push_back(qucs::Property("Interpolator", "linear", false,
 		QObject::tr("interpolation type")+" [hold, linear, cubic]"));
-  Props.push_back(Property("Repeat", "no", false,
+  Props.push_back(qucs::Property("Repeat", "no", false,
 		QObject::tr("repeat waveform")+" [no, yes]"));
-  Props.push_back(Property("G", "1", false, QObject::tr("voltage gain")));
-  Props.push_back(Property("T", "0", false, QObject::tr("delay time")));
+  Props.push_back(qucs::Property("G", "1", false, QObject::tr("voltage gain")));
+  Props.push_back(qucs::Property("T", "0", false, QObject::tr("delay time")));
 
   rotate();  // fix historical flaw
 }

--- a/qucs/components/vhdlfile.cpp
+++ b/qucs/components/vhdlfile.cpp
@@ -29,14 +29,14 @@ VHDL_File::VHDL_File()
   Type = isDigitalComponent;
   Description = QObject::tr("VHDL file");
 
-  Props.push_back(Property("File", "sub.vhdl", false,
+  Props.push_back(qucs::Property("File", "sub.vhdl", false,
 		QObject::tr("Name of VHDL file")));
 
   Model = "VHDL";
   Name  = "X";
 
   // Do NOT call createSymbol() here. But create port to let it rotate.
-  Ports.push_back(Port(0, 0));
+  Ports.push_back(qucs::Port(0, 0));
 }
 
 // -------------------------------------------------------
@@ -135,34 +135,34 @@ void VHDL_File::createSymbol()
 
   #define HALFWIDTH  17
   int h = 30*((No-1)/2) + 15;
-  Lines.push_back(Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h, HALFWIDTH, -h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( HALFWIDTH, -h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH,  h, HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-HALFWIDTH, -h,-HALFWIDTH,  h,QPen(Qt::darkBlue,2)));
 
   tmp = QObject::tr("vhdl");
   int w = metrics.horizontalAdvance(tmp);
-  Texts.push_back(Text(w/-2, fHeight/-2, tmp));
+  Texts.push_back(qucs::Text(w/-2, fHeight/-2, tmp));
 
   int y = 15-h, i = 0;
-  Port pp;
+  qucs::Port pp;
   while(i<No) {
-    Lines.push_back(Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
-    pp = Port(-30,  y);
+    Lines.push_back(qucs::Line(-30,  y,-HALFWIDTH,  y,QPen(Qt::darkBlue,2)));
+    pp = qucs::Port(-30,  y);
     pp.Type = TypeNames.section(',', i, i);
     Ports.push_back(pp);
     tmp = PortNames.section(',', i, i);
     w = metrics.horizontalAdvance(tmp);
-    Texts.push_back(Text(-19-w, y-fHeight-2, tmp));
+    Texts.push_back(qucs::Text(-19-w, y-fHeight-2, tmp));
     i++;
 
     if(i == No) break;
-    Lines.push_back(Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
-    pp = Port( 30,  y);
+    Lines.push_back(qucs::Line(HALFWIDTH,  y, 30,  y,QPen(Qt::darkBlue,2)));
+    pp = qucs::Port( 30,  y);
     pp.Type = TypeNames.section(',', i, i);
     Ports.push_back(pp);
     tmp = PortNames.section(',', i, i);
-    Texts.push_back(Text( 20, y-fHeight-2, tmp));
+    Texts.push_back(qucs::Text( 20, y-fHeight-2, tmp));
     y += 60;
     i++;
   }
@@ -180,7 +180,7 @@ void VHDL_File::createSymbol()
   ++pr;
   for(i=0; i<No; i++) {
     if(pr == Props.end()) {
-      Property newProp(GenNames.section(',', i, i),
+      qucs::Property newProp(GenNames.section(',', i, i),
                        GenDefs.section(',', i, i), true,
                        QObject::tr("generic variable")+
                          " "+QString::number(i+1));

--- a/qucs/components/volt_ac.cpp
+++ b/qucs/components/volt_ac.cpp
@@ -22,17 +22,17 @@ Volt_ac::Volt_ac()
 {
   Description = QObject::tr("ideal ac voltage source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
-  Arcs.push_back(Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -3, -7,  7,  7,16*270, 16*180,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc( -3,  0,  7,  7, 16*90, 16*180,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -42,13 +42,13 @@ Volt_ac::Volt_ac()
   Model = "Vac";
   Name  = "V";
 
-  Props.push_back(Property("U", "1 V", true,
+  Props.push_back(qucs::Property("U", "1 V", true,
 		QObject::tr("peak voltage in Volts")));
-  Props.push_back(Property("f", "1 GHz", false,
+  Props.push_back(qucs::Property("f", "1 GHz", false,
 		QObject::tr("frequency in Hertz")));
-  Props.push_back(Property("Phase", "0", false,
+  Props.push_back(qucs::Property("Phase", "0", false,
 		QObject::tr("initial phase in degrees")));
-  Props.push_back(Property("Theta", "0", false,
+  Props.push_back(qucs::Property("Theta", "0", false,
 		QObject::tr("damping factor (transient simulation only)")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/volt_dc.cpp
+++ b/qucs/components/volt_dc.cpp
@@ -22,16 +22,16 @@ Volt_dc::Volt_dc()
 {
   Description = QObject::tr("ideal dc voltage source");
 
-  Lines.push_back(Line(  4,-13,  4, 13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -4, -6, -4,  6,QPen(Qt::darkBlue,4)));
-  Lines.push_back(Line( 30,  0,  4,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -4,  0,-30,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 11,  5, 11, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 14,  8,  8,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-11,  5,-11, 11,QPen(Qt::black,1)));
+  Lines.push_back(qucs::Line(  4,-13,  4, 13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4, -6, -4,  6,QPen(Qt::darkBlue,4)));
+  Lines.push_back(qucs::Line( 30,  0,  4,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -4,  0,-30,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 11,  5, 11, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 14,  8,  8,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-11,  5,-11, 11,QPen(Qt::black,1)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -41,7 +41,7 @@ Volt_dc::Volt_dc()
   Model = "Vdc";
   Name  = "V";
 
-  Props.push_back(Property("U", "1 V", true,
+  Props.push_back(qucs::Property("U", "1 V", true,
 		QObject::tr("voltage in Volts")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/volt_noise.cpp
+++ b/qucs/components/volt_noise.cpp
@@ -22,17 +22,17 @@ Volt_noise::Volt_noise()
 {
   Description = QObject::tr("noise voltage source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-10,  6,  6,-10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -7, 10, 10, -7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -2, 12, 12, -2,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  1,  1,-12,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-10,  6,  6,-10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -7, 10, 10, -7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -2, 12, 12, -2,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -15;
   x2 =  30; y2 =  15;
@@ -42,13 +42,13 @@ Volt_noise::Volt_noise()
   Model = "Vnoise";
   Name  = "V";
 
-  Props.push_back(Property("u", "1e-6", true,
+  Props.push_back(qucs::Property("u", "1e-6", true,
 		QObject::tr("voltage power spectral density in V^2/Hz")));
-  Props.push_back(Property("e", "0", false,
+  Props.push_back(qucs::Property("e", "0", false,
 		QObject::tr("frequency exponent")));
-  Props.push_back(Property("c", "1", false,
+  Props.push_back(qucs::Property("c", "1", false,
 		QObject::tr("frequency coefficient")));
-  Props.push_back(Property("a", "0", false,
+  Props.push_back(qucs::Property("a", "0", false,
 		QObject::tr("additive frequency term")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/vprobe.cpp
+++ b/qucs/components/vprobe.cpp
@@ -22,27 +22,27 @@ vProbe::vProbe()
 {
   Description = QObject::tr("voltage probe");
 
-  Lines.push_back(Line(-20,-31, 20,-31,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,  9, 20,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-31,-20,  9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-31, 20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-31, 20,-31,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,  9, 20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-31,-20,  9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-31, 20,  9,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-16,-27, 16,-27,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-27,-16, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-27, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-27, 16,-27,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, -9, 16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-27,-16, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-27, 16, -9,QPen(Qt::darkBlue,2)));
 
-  Arcs.push_back(Arc(-20,-23, 39, 39, 16*50, 16*80,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-11,-24, -2, -9,QPen(Qt::darkBlue,2)));
+  Arcs.push_back(qucs::Arc(-20,-23, 39, 39, 16*50, 16*80,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-11,-24, -2, -9,QPen(Qt::darkBlue,2)));
 
-  Lines.push_back(Line(-10,  0,-10,  6,QPen(Qt::red,2)));
-  Lines.push_back(Line(-13,  3, -7,  3,QPen(Qt::red,2)));
-  Lines.push_back(Line(  7,  3, 13,  3,QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(-10,  0,-10,  6,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-13,  3, -7,  3,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(  7,  3, 13,  3,QPen(Qt::black,2)));
 
-  Lines.push_back(Line(-10,  9,-10, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  9, 10, 20,QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port(-10, 20));
-  Ports.push_back(Port( 10, 20));
+  Lines.push_back(qucs::Line(-10,  9,-10, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  9, 10, 20,QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port(-10, 20));
+  Ports.push_back(qucs::Port( 10, 20));
 
   x1 = -24; y1 = -35;
   x2 =  24; y2 =  20;

--- a/qucs/components/vpulse.cpp
+++ b/qucs/components/vpulse.cpp
@@ -22,21 +22,21 @@ vPulse::vPulse()
 {
   Description = QObject::tr("ideal voltage pulse source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
-  Lines.push_back(Line(  6, -3,  6,  3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, -7, -6, -3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  3, -6,  7,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6, -3,  6, -3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -6,  3,  6,  3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  6, -3,  6,  3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, -7, -6, -3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  3, -6,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6, -3,  6, -3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -6,  3,  6,  3,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -46,17 +46,17 @@ vPulse::vPulse()
   Model = "Vpulse";
   Name  = "V";
 
-  Props.push_back(Property("U1", "0 V", true,
+  Props.push_back(qucs::Property("U1", "0 V", true,
 		QObject::tr("voltage before and after the pulse")));
-  Props.push_back(Property("U2", "1 V", true,
+  Props.push_back(qucs::Property("U2", "1 V", true,
 		QObject::tr("voltage of the pulse")));
-  Props.push_back(Property("T1", "0", true,
+  Props.push_back(qucs::Property("T1", "0", true,
 		QObject::tr("start time of the pulse")));
-  Props.push_back(Property("T2", "1 ms", true,
+  Props.push_back(qucs::Property("T2", "1 ms", true,
 		QObject::tr("ending time of the pulse")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("fall time of the trailing edge")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/vrect.cpp
+++ b/qucs/components/vrect.cpp
@@ -22,23 +22,23 @@ vRect::vRect()
 {
   Description = QObject::tr("ideal rectangle voltage source");
 
-  Arcs.push_back(Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 18,  5, 18, 11,QPen(Qt::red,1)));
-  Lines.push_back(Line( 21,  8, 15,  8,QPen(Qt::red,1)));
-  Lines.push_back(Line(-18,  5,-18, 11,QPen(Qt::black,1)));
+  Arcs.push_back(qucs::Arc(-12,-12, 24, 24,     0, 16*360,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 30,  0, 12,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 18,  5, 18, 11,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line( 21,  8, 15,  8,QPen(Qt::red,1)));
+  Lines.push_back(qucs::Line(-18,  5,-18, 11,QPen(Qt::black,1)));
 
-  Lines.push_back(Line( -5, -7, -5, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5, -5,  5, -5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5, -5,  6,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  0,  6,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  0, -5,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( -5,  5,  5,  5,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  5,  5,  5,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5, -7, -5, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5, -5,  5, -5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5, -5,  6,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  0,  6,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  0, -5,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( -5,  5,  5,  5,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  5,  5,  5,  7,QPen(Qt::darkBlue,2)));
 
-  Ports.push_back(Port( 30,  0));
-  Ports.push_back(Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
 
   x1 = -30; y1 = -14;
   x2 =  30; y2 =  14;
@@ -48,17 +48,17 @@ vRect::vRect()
   Model = "Vrect";
   Name  = "V";
 
-  Props.push_back(Property("U", "1 V", true,
+  Props.push_back(qucs::Property("U", "1 V", true,
 		QObject::tr("voltage of high signal")));
-  Props.push_back(Property("TH", "1 ms", true,
+  Props.push_back(qucs::Property("TH", "1 ms", true,
 		QObject::tr("duration of high pulses")));
-  Props.push_back(Property("TL", "1 ms", true,
+  Props.push_back(qucs::Property("TL", "1 ms", true,
 		QObject::tr("duration of low pulses")));
-  Props.push_back(Property("Tr", "1 ns", false,
+  Props.push_back(qucs::Property("Tr", "1 ns", false,
 		QObject::tr("rise time of the leading edge")));
-  Props.push_back(Property("Tf", "1 ns", false,
+  Props.push_back(qucs::Property("Tf", "1 ns", false,
 		QObject::tr("fall time of the trailing edge")));
-  Props.push_back(Property("Td", "0 ns", false,
+  Props.push_back(qucs::Property("Td", "0 ns", false,
 		QObject::tr("initial delay time")));
 
   rotate();  // fix historical flaw

--- a/qucs/components/wprobe.cpp
+++ b/qucs/components/wprobe.cpp
@@ -29,53 +29,53 @@ wProbe::wProbe()
   Description = QObject::tr("power probe");
 
 //Large box
-  Lines.push_back(Line(-20,-33, 20,-33,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20, 14, 20, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-20,-33,-20, 14,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 20,-33, 20, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-33, 20,-33,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20, 14, 20, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-20,-33,-20, 14,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 20,-33, 20, 14,QPen(Qt::darkBlue,2)));
 
 //Small box
-  Lines.push_back(Line(-16,-28, 16,-28,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16, -10, 16, -10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(-16,-28,-16, -10,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 16,-28, 16, -10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-28, 16,-28,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16, -10, 16, -10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-16,-28,-16, -10,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 16,-28, 16, -10,QPen(Qt::darkBlue,2)));
 
 //Letter W
-  Lines.push_back(Line(-9,-22, -2, -11,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(0, -17, -2, -11,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(0, -17, 2, -11,QPen(Qt::darkBlue,3)));
-  Lines.push_back(Line(9,-22, 2, -11,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(-9,-22, -2, -11,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(0, -17, -2, -11,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(0, -17, 2, -11,QPen(Qt::darkBlue,3)));
+  Lines.push_back(qucs::Line(9,-22, 2, -11,QPen(Qt::darkBlue,3)));
 
 //+ and - signs
-  Lines.push_back(Line(-12,  5,-12,  11,QPen(Qt::red,2)));
-  Lines.push_back(Line(-15,  8, -9,  8,QPen(Qt::red,2)));
-  Lines.push_back(Line(  9,  8, 15,  8,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-12,  5,-12,  11,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(-15,  8, -9,  8,QPen(Qt::red,2)));
+  Lines.push_back(qucs::Line(  9,  8, 15,  8,QPen(Qt::darkBlue,2)));
 
 //Current Entries
-  Ports.push_back(Port(-30,  0));
-  Ports.push_back(Port( 30,  0));
+  Ports.push_back(qucs::Port(-30,  0));
+  Ports.push_back(qucs::Port( 30,  0));
 
 //Voltage Entries
-  Lines.push_back(Line(-10,  14,-10, 20,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 10,  14, 10, 20,QPen(Qt::darkBlue,2)));
-  Ports.push_back(Port(-10, 20));
-  Ports.push_back(Port( 10, 20));
+  Lines.push_back(qucs::Line(-10,  14,-10, 20,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 10,  14, 10, 20,QPen(Qt::darkBlue,2)));
+  Ports.push_back(qucs::Port(-10, 20));
+  Ports.push_back(qucs::Port( 10, 20));
 
 //Letter V
-  Lines.push_back(Line(-3,  7 ,0,  13,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line( 0,  13, 3,  7,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-3,  7 ,0,  13,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line( 0,  13, 3,  7,QPen(Qt::darkBlue,2)));
 
 //Letter A
-  Lines.push_back(Line(  11,  -9, 15,0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  7,  0, 11, -9,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  14, -3, 8, -3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  11,  -9, 15,0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  7,  0, 11, -9,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  14, -3, 8, -3,QPen(Qt::darkBlue,2)));
 
 //Arrow
-  Lines.push_back(Line(-30,  0,-20,  0,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line( 30,  0, 20,  0,QPen(Qt::darkBlue,1)));
-  Lines.push_back(Line(-20,  0, 20,  0,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4,  0, -4, -3,QPen(Qt::darkBlue,2)));
-  Lines.push_back(Line(  4,  0, -4,  4,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(-30,  0,-20,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line( 30,  0, 20,  0,QPen(Qt::darkBlue,1)));
+  Lines.push_back(qucs::Line(-20,  0, 20,  0,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4,  0, -4, -3,QPen(Qt::darkBlue,2)));
+  Lines.push_back(qucs::Line(  4,  0, -4,  4,QPen(Qt::darkBlue,2)));
 
   x1 = -24; y1 = -35;
   x2 =  24; y2 =  20;

--- a/qucs/diagrams/curvediagram.cpp
+++ b/qucs/diagrams/curvediagram.cpp
@@ -162,15 +162,15 @@ if(xAxis.log) {
   if(back) z = x2;
   while((z <= x2) && (z >= 0)) {    // create all grid lines
     if(xAxis.GridOn)  if(z < x2)  if(z > 0)
-      Lines.push_front(Line(z, y2, z, 0, GridPen));  // x grid
+      Lines.push_front(qucs::Line(z, y2, z, 0, GridPen));  // x grid
 
     if((zD < 1.5*zDstep) || (z == 0) || (z == x2)) {
       tmp = misc::StringNiceNum(zD);
       if(xAxis.up < 0.0)  tmp = '-'+tmp;
       w = metrics.horizontalAdvance(tmp);  // width of text
       // center text horizontally under the x tick mark
-      Texts.push_back(Text(z-(w>>1), -y1, tmp));
-      Lines.push_back(Line(z, 5, z, -5, QPen(Qt::black,0)));  // x tick marks
+      Texts.push_back(qucs::Text(z-(w>>1), -y1, tmp));
+      Lines.push_back(qucs::Line(z, 5, z, -5, QPen(Qt::black,0)));  // x tick marks
     }
 
     zD += zDstep;
@@ -197,19 +197,19 @@ else {  // not logarithmical
     tmp = misc::StringNiceNum(GridNum);
     w = metrics.horizontalAdvance(tmp);  // width of text
     // center text horizontally under the x tick mark
-    Texts.push_back(Text(z-(w>>1), -y1, tmp)); // Text(x, y, str, ...)
+    Texts.push_back(qucs::Text(z-(w>>1), -y1, tmp)); // Text(x, y, str, ...)
     GridNum += GridStep;
 
     if(xAxis.GridOn)  if(z < x2)  if(z > 0)
-      Lines.push_front(Line(z, y2, z, 0, GridPen)); // x grid
-    Lines.push_back(Line(z, 5, z, -5, QPen(Qt::black,0)));   // x tick marks
+      Lines.push_front(qucs::Line(z, y2, z, 0, GridPen)); // x grid
+    Lines.push_back(qucs::Line(z, 5, z, -5, QPen(Qt::black,0)));   // x tick marks
     zD += zDstep;
     z = int(zD);
   }
   
   if(xAxis.up >= 0.0) if(xAxis.low <= 0.0) {  // paint origin cross ?
     z = int(double(x2) * fabs(xAxis.low / (xAxis.up-xAxis.low)) + 0.5);
-    Lines.push_back(Line(z, 0, z, y2, QPen(Qt::black,0)));
+    Lines.push_back(qucs::Line(z, 0, z, y2, QPen(Qt::black,0)));
   }
 } // of "if(xlog) ... else ..."
 
@@ -220,17 +220,17 @@ else {  // not logarithmical
     valid |= 1;
     if(yAxis.up >= 0.0) if(yAxis.low <= 0.0) {  // paint origin cross ?
       z = int(double(y2) * fabs(yAxis.low / (yAxis.up-yAxis.low)) + 0.5);
-      Lines.push_back(Line(0, z, x2, z, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(0, z, x2, z, QPen(Qt::black,0)));
     }
   }
 
 
 Frame:
   // outer frame
-  Lines.push_back(Line(0,  y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,   0, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,  y2,  0,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,   0, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2,  0,  0, QPen(Qt::black,0)));
   return valid;
 }
 

--- a/qucs/diagrams/diagram.cpp
+++ b/qucs/diagrams/diagram.cpp
@@ -195,12 +195,12 @@ void Diagram::createAxisLabels()
           if(Name[0] != 'C') {   // locus curve ?
             w = metrics.horizontalAdvance(pD->Var) >> 1;
 	    if(w > wmax)  wmax = w;
-            Texts.push_back(Text(x-w, y, pD->Var, pg->Color, 12.0));
+            Texts.push_back(qucs::Text(x-w, y, pD->Var, pg->Color, 12.0));
 	  }
 	  if(Name[0] == 'C') {
             w = metrics.horizontalAdvance("real("+pg->Var+")") >> 1;
 	    if(w > wmax)  wmax = w;
-            Texts.push_back(Text(x-w, y, "real("+pg->Var+")",
+            Texts.push_back(qucs::Text(x-w, y, "real("+pg->Var+")",
                                 pg->Color, 12.0));
 	  }
     }
@@ -210,7 +210,7 @@ void Diagram::createAxisLabels()
     encode_String(xAxis.Label, Str);
     w = metrics.horizontalAdvance(Str) >> 1;
     if(w > wmax)  wmax = w;
-    Texts.push_back(Text(x-w, y, Str, Qt::black, 12.0));
+    Texts.push_back(qucs::Text(x-w, y, Str, Qt::black, 12.0));
   }
   Bounding_y2 = 0;
   Bounding_y1 = y - LineSpacing;
@@ -230,19 +230,19 @@ void Diagram::createAxisLabels()
 	if(Name[0] != 'C') {   // location curve ?
           w = metrics.horizontalAdvance(pg->Var) >> 1;
           if(w > wmax)  wmax = w;
-          Texts.push_back(Text(x, y-w, pg->Var, pg->Color, 12.0, 0.0, 1.0));
+          Texts.push_back(qucs::Text(x, y-w, pg->Var, pg->Color, 12.0, 0.0, 1.0));
 	}
 	else {
           w = metrics.horizontalAdvance("imag("+pg->Var+")") >> 1;
           if(w > wmax)  wmax = w;
-          Texts.push_back(Text(x, y-w, "imag("+pg->Var+")",
+          Texts.push_back(qucs::Text(x, y-w, "imag("+pg->Var+")",
                                 pg->Color, 12.0, 0.0, 1.0));
 	}
       }
       else {     // if no data => <invalid>
         w = metrics.horizontalAdvance(pg->Var+INVALID_STR) >> 1;
         if(w > wmax)  wmax = w;
-        Texts.push_back(Text(x, y-w, pg->Var+INVALID_STR,
+        Texts.push_back(qucs::Text(x, y-w, pg->Var+INVALID_STR,
                               pg->Color, 12.0, 0.0, 1.0));
       }
       x -= LineSpacing;
@@ -252,7 +252,7 @@ void Diagram::createAxisLabels()
     encode_String(yAxis.Label, Str);
     w = metrics.horizontalAdvance(Str) >> 1;
     if(w > wmax)  wmax = w;
-    Texts.push_back(Text(x, y-w, Str, Qt::black, 12.0, 0.0, 1.0));
+    Texts.push_back(qucs::Text(x, y-w, Str, Qt::black, 12.0, 0.0, 1.0));
     x -= LineSpacing;
   }
   if(Bounding_x1 < -x) Bounding_x1 = -x;
@@ -268,20 +268,20 @@ void Diagram::createAxisLabels()
 	if(Name[0] != 'C') {   // location curve ?
           w = metrics.horizontalAdvance(pg->Var) >> 1;
           if(w > wmax)  wmax = w;
-          Texts.push_back(Text(x, y+w, pg->Var,
+          Texts.push_back(qucs::Text(x, y+w, pg->Var,
                                 pg->Color, 12.0, 0.0, -1.0));
 	}
 	else {
           w = metrics.horizontalAdvance("imag("+pg->Var+")") >> 1;
           if(w > wmax)  wmax = w;
-          Texts.push_back(Text(x, y+w, "imag("+pg->Var+")",
+          Texts.push_back(qucs::Text(x, y+w, "imag("+pg->Var+")",
                                 pg->Color, 12.0, 0.0, -1.0));
 	}
       }
       else {     // if no data => <invalid>
         w = metrics.horizontalAdvance(pg->Var+INVALID_STR) >> 1;
         if(w > wmax)  wmax = w;
-        Texts.push_back(Text(x, y+w, pg->Var+INVALID_STR,
+        Texts.push_back(qucs::Text(x, y+w, pg->Var+INVALID_STR,
                               pg->Color, 12.0, 0.0, -1.0));
       }
       x += LineSpacing;
@@ -291,7 +291,7 @@ void Diagram::createAxisLabels()
     encode_String(zAxis.Label, Str);
     w = metrics.horizontalAdvance(Str) >> 1;
     if(w > wmax)  wmax = w;
-    Texts.push_back(Text(x, y+w, Str, Qt::black, 12.0, 0.0, -1.0));
+    Texts.push_back(qucs::Text(x, y+w, Str, Qt::black, 12.0, 0.0, -1.0));
   }
   x -= x2;
   if(Bounding_x2 < x) Bounding_x2 = x;
@@ -1154,9 +1154,9 @@ int Diagram::checkColumnWidth(const QString& Str,
     colWidth = w;
     if((x+colWidth) >= x2) {    // enough space for text ?
       // mark lack of space with a small arrow
-      Lines.push_back(Line(x2-6, y-4, x2+7, y-4, QPen(Qt::red,2)));
-      Lines.push_back(Line(x2,   y-7, x2+6, y-4, QPen(Qt::red,2)));
-      Lines.push_back(Line(x2,   y-1, x2+6, y-4, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(x2-6, y-4, x2+7, y-4, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(x2,   y-7, x2+6, y-4, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(x2,   y-1, x2+6, y-4, QPen(Qt::red,2)));
       return -1;
     }
   }
@@ -1485,9 +1485,9 @@ void Diagram::createSmithChart(Axis *Axis, int Mode)
     }
 
     if(Above)
-      Arcs.push_back(Arc(x, dx2+y, y, y, beta, theta, GridPen));
+      Arcs.push_back(qucs::Arc(x, dx2+y, y, y, beta, theta, GridPen));
     if(Below)
-      Arcs.push_back(Arc(x, dx2, y, y, 16*360-beta-theta, theta, GridPen));
+      Arcs.push_back(qucs::Arc(x, dx2, y, y, 16*360-beta-theta, theta, GridPen));
   }
 
   // ....................................................
@@ -1506,7 +1506,7 @@ void Diagram::createSmithChart(Axis *Axis, int Mode)
     else
       x = (x2-R1)>>1;
     if(fabs(fabs(im)-1.0) > 0.2)   // if too near to |r|=1, it looks ugly
-      Arcs.push_back(Arc(x, (x2+y)>>1, y, y, beta, theta, GridPen));
+      Arcs.push_back(qucs::Arc(x, (x2+y)>>1, y, y, beta, theta, GridPen));
 
     if(Axis->up > 1.0) {  // draw arcs on the rigth-handed side ?
       im = 1.0-im;
@@ -1514,14 +1514,14 @@ void Diagram::createSmithChart(Axis *Axis, int Mode)
       if(Zplane)  x += y;
       else  x -= y;
       if(im >= 1.0)
-        Arcs.push_back(Arc(x, (x2+y)>>1, y, y, beta, theta, GridPen));
+        Arcs.push_back(qucs::Arc(x, (x2+y)>>1, y, y, beta, theta, GridPen));
       else {
         phi = int(16.0*180.0/pi*acos(im));
         len = 16*180-phi;
         if(Above && Below)  len += len;
         else if(Below)  phi = 16*180;
         if(!Zplane)  phi += 16*180;
-        Arcs.push_back(Arc(x, (x2+y)>>1, y, y, phi, len, GridPen));
+        Arcs.push_back(qucs::Arc(x, (x2+y)>>1, y, y, phi, len, GridPen));
       }
     }
   }
@@ -1531,7 +1531,7 @@ void Diagram::createSmithChart(Axis *Axis, int Mode)
   if(Axis->up > 1.0) {  // draw circle with |r|=1 ?
     x = (x2-R1) >> 1;
     y = (x2+R1) >> 1;
-    Arcs.push_back(Arc(x, y, R1, R1, beta, theta, QPen(Qt::black,0)));
+    Arcs.push_back(qucs::Arc(x, y, R1, R1, beta, theta, QPen(Qt::black,0)));
 
     // vertical line Re(r)=1 (visible only if |r|>1)
     if(Zplane)  x = y;
@@ -1539,11 +1539,11 @@ void Diagram::createSmithChart(Axis *Axis, int Mode)
     if(Above)  m = y;
     else  m = 0;
     if(!Below)  y = 0;
-    Lines.push_back(Line(x, dx2+m, x, dx2-y, GridPen));
+    Lines.push_back(qucs::Line(x, dx2+m, x, dx2-y, GridPen));
 
     if(Below)  y = 4;
     else  y = y2-4-QucsSettings.font.pointSize();
-    Texts.push_back(Text(0, y, misc::StringNum(Axis->up)));
+    Texts.push_back(qucs::Text(0, y, misc::StringNum(Axis->up)));
   }
 
 }
@@ -1603,7 +1603,7 @@ void Diagram::createPolarDiagram(Axis *Axis, int Mode)
   if(Above)  i = y2;  else  i = y2>>1;
   if(Below)  z = 0;   else  z = y2>>1;
   // y line
-  Lines.push_back(Line(x2>>1, i, x2>>1, z, GridPen));
+  Lines.push_back(qucs::Line(x2>>1, i, x2>>1, z, GridPen));
 
   int len  = 0;       // arc length
   int beta = 16*180;  // start angle
@@ -1624,12 +1624,12 @@ void Diagram::createPolarDiagram(Axis *Axis, int Mode)
     for(i=int(numGrids); i>1; i--) {    // create all grid circles
       z = int(zD);
       GridNum += GridStep;
-      Texts.push_back(Text(((x2+z)>>1)-10, tPos, misc::StringNiceNum(GridNum)));
+      Texts.push_back(qucs::Text(((x2+z)>>1)-10, tPos, misc::StringNiceNum(GridNum)));
 
       phi = int(16.0*180.0/pi*atan(double(2*tHeight)/zD));
       if(!Below)  tmp = beta + phi;
       else  tmp = beta;
-      Arcs.push_back(Arc((x2-z)>>1, (y2+z)>>1, z, z, tmp, len-phi,
+      Arcs.push_back(qucs::Arc((x2-z)>>1, (y2+z)>>1, z, z, tmp, len-phi,
 			  GridPen));
       zD += zDstep;
     }
@@ -1641,11 +1641,11 @@ void Diagram::createPolarDiagram(Axis *Axis, int Mode)
   }
 
   // create outer circle
-  Texts.push_back(Text(x2-8, tPos, misc::StringNiceNum(Axis->up)));
+  Texts.push_back(qucs::Text(x2-8, tPos, misc::StringNiceNum(Axis->up)));
   phi = int(16.0*180.0/pi*atan(double(2*tHeight)/double(x2)));
   if(!Below)  tmp = phi;
   else  tmp = 0;
-  Arcs.push_back(Arc(0, y2, x2, y2, tmp, 16*360-phi, QPen(Qt::black,0)));
+  Arcs.push_back(qucs::Arc(0, y2, x2, y2, tmp, 16*360-phi, QPen(Qt::black,0)));
 
   // get size of text using the screen-compatible metric
   QFontMetrics metrics(QucsSettings.font, 0);
@@ -1900,7 +1900,7 @@ if(Axis->log) {
   if(back) z = y2;
   while((z <= y2) && (z >= 0)) {    // create all grid lines
     if(Axis->GridOn)  if(z < y2)  if(z > 0)
-      Lines.push_front(Line(0, z, x2, z, GridPen));  // y grid
+      Lines.push_front(qucs::Line(0, z, x2, z, GridPen));  // y grid
 
     if((zD < 1.5*zDstep) || (z == 0)) {
       tmp = misc::StringNiceNum(zD);
@@ -1909,12 +1909,12 @@ if(Axis->log) {
       w = metrics.horizontalAdvance(tmp);  // width of text
       if(maxWidth < w) maxWidth = w;
       if(x0 > 0)
-        Texts.push_back(Text(x0+7, z-6, tmp)); // text aligned left
+        Texts.push_back(qucs::Text(x0+7, z-6, tmp)); // text aligned left
       else
-        Texts.push_back(Text(-w-7, z-6, tmp)); // text aligned right
+        Texts.push_back(qucs::Text(-w-7, z-6, tmp)); // text aligned right
 
       // y marks
-      Lines.push_back(Line(x0-5, z, x0+5, z, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(x0-5, z, x0+5, z, QPen(Qt::black,0)));
     }
 
     zD += zDstep;
@@ -1943,15 +1943,15 @@ else {  // not logarithmical
      w = metrics.horizontalAdvance(tmp);  // width of text
       if(maxWidth < w) maxWidth = w;
       if(x0 > 0)
-        Texts.push_back(Text(x0+8, z-6, tmp));  // text aligned left
+        Texts.push_back(qucs::Text(x0+8, z-6, tmp));  // text aligned left
       else
-        Texts.push_back(Text(-w-7, z-6, tmp));  // text aligned right
+        Texts.push_back(qucs::Text(-w-7, z-6, tmp));  // text aligned right
       GridNum += GridStep;
 
 
     if(Axis->GridOn)  if(z < y2)  if(z > 0)
-      Lines.push_front(Line(0, z, x2, z, GridPen));  // y grid
-    Lines.push_back(Line(x0-5, z, x0+5, z, QPen(Qt::black,0))); // y marks
+      Lines.push_front(qucs::Line(0, z, x2, z, GridPen));  // y grid
+    Lines.push_back(qucs::Line(x0-5, z, x0+5, z, QPen(Qt::black,0))); // y marks
     zD += zDstep;
     z = int(zD);
   }

--- a/qucs/diagrams/diagram.h
+++ b/qucs/diagrams/diagram.h
@@ -21,7 +21,6 @@
 #include "graph.h"
 #include "marker.h"
 #include "element.h"
-using namespace qucs;
 #include "viewpainter.h"
 #include "sharedObjectList.h"
 

--- a/qucs/diagrams/diagram.h
+++ b/qucs/diagrams/diagram.h
@@ -21,6 +21,7 @@
 #include "graph.h"
 #include "marker.h"
 #include "element.h"
+using namespace qucs;
 #include "viewpainter.h"
 #include "sharedObjectList.h"
 
@@ -110,9 +111,9 @@ public:
   QPen    GridPen;
 
   SharedObjectList<Graph>  Graphs;
-  std::list<Arc>    Arcs;
-  std::list<Line>   Lines;
-  std::list<Text>   Texts;
+  std::list<qucs::Arc>    Arcs;
+  std::list<qucs::Line>   Lines;
+  std::list<qucs::Text>   Texts;
 
   QString sfreq;
   double *freq=nullptr;

--- a/qucs/diagrams/polardiagram.cpp
+++ b/qucs/diagrams/polardiagram.cpp
@@ -41,7 +41,7 @@ PolarDiagram::PolarDiagram(int _cx, int _cy) : Diagram(_cx, _cy)
   x3 = 207;    // with some distance for right axes text
   Name = "Polar";
 
-  Arcs.push_back(Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
+  Arcs.push_back(qucs::Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
 //  calcDiagram();
 }
 
@@ -82,7 +82,7 @@ int PolarDiagram::calcDiagram()
   Arcs.clear();
 
   // x line
-  Lines.push_back(Line(0, y2>>1, x2, y2>>1, GridPen));
+  Lines.push_back(qucs::Line(0, y2>>1, x2, y2>>1, GridPen));
 
   x3 = x2 + 7;
   createPolarDiagram(&yAxis);

--- a/qucs/diagrams/psdiagram.cpp
+++ b/qucs/diagrams/psdiagram.cpp
@@ -43,7 +43,7 @@ PSDiagram::PSDiagram(int _cx, int _cy, bool _polarUp)
   if(_polarUp)  Name = "PS";  // polar diagram upper half ?
   else  Name = "SP";
 
-  Arcs.push_back(Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
+  Arcs.push_back(qucs::Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
 //  calcDiagram();
 }
 
@@ -112,7 +112,7 @@ int PSDiagram::calcDiagram()
   }
 
   // x line
-  Lines.push_back(Line(0, y2>>1, x2, y2>>1, GridPen));
+  Lines.push_back(qucs::Line(0, y2>>1, x2, y2>>1, GridPen));
   return 3;
 }
 

--- a/qucs/diagrams/rect3ddiagram.cpp
+++ b/qucs/diagrams/rect3ddiagram.cpp
@@ -49,9 +49,9 @@ Rect3DDiagram::Rect3DDiagram(int _cx, int _cy) : Diagram(_cx, _cy)
 
   Name = "Rect3D"; // BUG
   // symbolic diagram painting
-  Lines.push_back(Line(0, 0, cx,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, 0,  0, cy, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, 0, cx/2, cy/2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0, cx,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0,  0, cy, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0, cx/2, cy/2, QPen(Qt::black,0)));
 }
 
 Rect3DDiagram::~Rect3DDiagram()
@@ -619,7 +619,7 @@ void Rect3DDiagram::removeHiddenCross(int x1_, int y1_, int x2_, int y2_,
   p = Mem+2;
   do {
     if(((p-1)->done & 4) == 0)
-      Lines.push_back( Line((p-1)->x, (p-1)->y, p->x, p->y, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line((p-1)->x, (p-1)->y, p->x, p->y, QPen(Qt::black,0)));
     p++;
   } while(p <= pMem);
 }
@@ -704,12 +704,12 @@ int Rect3DDiagram::calcAxis(Axis *Axis, int x, int y,
       xLen = int(ystepD * cos(phi) + 0.5) + x;
       yLen = int(ystepD * sin(phi) + 0.5) + y;
 
-          Texts.push_back(Text(xLen+3+gx, yLen-6+gy, tmp));
+          Texts.push_back(qucs::Text(xLen+3+gx, yLen-6+gy, tmp));
       // it seems that the text used to have a left/right alignment
 	  //Texts.append(new Text(xLen-w-2-gx, yLen-6-gy, tmp));
       
       // short grid marks
-      Lines.push_back(Line(xLen-gx, yLen-gy, xLen+gx, yLen+gy,
+      Lines.push_back(qucs::Line(xLen-gx, yLen-gy, xLen+gx, yLen+gy,
 			    QPen(Qt::black,0)));
       yD *= 10.0;
       ystepD += corr;
@@ -738,13 +738,13 @@ int Rect3DDiagram::calcAxis(Axis *Axis, int x, int y,
       if(maxWidth < w) maxWidth = w;
 
       // it seems that the text used to have a left/right alignment
-      Texts.push_back(Text(x+3+gx, y-6+gy, tmp)); // place text right
+      Texts.push_back(qucs::Text(x+3+gx, y-6+gy, tmp)); // place text right
 	  //Texts.append(new Text(x-w-2-gx, y-6-gy, tmp)); // place left
 
       GridNum += GridStep;
       
       // short grid marks
-      Lines.push_back(Line(x-gx, y-gy, x+gx, y+gy, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(x-gx, y-gy, x+gx, y+gy, QPen(Qt::black,0)));
       xD += xstepD;
       yD += ystepD;
     }
@@ -805,7 +805,7 @@ void Rect3DDiagram::createAxis(Axis *Axis, bool Right,
       x += int(double(metrics.lineSpacing())*sin_phi);
       y -= int(double(metrics.lineSpacing())*cos_phi);
       w = metrics.horizontalAdvance(s);
-      Texts.push_back(Text(x+int(double((z-w)>>1)*cos_phi),
+      Texts.push_back(qucs::Text(x+int(double((z-w)>>1)*cos_phi),
                             y+int(double((z-w)>>1)*sin_phi),
                             s, pg->Color, 12.0, cos_phi, sin_phi));
     }
@@ -814,7 +814,7 @@ void Rect3DDiagram::createAxis(Axis *Axis, bool Right,
     x += int(double(metrics.lineSpacing())*sin_phi);
     y -= int(double(metrics.lineSpacing())*cos_phi);
     w = metrics.horizontalAdvance(Axis->Label);
-    Texts.push_back(Text(x+int(double((z-w)>>1)*cos_phi),
+    Texts.push_back(qucs::Text(x+int(double((z-w)>>1)*cos_phi),
                           y+int(double((z-w)>>1)*sin_phi),
                           Axis->Label, Qt::black, 12.0, cos_phi, sin_phi));
   }
@@ -892,16 +892,16 @@ int Rect3DDiagram::calcDiagram()
 
   // =====  paint coordinate cross  ====================================
   // xy area
-  Lines.push_back(Line(X[o^1], Y[o^1], X[o^3], Y[o^3], QPen(Qt::black,0)));
-  Lines.push_back(Line(X[o^2], Y[o^2], X[o^3], Y[o^3], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^1], Y[o^1], X[o^3], Y[o^3], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^2], Y[o^2], X[o^3], Y[o^3], QPen(Qt::black,0)));
 
   // yz area
-  Lines.push_back(Line(X[o^2], Y[o^2], X[o^6], Y[o^6], QPen(Qt::black,0)));
-  Lines.push_back(Line(X[o^4], Y[o^4], X[o^6], Y[o^6], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^2], Y[o^2], X[o^6], Y[o^6], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^4], Y[o^4], X[o^6], Y[o^6], QPen(Qt::black,0)));
 
   // xz area
-  Lines.push_back(Line(X[o^1], Y[o^1], X[o^5], Y[o^5], QPen(Qt::black,0)));
-  Lines.push_back(Line(X[o^4], Y[o^4], X[o^5], Y[o^5], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^1], Y[o^1], X[o^5], Y[o^5], QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(X[o^4], Y[o^4], X[o^5], Y[o^5], QPen(Qt::black,0)));
 
 
   // =====  create axis  =============================================
@@ -954,9 +954,9 @@ int Rect3DDiagram::calcDiagram()
     free(zBuffer);
   }
   else {
-    Lines.push_back(Line(X[o], Y[o], X[o^1], Y[o^1], QPen(Qt::black,0)));
-    Lines.push_back(Line(X[o], Y[o], X[o^2], Y[o^2], QPen(Qt::black,0)));
-    Lines.push_back(Line(X[o], Y[o], X[o^4], Y[o^4], QPen(Qt::black,0)));
+    Lines.push_back(qucs::Line(X[o], Y[o], X[o^1], Y[o^1], QPen(Qt::black,0)));
+    Lines.push_back(qucs::Line(X[o], Y[o], X[o^2], Y[o^2], QPen(Qt::black,0)));
+    Lines.push_back(qucs::Line(X[o], Y[o], X[o^4], Y[o^4], QPen(Qt::black,0)));
   }
 
   pMem = Mem;
@@ -964,10 +964,10 @@ int Rect3DDiagram::calcDiagram()
 
 
 Frame:   // jump here if error occurred (e.g. impossible log boundings)
-  Lines.push_back(Line(0,  y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,   0, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,  y2,  0,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,   0, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2,  0,  0, QPen(Qt::black,0)));
   return 0;
 }
 

--- a/qucs/diagrams/rectdiagram.cpp
+++ b/qucs/diagrams/rectdiagram.cpp
@@ -171,15 +171,15 @@ if(xAxis.log) {
   if(back) z = x2;
   while((z <= x2) && (z >= 0)) {    // create all grid lines
     if(xAxis.GridOn)  if(z < x2)  if(z > 0)
-      Lines.push_front(Line(z, y2, z, 0, GridPen));  // x grid
+      Lines.push_front(qucs::Line(z, y2, z, 0, GridPen));  // x grid
 
     if((zD < 1.5*zDstep) || (z == 0) || (z == x2)) {
       tmp = misc::StringNiceNum(zD);
       if(xAxis.up < 0.0)  tmp = '-'+tmp;
       w = metrics.horizontalAdvance(tmp);  // width of text
       // center text horizontally under the x tick mark
-      Texts.push_back(Text(z-(w>>1), -y1, tmp));
-      Lines.push_back(Line(z, 5, z, -5, QPen(Qt::black,0)));  // x tick marks
+      Texts.push_back(qucs::Text(z-(w>>1), -y1, tmp));
+      Lines.push_back(qucs::Line(z, 5, z, -5, QPen(Qt::black,0)));  // x tick marks
     }
 
     zD += zDstep;
@@ -206,12 +206,12 @@ else {  // not logarithmical
     tmp = misc::StringNiceNum(GridNum);
     w = metrics.horizontalAdvance(tmp);  // width of text
     // center text horizontally under the x tick mark
-    Texts.push_back(Text(z-(w>>1), -y1, tmp)); // Text(x, y, str, ...)
+    Texts.push_back(qucs::Text(z-(w>>1), -y1, tmp)); // Text(x, y, str, ...)
     GridNum += GridStep;
 
     if(xAxis.GridOn)  if(z < x2)  if(z > 0)
-      Lines.push_front(Line(z, y2, z, 0, GridPen)); // x grid
-    Lines.push_back(Line(z, 5, z, -5, QPen(Qt::black,0)));   // x tick marks
+      Lines.push_front(qucs::Line(z, y2, z, 0, GridPen)); // x grid
+    Lines.push_back(qucs::Line(z, 5, z, -5, QPen(Qt::black,0)));   // x tick marks
     zD += zDstep;
     z = int(zD);
   }
@@ -225,10 +225,10 @@ else {  // not logarithmical
 
 Frame:
   // outer frame
-  Lines.push_back(Line(0,  y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,   0, x2,  0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0,  y2,  0,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,   0, x2,  0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0,  y2,  0,  0, QPen(Qt::black,0)));
   return valid;
 }
 

--- a/qucs/diagrams/smithdiagram.cpp
+++ b/qucs/diagrams/smithdiagram.cpp
@@ -46,7 +46,7 @@ SmithDiagram::SmithDiagram(int _cx, int _cy, bool ImpMode) : Diagram(_cx, _cy)
   if(ImpMode)  Name = "Smith";  // with impedance circles
   else  Name = "ySmith";        // with admittance circles
 
-  Arcs.push_back(Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
+  Arcs.push_back(qucs::Arc(0, y2, x2, y2, 0, 16*360, QPen(Qt::black,0)));
 //  calcDiagram();    // calculate circles for smith chart with |r|=1
 }
 
@@ -94,10 +94,10 @@ int SmithDiagram::calcDiagram()
   else  createSmithChart(&yAxis);
 
   // outer most circle
-  Arcs.push_back(Arc(0, x2, x2, x2, 0, 16*360, QPen(Qt::black,0)));
+  Arcs.push_back(qucs::Arc(0, x2, x2, x2, 0, 16*360, QPen(Qt::black,0)));
 
   // horizontal line Im(r)=0
-  Lines.push_back(Line(0, x2>>1, x2, x2>>1, GridPen));
+  Lines.push_back(qucs::Line(0, x2>>1, x2, x2>>1, GridPen));
 
   return 3;
 }

--- a/qucs/diagrams/tabdiagram.cpp
+++ b/qucs/diagrams/tabdiagram.cpp
@@ -148,11 +148,11 @@ int TabDiagram::calcDiagram()
   y = y2 - tHeight - 6;
 
   // outer frame
-  Lines.push_back(Line(0, y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y2, 0, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, 0, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y+2, x2, y+2, QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(0, y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y2, 0, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y+2, x2, y+2, QPen(Qt::black,2)));
 
   if(xAxis.limit_min < 0.0)
     xAxis.limit_min = 0.0;
@@ -165,7 +165,7 @@ int TabDiagram::calcDiagram()
     Str = QObject::tr("no variables");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth >= 0)
-      Texts.push_back(Text(x-4, y2-2, Str)); // independent variable
+      Texts.push_back(qucs::Text(x-4, y2-2, Str)); // independent variable
     return 0;
   }
 
@@ -202,7 +202,7 @@ int TabDiagram::calcDiagram()
       if(colWidth < 0)  goto funcEnd;
       startWriting = int(xAxis.limit_min + 0.5);  // when to reach visible area
       
-      Texts.push_back(Text(x-4, y2-2, Str)); // independent variable
+      Texts.push_back(qucs::Text(x-4, y2-2, Str)); // independent variable
       if(pD->count != 0) {
 	y = y2-tHeight-5;
 	counting /= pD->count;   // how many rows to be skipped
@@ -217,7 +217,7 @@ int TabDiagram::calcDiagram()
 	      colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
 	      if(colWidth < 0)  goto funcEnd;
 	      
-              Texts.push_back(Text( x, y, Str));
+              Texts.push_back(qucs::Text( x, y, Str));
 	      y -= tHeight*counting;
 	    }
 	    else startWriting -= counting;
@@ -225,12 +225,12 @@ int TabDiagram::calcDiagram()
 	  }
           if(pD == ig->axis(0))   // only paint one time
 	    if(y >= tHeight) if(y < y2-tHeight-5)
-              Lines.push_back(Line(0, y+1, x2, y+1, QPen(Qt::black,0)));
+              Lines.push_back(qucs::Line(0, y+1, x2, y+1, QPen(Qt::black,0)));
 	}
 	lastCount *= pD->count;
       }
       x += colWidth+15;
-      Lines.push_back(Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
     }
     Lines.back().style = QPen(Qt::black,2);
   }  // of "if no data in graphs"
@@ -247,7 +247,7 @@ int TabDiagram::calcDiagram()
     Str = g->Var;
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth < 0)  goto funcEnd;
-    Texts.push_back(Text(x, y2-2, Str));  // dependent variable
+    Texts.push_back(qucs::Text(x, y2-2, Str));  // dependent variable
 
 
     startWriting = int(xAxis.limit_min + 0.5); // when to reach visible area
@@ -258,7 +258,7 @@ int TabDiagram::calcDiagram()
 	Str = QObject::tr("invalid");
 	colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
 	if(colWidth < 0)  goto funcEnd;
-        Texts.push_back(Text(x, y, Str));
+        Texts.push_back(qucs::Text(x, y, Str));
       }
       else if(sameDependencies(g.operator->(), firstGraph)) {
         int z=g->axis(0)->count * g->countY;
@@ -278,7 +278,7 @@ int TabDiagram::calcDiagram()
             colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
             if(colWidth < 0)  goto funcEnd;
 
-            Texts.push_back(Text(x, y, Str));
+            Texts.push_back(qucs::Text(x, y, Str));
             y -= tHeight;
           }
 
@@ -295,7 +295,7 @@ int TabDiagram::calcDiagram()
             colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
             if(colWidth < 0)  goto funcEnd;
 
-            Texts.push_back(Text(x, y, Str));
+            Texts.push_back(qucs::Text(x, y, Str));
             pcy += strlen(pcy) + 1;
             y -= tHeight;
           }
@@ -307,19 +307,19 @@ int TabDiagram::calcDiagram()
         Str = QObject::tr("wrong dependency");
         colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
         if(colWidth < 0)  goto funcEnd;
-        Texts.push_back(Text(x, y, Str));
+        Texts.push_back(qucs::Text(x, y, Str));
       }
     }
     else {   // no data in graph
       Str = QObject::tr("no data");
       colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
       if(colWidth < 0)  goto funcEnd;
-      Texts.push_back(Text(x, y, Str));
+      Texts.push_back(qucs::Text(x, y, Str));
     }
     x += colWidth+15;
     auto gn = g;
     if(++gn != Graphs.end())   // do not paint last line
-      Lines.push_back(Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
   }
 
 funcEnd:

--- a/qucs/diagrams/timingdiagram.cpp
+++ b/qucs/diagrams/timingdiagram.cpp
@@ -143,11 +143,11 @@ int TimingDiagram::calcDiagram()
   y = y2 - tHeight - 6;
 
   // outer frame
-  Lines.push_back(Line(0, y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y2, 0, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, 0, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y+2, x2, y+2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y2, 0, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y+2, x2, y+2, QPen(Qt::black,0)));
 
   if(xAxis.limit_min < 0.0)
     xAxis.limit_min = 0.0;
@@ -160,7 +160,7 @@ int TimingDiagram::calcDiagram()
     Str = QObject::tr("no variables");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth >= 0)
-      Texts.push_back(Text(x, y2-2, Str)); // independent variable
+      Texts.push_back(qucs::Text(x, y2-2, Str)); // independent variable
     return 0;
   }
 
@@ -174,7 +174,7 @@ int TimingDiagram::calcDiagram()
     Str = QObject::tr("no data");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth < 0)  return 0;
-    Texts.push_back(Text(x, y2-2, Str));
+    Texts.push_back(qucs::Text(x, y2-2, Str));
     return 0;
   }
   firstGraph = ig.operator->();
@@ -207,7 +207,7 @@ if(!firstGraph->isEmpty()) {
     Str = QObject::tr("wrong dependency");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth >= 0)
-      Texts.push_back(Text(x, y2-2, Str)); // independent variable
+      Texts.push_back(qucs::Text(x, y2-2, Str)); // independent variable
     return 0;
   }
 
@@ -218,7 +218,7 @@ if(!firstGraph->isEmpty()) {
   Str = pD->Var;
   colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
   if(colWidth < 0)  return 1;
-  Texts.push_back(Text(x, y2-2, Str));
+  Texts.push_back(qucs::Text(x, y2-2, Str));
   
 
   y -= 5;
@@ -228,12 +228,12 @@ if(!firstGraph->isEmpty()) {
     Str = g->Var;
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
     if(colWidth < 0)  return 1;
-    Texts.push_back(Text(x, y, Str));  // dependent variable
+    Texts.push_back(qucs::Text(x, y, Str));  // dependent variable
     y -= tHeight + 2;
   }
   x += colWidth + 13;
   xAxis.numGraphs = x -6;
-  Lines.push_back(Line(x-6, y2, x-6, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x-6, y2, x-6, 0, QPen(Qt::black,0)));
   xStart = x;
 
 
@@ -258,8 +258,8 @@ if(!firstGraph->isEmpty()) {
     colWidth = metrics.horizontalAdvance(Str);  // width of text
     if(x+colWidth+2 >= x2)  break;
 
-    Texts.push_back(Text( x, y2-2, Str));
-    Lines.push_back(Line(x+5, y, x+5, y-3, QPen(Qt::black,0)));
+    Texts.push_back(qucs::Text( x, y2-2, Str));
+    Lines.push_back(qucs::Line(x+5, y, x+5, y-3, QPen(Qt::black,0)));
     x += TimeStepWidth;
   }
 
@@ -275,9 +275,9 @@ if(!firstGraph->isEmpty()) {
   for (auto g = Graphs.begin(); g != Graphs.end(); ++g) {
     if(y < tHeight) {
       // mark lack of space with a small arrow
-      Lines.push_back(Line(4, 6, 4, -7, QPen(Qt::red,2)));
-      Lines.push_back(Line(1, 0, 4, -7, QPen(Qt::red,2)));
-      Lines.push_back(Line(7, 0, 4, -7, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(4, 6, 4, -7, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(1, 0, 4, -7, QPen(Qt::red,2)));
+      Lines.push_back(qucs::Line(7, 0, 4, -7, QPen(Qt::red,2)));
       break;
     }
 
@@ -288,7 +288,7 @@ if(!firstGraph->isEmpty()) {
       Str = QObject::tr("no data");
       colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
       if(colWidth < 0)  goto funcEnd;
-      Texts.push_back(Text(x, y, Str));
+      Texts.push_back(qucs::Text(x, y, Str));
       y -= tHeight;
       continue;
     }
@@ -297,7 +297,7 @@ if(!firstGraph->isEmpty()) {
       Str = QObject::tr("wrong dependency");
       colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
       if(colWidth < 0)  goto funcEnd;
-      Texts.push_back(Text(x, y, Str));
+      Texts.push_back(qucs::Text(x, y, Str));
       y -= tHeight;
       continue;
     }
@@ -315,25 +315,25 @@ if(!firstGraph->isEmpty()) {
       px += 2 * z;
       z = g->axis(0)->count - z;
       yNow = 1 + ((tHeight - 6) >> 1);
-      Lines.push_back(Line(x, y-yNow, x+2, y-1, Pen));
-      Lines.push_back(Line(x+2, y-tHeight+5, x, y-yNow, Pen));
+      Lines.push_back(qucs::Line(x, y-yNow, x+2, y-1, Pen));
+      Lines.push_back(qucs::Line(x+2, y-tHeight+5, x, y-yNow, Pen));
       for( ; z>0; z--) {
         if(x+TimeStepWidth >= x2) break;
-        Lines.push_back(Line(x+2, y-1, x+TimeStepWidth-2, y-1, Pen));
-        Lines.push_back(Line(x+2, y-tHeight+5, x+TimeStepWidth-2, y-tHeight+5, Pen));
+        Lines.push_back(qucs::Line(x+2, y-1, x+TimeStepWidth-2, y-1, Pen));
+        Lines.push_back(qucs::Line(x+2, y-tHeight+5, x+TimeStepWidth-2, y-tHeight+5, Pen));
 
 	if (*(px+1) == 0.0)
 	  // output real number
-          Texts.push_back(Text(x+3, y,QString::number(*px)));
+          Texts.push_back(qucs::Text(x+3, y,QString::number(*px)));
 	else
 	  // output magnitude of (complex) number
-          Texts.push_back(Text(x+3, y,
+          Texts.push_back(qucs::Text(x+3, y,
               QString::number(sqrt((*px)*(*px) + (*(px+1))*(*(px+1))))));
 
         px += 2;
         x += TimeStepWidth;
-        Lines.push_back(Line(x-2, y-tHeight+5, x+2, y-1, Pen));
-        Lines.push_back(Line(x+2, y-tHeight+5, x-2, y-1, Pen));
+        Lines.push_back(qucs::Line(x-2, y-tHeight+5, x+2, y-1, Pen));
+        Lines.push_back(qucs::Line(x+2, y-tHeight+5, x-2, y-1, Pen));
       }
       y -= tHeight;
       continue;
@@ -375,18 +375,18 @@ if(!firstGraph->isEmpty()) {
         } 
 
         if(yLast != yNow)
-          Lines.push_back(Line(x, y-yLast, x, y-yNow, Pen));
+          Lines.push_back(qucs::Line(x, y-yLast, x, y-yNow, Pen));
         if(x+TimeStepWidth >= x2) break;
         if((*pcx & 254) == '0')
-          Lines.push_back(Line(x, y-yNow, x+TimeStepWidth, y-yNow, Pen));
+          Lines.push_back(qucs::Line(x, y-yNow, x+TimeStepWidth, y-yNow, Pen));
         else {
-          Texts.push_back(Text(x+(TimeStepWidth>>1)-3, y, QString(pcx)));
-          Lines.push_back(Line(x+3, y-1, x+TimeStepWidth-3, y-1, Pen));
-          Lines.push_back(Line(x+3, y-tHeight+5, x+TimeStepWidth-3, y-tHeight+5, Pen));
-          Lines.push_back(Line(x, y-yNow, x+3, y-1, Pen));
-          Lines.push_back(Line(x, y-yNow, x+3, y-tHeight+5, Pen));
-          Lines.push_back(Line(x+TimeStepWidth-3, y-1, x+TimeStepWidth, y-yNow, Pen));
-          Lines.push_back(Line(x+TimeStepWidth-3, y-tHeight+5, x+TimeStepWidth, y-yNow, Pen));
+          Texts.push_back(qucs::Text(x+(TimeStepWidth>>1)-3, y, QString(pcx)));
+          Lines.push_back(qucs::Line(x+3, y-1, x+TimeStepWidth-3, y-1, Pen));
+          Lines.push_back(qucs::Line(x+3, y-tHeight+5, x+TimeStepWidth-3, y-tHeight+5, Pen));
+          Lines.push_back(qucs::Line(x, y-yNow, x+3, y-1, Pen));
+          Lines.push_back(qucs::Line(x, y-yNow, x+3, y-tHeight+5, Pen));
+          Lines.push_back(qucs::Line(x+TimeStepWidth-3, y-1, x+TimeStepWidth, y-yNow, Pen));
+          Lines.push_back(qucs::Line(x+TimeStepWidth-3, y-tHeight+5, x+TimeStepWidth, y-yNow, Pen));
         }
 
         yLast = yNow;
@@ -399,19 +399,19 @@ if(!firstGraph->isEmpty()) {
 
       z = g->axis(0)->count - z;
       yNow = 1 + ((tHeight - 6) >> 1);
-      Lines.push_back(Line(x, y-yNow, x+2, y-1, Pen));
-      Lines.push_back(Line(x+2, y-tHeight+5, x, y-yNow, Pen));
+      Lines.push_back(qucs::Line(x, y-yNow, x+2, y-1, Pen));
+      Lines.push_back(qucs::Line(x+2, y-tHeight+5, x, y-yNow, Pen));
       for( ; z>0; z--) {
         if(x+TimeStepWidth >= x2) break;
-        Lines.push_back(Line(x+2, y-1, x+TimeStepWidth-2, y-1, Pen));
-        Lines.push_back(Line(x+2, y-tHeight+5, x+TimeStepWidth-2, y-tHeight+5, Pen));
+        Lines.push_back(qucs::Line(x+2, y-1, x+TimeStepWidth-2, y-1, Pen));
+        Lines.push_back(qucs::Line(x+2, y-tHeight+5, x+TimeStepWidth-2, y-tHeight+5, Pen));
 
-        Texts.push_back(Text(x+3, y, QString(pcx)));
+        Texts.push_back(qucs::Text(x+3, y, QString(pcx)));
 
         x += TimeStepWidth;
         pcx += strlen(pcx) + 1;
-        Lines.push_back(Line(x-2, y-tHeight+5, x+2, y-1, Pen));
-        Lines.push_back(Line(x+2, y-tHeight+5, x-2, y-1, Pen));
+        Lines.push_back(qucs::Line(x-2, y-tHeight+5, x+2, y-1, Pen));
+        Lines.push_back(qucs::Line(x+2, y-tHeight+5, x-2, y-1, Pen));
       }
     }
 
@@ -423,9 +423,9 @@ funcEnd:
   if(invisibleCount > 0) {  // could all values be displayed ?
     x  = x2 - xAxis.numGraphs - 37;
     if(x < MIN_SCROLLBAR_SIZE+2) {  // not enough space for scrollbar ?
-      Lines.push_back(Line(x2, 0, x2, -17, QPen(Qt::red,0)));
-      Lines.push_back(Line(xAxis.numGraphs, -17, x2, -17, QPen(Qt::red,0)));
-      Lines.push_back(Line(xAxis.numGraphs, 0, xAxis.numGraphs, -17, QPen(Qt::red,0)));
+      Lines.push_back(qucs::Line(x2, 0, x2, -17, QPen(Qt::red,0)));
+      Lines.push_back(qucs::Line(xAxis.numGraphs, -17, x2, -17, QPen(Qt::red,0)));
+      Lines.push_back(qucs::Line(xAxis.numGraphs, 0, xAxis.numGraphs, -17, QPen(Qt::red,0)));
       return 1;
     }
 

--- a/qucs/diagrams/truthdiagram.cpp
+++ b/qucs/diagrams/truthdiagram.cpp
@@ -68,11 +68,11 @@ int TruthDiagram::calcDiagram()
   y = y2 - tHeight - 6;
 
   // outer frame
-  Lines.push_back(Line(0, y2, x2, y2, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y2, 0, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(x2, y2, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, 0, x2, 0, QPen(Qt::black,0)));
-  Lines.push_back(Line(0, y+2, x2, y+2, QPen(Qt::black,2)));
+  Lines.push_back(qucs::Line(0, y2, x2, y2, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y2, 0, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(x2, y2, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, 0, x2, 0, QPen(Qt::black,0)));
+  Lines.push_back(qucs::Line(0, y+2, x2, y+2, QPen(Qt::black,2)));
 
   if(xAxis.limit_min < 0.0)
     xAxis.limit_min = 0.0;
@@ -84,7 +84,7 @@ int TruthDiagram::calcDiagram()
     Str = QObject::tr("no variables");
     colWidth = checkColumnWidth(Str, metrics, colWidth, x, y2);
     if(colWidth >= 0)
-      Texts.push_back(Text(x-4, y2-2, Str)); // independent variable
+      Texts.push_back(qucs::Text(x-4, y2-2, Str)); // independent variable
     return 0;
   }
 
@@ -112,7 +112,7 @@ int TruthDiagram::calcDiagram()
     }
 
     colWidth = 0;
-    Texts.push_back(Text(x-4, y2-2, Str)); // independent variable
+    Texts.push_back(qucs::Text(x-4, y2-2, Str)); // independent variable
     if(NumAll != 0) {
       z = metrics.horizontalAdvance("1");
       colWidth = metrics.horizontalAdvance("0");
@@ -133,14 +133,14 @@ int TruthDiagram::calcDiagram()
 	for(int zi=counting-1; zi>=0; zi--) {
 	  if(z & (1 << zi))  Str = "1";
 	  else  Str = "0";
-          Texts.push_back(Text( startWriting, y, Str));
+          Texts.push_back(qucs::Text( startWriting, y, Str));
 	  startWriting += colWidth;
 	}
 	y -= tHeight;
       }
       x = startWriting + 15;
     }
-    Lines.push_back(Line(x-8, y2, x-8, 0, QPen(Qt::black,2)));
+    Lines.push_back(qucs::Line(x-8, y2, x-8, 0, QPen(Qt::black,2)));
   }  // of "if no data in graphs"
   
 
@@ -154,7 +154,7 @@ int TruthDiagram::calcDiagram()
     Str = g->Var;
     colWidth = checkColumnWidth(Str, metrics, 0, x, y2);
     if(colWidth < 0)  goto funcEnd;
-    Texts.push_back(Text(x, y2-2, Str));  // dependent variable
+    Texts.push_back(qucs::Text(x, y2-2, Str));  // dependent variable
 
 
     startWriting = int(xAxis.limit_min + 0.5);  // when to reach visible area
@@ -173,7 +173,7 @@ int TruthDiagram::calcDiagram()
             colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
             if(colWidth < 0)  goto funcEnd;
 
-            Texts.push_back(Text(x, y, Str));
+            Texts.push_back(qucs::Text(x, y, Str));
             y -= tHeight;
           }
         }
@@ -198,7 +198,7 @@ int TruthDiagram::calcDiagram()
             zi = 0;
             while(*py) {
               Str = *(py++);
-              Texts.push_back(Text(x + zi, y, Str));
+              Texts.push_back(qucs::Text(x + zi, y, Str));
               zi += digitWidth;
             }
             py++;
@@ -215,19 +215,19 @@ int TruthDiagram::calcDiagram()
         Str = QObject::tr("wrong dependency");
         colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
         if(colWidth < 0)  goto funcEnd;
-        Texts.push_back(Text(x, y, Str));
+        Texts.push_back(qucs::Text(x, y, Str));
       }
     }
     else {   // no data in graph
       Str = QObject::tr("no data");
       colWidth = checkColumnWidth(Str, metrics, colWidth, x, y);
       if(colWidth < 0)  goto funcEnd;
-      Texts.push_back(Text(x, y, Str));
+      Texts.push_back(qucs::Text(x, y, Str));
     }
     x += colWidth+15;
     auto gn = g;
     if(++gn != Graphs.end())   // do not paint last line
-      Lines.push_back(Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
+      Lines.push_back(qucs::Line(x-8, y2, x-8, 0, QPen(Qt::black,0)));
   }
 
 funcEnd:

--- a/qucs/dialogs/simmessage.cpp
+++ b/qucs/dialogs/simmessage.cpp
@@ -320,7 +320,7 @@ void SimMessage::slotFinishSpiceNetlist(int status )
 #ifdef __MINGW32__
 #include <windows.h>
 static QString pathName(QString longpath) {
-  const char * lpath = QDir::toNativeSeparators(longpath).toAscii();
+  const char * lpath = QDir::toNativeSeparators(longpath).toLatin1();
   char spath[2048];
   int len = GetShortPathNameA(lpath,spath,sizeof(spath)-1);
   spath[len] = '\0';

--- a/qucs/element.h
+++ b/qucs/element.h
@@ -45,61 +45,62 @@ class QPainter;
 class WireLabel;
 class Schematic;
 
-struct Line {
-  Line(int _x1, int _y1, int _x2, int _y2, QPen _style)
-       : x1(_x1), y1(_y1), x2(_x2), y2(_y2), style(_style) {}
-  int   x1, y1, x2, y2;
-  QPen  style;
-};
+namespace qucs {
+  struct Line {
+    Line(int _x1, int _y1, int _x2, int _y2, QPen _style)
+        : x1(_x1), y1(_y1), x2(_x2), y2(_y2), style(_style) {}
+    int   x1, y1, x2, y2;
+    QPen  style;
+  };
 
-struct Arc {
-  Arc(int _x, int _y, int _w, int _h, int _angle, int _arclen, QPen _style)
-      : x(_x), y(_y), w(_w), h(_h), angle(_angle),
-        arclen(_arclen), style(_style) {}
-  int   x, y, w, h, angle, arclen;
-  QPen  style;
-};
+  struct Arc {
+    Arc(int _x, int _y, int _w, int _h, int _angle, int _arclen, QPen _style)
+        : x(_x), y(_y), w(_w), h(_h), angle(_angle),
+          arclen(_arclen), style(_style) {}
+    int   x, y, w, h, angle, arclen;
+    QPen  style;
+  };
 
-struct Area {
-  Area(int _x, int _y, int _w, int _h, QPen _Pen,
-	QBrush _Brush = QBrush(Qt::NoBrush))
-        : x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {}
-  int    x, y, w, h;
-  QPen   Pen;
-  QBrush Brush;    // filling style/color
-};
+  struct Area {
+    Area(int _x, int _y, int _w, int _h, QPen _Pen,
+    QBrush _Brush = QBrush(Qt::NoBrush))
+          : x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {}
+    int    x, y, w, h;
+    QPen   Pen;
+    QBrush Brush;    // filling style/color
+  };
 
-struct Port {
-  Port() {}
-  Port(int _x, int _y, bool _avail=true) : x(_x), y(_y), avail(_avail) {}
-  int   x, y;
-  bool  avail;
-  QString Type;
-  std::weak_ptr<Node> Connection;
-  std::shared_ptr<Node> getConnection() const { return Connection.lock(); }
-};
+  struct Port {
+    Port() {}
+    Port(int _x, int _y, bool _avail=true) : x(_x), y(_y), avail(_avail) {}
+    int   x, y;
+    bool  avail;
+    QString Type;
+    std::weak_ptr<Node> Connection;
+    std::shared_ptr<Node> getConnection() const { return Connection.lock(); }
+  };
 
-struct Text {
-  Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
-	float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
-	: x(_x), y(_y), s(_s), Color(_Color), Size(_Size),
-          mSin(_mSin), mCos(_mCos) { over = under = false; }
-  int	  x, y;
-  QString s;
-  QColor  Color;
-  float	  Size, mSin, mCos; // font size and rotation coefficients
-  bool	  over, under;      // text attributes
-};
+  struct Text {
+    Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
+    float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
+    : x(_x), y(_y), s(_s), Color(_Color), Size(_Size),
+            mSin(_mSin), mCos(_mCos) { over = under = false; }
+    int	  x, y;
+    QString s;
+    QColor  Color;
+    float	  Size, mSin, mCos; // font size and rotation coefficients
+    bool	  over, under;      // text attributes
+  };
 
-struct Property {
-  Property(const QString& _Name="", const QString& _Value="",
-	   bool _display=false, const QString& Desc="")
-         : Name(_Name), Value(_Value), display(_display), Description(Desc) {}
-  QString Name, Value;
-  bool    display;   // show on schematic or not ?
-  QString Description;
-};
-
+  struct Property {
+    Property(const QString& _Name="", const QString& _Value="",
+      bool _display=false, const QString& Desc="")
+          : Name(_Name), Value(_Value), display(_display), Description(Desc) {}
+    QString Name, Value;
+    bool    display;   // show on schematic or not ?
+    QString Description;
+  };
+}
 
 // valid values for Element.Type
 // The 4 least significant bits of each value are reserved for special

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -55,7 +55,6 @@
 #include <Windows.h>  //for OutputDebugString
 #endif
 
-#define toAscii toLatin1
 
 // void attach(const char*); not yet.
 
@@ -444,7 +443,7 @@ void createDocData() {
         outProps << compProps.join("\n");
         compProps.clear();
         file.close();
-        fprintf(stdout, "[%s] %s %s \n", category.toAscii().data(), c->obsolete_model_hack().toAscii().data(), fileProps.fileName().toAscii().data());
+        fprintf(stdout, "[%s] %s %s \n", category.toLatin1().data(), c->obsolete_model_hack().toLatin1().data(), fileProps.fileName().toLatin1().data());
     } // module
   } // category
   fprintf(stdout, "Created data for %i components from %i categories\n", nComps, nCats);
@@ -482,7 +481,7 @@ void createListComponentEntry(){
 		QTextStream s;
 		c->getSchematic()->saveComponent(s, c);
       QString qucsEntry = *(s.string());
-      fprintf(stdout, "%s; qucs    ; %s\n", c->obsolete_model_hack().toAscii().data(), qucsEntry.toAscii().data());
+      fprintf(stdout, "%s; qucs    ; %s\n", c->obsolete_model_hack().toLatin1().data(), qucsEntry.toLatin1().data());
 
       // add dummy ports/wires, avoid segfault
       int port = 0;
@@ -497,12 +496,12 @@ void createListComponentEntry(){
 
       // skip Subcircuit, segfault, there is nothing to netlist
       if (c->obsolete_model_hack() == "Sub" or c->obsolete_model_hack() == ".Opt") {
-        fprintf(stdout, "WARNING, qucsator netlist not generated for %s\n\n", c->obsolete_model_hack().toAscii().data());
+        fprintf(stdout, "WARNING, qucsator netlist not generated for %s\n\n", c->obsolete_model_hack().toLatin1().data());
         continue;
       }
 
       QString qucsatorEntry = c->getNetlist();
-      fprintf(stdout, "%s; qucsator; %s\n", c->obsolete_model_hack().toAscii().data(), qucsatorEntry.toAscii().data());
+      fprintf(stdout, "%s; qucsator; %s\n", c->obsolete_model_hack().toLatin1().data(), qucsatorEntry.toLatin1().data());
       } // module
     } // category
 }

--- a/qucs/main.cpp
+++ b/qucs/main.cpp
@@ -254,12 +254,12 @@ void createIcons() {
 
         Component *c = (Component* ) e;
 
-        std::list<Line> Lines      = c->Lines;
-        std::list<Arc> Arcs        = c-> Arcs;
-        std::list<Area> Rects      = c-> Rects;
-        std::list<Area> Ellips     = c-> Ellips;
-        std::list<Port> Ports      = c->Ports;
-        std::list<Text> Texts      = c->Texts;
+        std::list<qucs::Line> Lines      = c->Lines;
+        std::list<qucs::Arc> Arcs        = c-> Arcs;
+        std::list<qucs::Area> Rects      = c-> Rects;
+        std::list<qucs::Area> Ellips     = c-> Ellips;
+        std::list<qucs::Port> Ports      = c->Ports;
+        std::list<qucs::Text> Texts      = c->Texts;
 
         QGraphicsScene *scene = new QGraphicsScene();
 

--- a/qucs/qucs_actions.cpp
+++ b/qucs/qucs_actions.cpp
@@ -1002,7 +1002,7 @@ void QucsApp::slotCursorUp(bool up)
   }else if(up){
     if(view->MAx3 == 0) return;  // edit component namen ?
     auto pc = std::dynamic_pointer_cast<Component>(view->focusElement);
-    const Property &pp = pc->prop(view->MAx3-1);  // current property
+    const qucs::Property &pp = pc->prop(view->MAx3-1);  // current property
     int Begin = pp.Description.indexOf('[');
     if(Begin < 0) return;  // no selection list ?
     int End = pp.Description.indexOf(editText->text(), Begin); // current
@@ -1020,7 +1020,7 @@ void QucsApp::slotCursorUp(bool up)
   }else{ // down
     if(view->MAx3 == 0) return;  // edit component namen ?
     auto pc = std::dynamic_pointer_cast<Component>(view->focusElement);
-    const Property &pp = pc->prop(view->MAx3-1);  // current property
+    const qucs::Property &pp = pc->prop(view->MAx3-1);  // current property
     int Pos = pp.Description.indexOf('[');
     if(Pos < 0) return;  // no selection list ?
     Pos = pp.Description.indexOf(editText->text(), Pos); // current list item
@@ -1092,7 +1092,7 @@ void QucsApp::slotApplyCompText()
     }
   }
 
-  Property *pp = 0;
+  qucs::Property *pp = 0;
   if(view->MAx3 > 0)  pp = &pc->prop(view->MAx3-1); // current property
   else s = pc->name();
 

--- a/qucs/schematic_element.cpp
+++ b/qucs/schematic_element.cpp
@@ -2449,7 +2449,7 @@ void Schematic::setComponentNumber(const std::shared_ptr<Component> &c)
       return;
     }
 
-    Property &pp = c->Props.front();
+    qucs::Property &pp = c->Props.front();
     if(pp.Name != "Num") return;
 
     int n=1;


### PR DESCRIPTION
This patch fixes the following issues:

- git raising an error on 1u not being an integer during bootstrap / autoconf
- Name clash of lst2 and lst3 with defines in dlgs.h
- Name clash of Arc with function definition in wingdi.h
- toAscii deprecation, replaced with toLatin1
- Missing QtScript in configure.ac caused compilation errors