### PR TITLE
S parameter simulation component fix

### DIFF
--- a/qucs/components/sp_sim.cpp
+++ b/qucs/components/sp_sim.cpp
@@ -96,8 +96,10 @@ void SP_Sim::recreate(Schematic*)
     prop(3).Name = "Values";
   }
   else {
-    prop(0).Name = "Start";
-    prop(1).Name = "Stop";
-    prop(2).Name = "Points";
+    prop(0).Name = "Type";
+    prop(1).Name = "Start";
+    prop(2).Name = "Stop";
+    prop(3).Name = "Points";
   }
 }
+


### PR DESCRIPTION
Hey there! Recently I was playing around microstrip lines and found annoying bug which did not allow me to perform an s-parameters simulation. Right after making changes to simulation parameters, simulation symbol description in scheme window turned shifted and clicking on simulation button caused bunch of errors... So here is a little fix)